### PR TITLE
add Clipboard button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
+### Added
+
+- Added a clipboard button
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ position: Top # optional, default Top
 # App lancher commanda, it will be used to open the launcher,
 # without a value the related button will not appear
 appLauncherCmd: "~/.config/rofi/launcher.sh" # optional, default None 
+# Clipboard command, it will be used to open the clipboard menu,
+# without a value the related button will not appear
+clipboardCmd: "cliphist-rofi-img | wl-copy"  # optional, default None 
 # Update module configuration. 
 # Without a value the related button will not appear.
 updates: # optional, default None 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
     get_log_spec,
     menu::{menu_wrapper, Menu, MenuPosition, MenuType},
     modules::{
-        self, clock::Clock, launcher, privacy::PrivacyMessage, settings::Settings,
+        self, clipboard, clock::Clock, launcher, privacy::PrivacyMessage, settings::Settings,
         system_info::SystemInfo, title::Title, updates::Updates, workspaces::Workspaces,
     },
     services::{privacy::PrivacyService, ReadOnlyService, ServiceEvent},
@@ -41,6 +41,7 @@ pub enum Message {
     ConfigChanged(Box<Config>),
     CloseMenu,
     OpenLauncher,
+    OpenClipboard,
     Updates(modules::updates::Message),
     Workspaces(modules::workspaces::Message),
     Title(modules::title::Message),
@@ -117,6 +118,12 @@ impl Application for App {
                 }
                 Command::none()
             }
+            Message::OpenClipboard => {
+                if let Some(clipboard_cmd) = self.config.clipboard_cmd.as_ref() {
+                    utils::launcher::execute_command(clipboard_cmd.to_string());
+                }
+                Command::none()
+            }
             Message::Workspaces(msg) => {
                 self.workspaces.update(msg);
 
@@ -184,6 +191,12 @@ impl Application for App {
                         .app_launcher_cmd
                         .as_ref()
                         .map(|_| launcher::launcher()),
+                )
+                .push_maybe(
+                    self.config
+                        .clipboard_cmd
+                        .as_ref()
+                        .map(|_| clipboard::clipboard()),
                 )
                 .push_maybe(
                     self.config

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -8,6 +8,7 @@ pub enum Icons {
     #[default]
     None,
     Launcher,
+    Clipboard,
     Refresh,
     NoUpdatesAvailable,
     UpdatesAvailable,
@@ -71,6 +72,7 @@ impl From<Icons> for &'static str {
         match icon {
             Icons::None => "",
             Icons::Launcher => "󱗼",
+            Icons::Clipboard => "󰅌",
             Icons::Refresh => "󰑐",
             Icons::NoUpdatesAvailable => "󰗠",
             Icons::UpdatesAvailable => "󰳛",

--- a/src/config.rs
+++ b/src/config.rs
@@ -262,6 +262,7 @@ pub struct Config {
     #[serde(default)]
     pub position: Position,
     pub app_launcher_cmd: Option<String>,
+    pub clipboard_cmd: Option<String>,
     #[serde(default = "default_truncate_title_after_length")]
     pub truncate_title_after_length: u32,
     #[serde(deserialize_with = "try_default")]
@@ -305,6 +306,7 @@ impl Default for Config {
             log_level: default_log_level(),
             position: Position::Top,
             app_launcher_cmd: None,
+            clipboard_cmd: None,
             truncate_title_after_length: default_truncate_title_after_length(),
             updates: None,
             system: SystemModuleConfig::default(),

--- a/src/modules/clipboard.rs
+++ b/src/modules/clipboard.rs
@@ -1,0 +1,14 @@
+use crate::{
+    app::Message,
+    components::icons::{icon, Icons},
+    style::HeaderButtonStyle,
+};
+use iced::{theme, widget::button, Element};
+
+pub fn clipboard<'a>() -> Element<'a, Message> {
+    button(icon(Icons::Clipboard))
+        .padding([2, 7])
+        .on_press(Message::OpenClipboard)
+        .style(theme::Button::custom(HeaderButtonStyle::Full))
+        .into()
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,3 +1,4 @@
+pub mod clipboard;
 pub mod clock;
 pub mod launcher;
 pub mod privacy;


### PR DESCRIPTION
A simple button to open the clipboard may not seem very necessary at first, but it will be really useful for some users.

I also often use this button myself)

![image](https://github.com/user-attachments/assets/c886ef49-5850-4bd3-b59d-c0590ded778a)
