### PR TITLE
Fix special workspaces

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,9 @@ use iced_sctk::{
     multi_window::{settings::Settings, Application},
     settings::InitialSurface,
 };
-use log::error;
-use std::{borrow::Cow, panic};
+use log::{error, LevelFilter};
 use std::backtrace::Backtrace;
+use std::{borrow::Cow, panic};
 
 mod app;
 mod centerbox;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use iced_sctk::{
 };
 use log::error;
 use std::{borrow::Cow, panic};
+use std::backtrace::Backtrace;
 
 mod app;
 mod centerbox;
@@ -54,7 +55,8 @@ async fn main() {
     };
     let logger = logger.start().unwrap();
     panic::set_hook(Box::new(|info| {
-        error!("Panic: {}", info);
+        let b = Backtrace::capture();
+        error!("Panic: {} \n {}", info, b);
     }));
 
     let config = read_config().unwrap_or_else(|err| {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -40,6 +40,7 @@ fn get_workspaces() -> Vec<Workspace> {
     let mut current: usize = 1;
     let s = workspaces
         .iter()
+        .filter(|w| w.id > 0)
         .flat_map(|w| {
             let missing: usize = w.id as usize - current;
             let mut res = Vec::with_capacity(missing + 1);


### PR DESCRIPTION
Vector was constantly surprised by the massive request for capacity (in 44th/45th line of workspaces.rs). I chose to hide special workspaces so they wouldn't appear in the status bar.

In addition to this, I have added a backtrace. Right now, it simply just spit out the error message without any backtrace, whatsoever - it was hard to debug. In a perfect world, this should have been handled differently, but for now, it will be sufficient, I hope.