### PR TITLE
Fix title panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,9 +10,9 @@ use iced_sctk::{
     multi_window::{settings::Settings, Application},
     settings::InitialSurface,
 };
-use log::error;
-use std::{borrow::Cow, panic};
+use log::{error, LevelFilter};
 use std::backtrace::Backtrace;
+use std::{borrow::Cow, panic};
 
 mod app;
 mod centerbox;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use iced_sctk::{
 };
 use log::error;
 use std::{borrow::Cow, panic};
+use std::backtrace::Backtrace;
 
 mod app;
 mod centerbox;
@@ -54,7 +55,8 @@ async fn main() {
     };
     let logger = logger.start().unwrap();
     panic::set_hook(Box::new(|info| {
-        error!("Panic: {}", info);
+        let b = Backtrace::capture();
+        error!("Panic: {} \n {}", info, b);
     }));
 
     let config = read_config().unwrap_or_else(|err| {

--- a/src/modules/title.rs
+++ b/src/modules/title.rs
@@ -37,6 +37,7 @@ impl Title {
 
                     self.value = Some(if length > truncate_title_after_length as usize {
                         let split = truncate_title_after_length as usize / 2;
+                        let split = value.char_indices().map(|(i, _)| i).nth(split).unwrap();
                         let first_part = &value[0..split];
                         let last_part = &value[length - split..length];
                         format!("{}...{}", first_part, last_part)

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -40,6 +40,7 @@ fn get_workspaces() -> Vec<Workspace> {
     let mut current: usize = 1;
     let s = workspaces
         .iter()
+        .filter(|w| w.id > 0)
         .flat_map(|w| {
             let missing: usize = w.id as usize - current;
             let mut res = Vec::with_capacity(missing + 1);


### PR DESCRIPTION
Sadly, I can make this diff a little bit nicer (just merging into my previous branch, instead of the main one) as I cannot put this PR in your repo when targeting my other PR, so you will have to ignore that noise, haha. 

There was this special case when the substring was made in the middle of the symbol's codepoint(s) - rust just panics and returns an error: "byte index X is not a char boundary". As I understand that's the easiest way to solve this (numbering by codepoints and then taking the symbol's byte index). 
Pardon me, if that's not the right way - Rust is not my main language.