### PR TITLE
add keyboard-layout and keyboard-submap modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Hyprland Keyboard Layout module
+- Hyprland Keyboard Submap module
+
 ## [0.2.0] - 2024-11-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -78,10 +78,13 @@ but I'm quite sure that if you use NixOS you are smart enough to add ashell to y
 ## Features
 
 - Lancher button
+- Сlipboard button
 - OS Updates indicator
 - Hyprland Active Window
 - Hyprland Workspaces
 - System Information (CPU, RAM, Temperature)
+- Hyprland Keyboard Layout
+- Hyprland Keyboard Submap
 - Date time
 - Privacy (check microphone, camera and screenshare usage)
 - Settings panel
@@ -130,6 +133,12 @@ system:
   memAlertThreshold: 85 # mem indicator alert level (default 85)
   tempWarnThreshold: 6O # temperature indicator warning level (default 60)
   tempAlertThreshold: 8O # temperature indicator alert level (default 80)
+# Keyboard modules configuration
+keyboard:
+  layout:
+    disabled: false # Enable or disable the keyboard layout module
+  submap: # see: https://wiki.hyprland.org/Configuring/Binds/#submaps
+    disabled: false # Enable or disable the keyboard submap module
 # Clock module configuration
 clock:
   # clock format see: https://docs.rs/chrono/latest/chrono/format/strftime/index.html 

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,8 +4,9 @@ use crate::{
     get_log_spec,
     menu::{menu_wrapper, Menu, MenuPosition, MenuType},
     modules::{
-        self, clipboard, clock::Clock, launcher, privacy::PrivacyMessage, settings::Settings,
-        system_info::SystemInfo, title::Title, updates::Updates, workspaces::Workspaces,
+        self, clipboard, clock::Clock, keyboard_layout::KeyboardLayout, launcher,
+        privacy::PrivacyMessage, settings::Settings, system_info::SystemInfo, title::Title,
+        updates::Updates, workspaces::Workspaces,
     },
     services::{privacy::PrivacyService, ReadOnlyService, ServiceEvent},
     style::ashell_theme,
@@ -30,6 +31,7 @@ pub struct App {
     workspaces: Workspaces,
     window_title: Title,
     system_info: SystemInfo,
+    keyboard_layout: KeyboardLayout,
     clock: Clock,
     privacy: Option<PrivacyService>,
     pub settings: Settings,
@@ -46,6 +48,7 @@ pub enum Message {
     Workspaces(modules::workspaces::Message),
     Title(modules::title::Message),
     SystemInfo(modules::system_info::Message),
+    KeyboardLayout(modules::keyboard_layout::Message),
     Clock(modules::clock::Message),
     Privacy(modules::privacy::PrivacyMessage),
     Settings(modules::settings::Message),
@@ -67,6 +70,7 @@ impl Application for App {
                 workspaces: Workspaces::default(),
                 window_title: Title::default(),
                 system_info: SystemInfo::default(),
+                keyboard_layout: KeyboardLayout::default(),
                 clock: Clock::default(),
                 privacy: None,
                 settings: Settings::default(),
@@ -136,6 +140,10 @@ impl Application for App {
             }
             Message::SystemInfo(message) => {
                 self.system_info.update(message);
+                Command::none()
+            }
+            Message::KeyboardLayout(message) => {
+                self.keyboard_layout.update(message);
                 Command::none()
             }
             Message::Clock(message) => {
@@ -227,6 +235,13 @@ impl Application for App {
                         .map(|c| c.map(Message::SystemInfo)),
                 )
                 .push(
+                    Row::new().push_maybe(
+                        self.keyboard_layout
+                            .view(&self.config.keyboard.layout)
+                            .map(|l| l.map(Message::KeyboardLayout)),
+                    ),
+                )
+                .push(
                     Row::new()
                         .push(
                             self.clock
@@ -264,6 +279,11 @@ impl Application for App {
                 Some(self.workspaces.subscription().map(Message::Workspaces)),
                 Some(self.window_title.subscription().map(Message::Title)),
                 Some(self.system_info.subscription().map(Message::SystemInfo)),
+                Some(
+                    self.keyboard_layout
+                        .subscription()
+                        .map(Message::KeyboardLayout),
+                ),
                 Some(self.clock.subscription().map(Message::Clock)),
                 Some(
                     PrivacyService::subscribe().map(|e| Message::Privacy(PrivacyMessage::Event(e))),

--- a/src/config.rs
+++ b/src/config.rs
@@ -85,21 +85,35 @@ pub struct KeyboardLayoutModule {
     pub disabled: bool,
 }
 
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyboardSubmapModule {
+    #[serde(default)]
+    pub disabled: bool,
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct KeyboardModuleConfig {
     #[serde(default = "default_keyboard_layout")]
     pub layout: KeyboardLayoutModule,
+    #[serde(default = "default_keyboard_submap")]
+    pub submap: KeyboardSubmapModule,
 }
 
 fn default_keyboard_layout() -> KeyboardLayoutModule {
     KeyboardLayoutModule { disabled: false }
 }
 
+fn default_keyboard_submap() -> KeyboardSubmapModule {
+    KeyboardSubmapModule { disabled: false }
+}
+
 impl Default for KeyboardModuleConfig {
     fn default() -> Self {
         Self {
             layout: default_keyboard_layout(),
+            submap: default_keyboard_submap(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -78,6 +78,32 @@ impl Default for SystemModuleConfig {
     }
 }
 
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyboardLayoutModule {
+    #[serde(default)]
+    pub disabled: bool,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct KeyboardModuleConfig {
+    #[serde(default = "default_keyboard_layout")]
+    pub layout: KeyboardLayoutModule,
+}
+
+fn default_keyboard_layout() -> KeyboardLayoutModule {
+    KeyboardLayoutModule { disabled: false }
+}
+
+impl Default for KeyboardModuleConfig {
+    fn default() -> Self {
+        Self {
+            layout: default_keyboard_layout(),
+        }
+    }
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ClockModuleConfig {
@@ -272,6 +298,8 @@ pub struct Config {
     #[serde(default)]
     pub system: SystemModuleConfig,
     #[serde(default)]
+    pub keyboard: KeyboardModuleConfig,
+    #[serde(default)]
     pub clock: ClockModuleConfig,
     #[serde(default)]
     pub settings: SettingsModuleConfig,
@@ -312,6 +340,7 @@ impl Default for Config {
             truncate_title_after_length: default_truncate_title_after_length(),
             updates: None,
             system: SystemModuleConfig::default(),
+            keyboard: KeyboardModuleConfig::default(),
             clock: ClockModuleConfig::default(),
             settings: SettingsModuleConfig::default(),
             appearance: Appearance::default(),

--- a/src/modules/keyboard_layout.rs
+++ b/src/modules/keyboard_layout.rs
@@ -1,0 +1,139 @@
+use crate::{config::KeyboardLayoutModule, style::HeaderButtonStyle};
+use hyprland::{
+    ctl::switch_xkb_layout::SwitchXKBLayoutCmdTypes, event_listener::AsyncEventListener,
+    shared::HyprData,
+};
+use iced::{
+    subscription::channel,
+    theme::Button,
+    widget::{button, text},
+    Element, Subscription,
+};
+use log::{debug, error};
+use std::{
+    any::TypeId,
+    sync::{Arc, RwLock},
+};
+
+fn get_multiple_layout_flag() -> bool {
+    match hyprland::keyword::Keyword::get("input:kb_layout") {
+        Ok(layouts) => layouts.value.to_string().split(",").count() > 1,
+        Err(_) => false,
+    }
+}
+
+fn get_active_layout() -> String {
+    hyprland::data::Devices::get()
+        .ok()
+        .and_then(|devices| {
+            devices
+                .keyboards
+                .iter()
+                .find(|k| k.main)
+                .map(|keyboard| keyboard.active_keymap.to_string())
+        })
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+#[derive(Debug, Clone)]
+pub struct KeyboardLayout {
+    multiple_layout: bool,
+    active: String,
+}
+
+impl Default for KeyboardLayout {
+    fn default() -> Self {
+        Self {
+            multiple_layout: get_multiple_layout_flag(),
+            active: get_active_layout(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    LayoutConfigChanged(bool),
+    ActiveLayoutChanged(String),
+    ChangeLayout,
+}
+
+impl KeyboardLayout {
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::ActiveLayoutChanged(layout) => {
+                self.active = layout;
+            }
+            Message::LayoutConfigChanged(layout_flag) => self.multiple_layout = layout_flag,
+            Message::ChangeLayout => {
+                let res =
+                    hyprland::ctl::switch_xkb_layout::call("all", SwitchXKBLayoutCmdTypes::Next);
+
+                if let Err(e) = res {
+                    error!("failed to keymap change: {:?}", e);
+                }
+            }
+        }
+    }
+
+    pub fn view(&self, config: &KeyboardLayoutModule) -> Option<Element<Message>> {
+        if config.disabled || !self.multiple_layout {
+            None
+        } else {
+            Some(
+                button(text(&self.active))
+                    .padding([2, 7])
+                    .on_press(Message::ChangeLayout)
+                    .style(Button::custom(HeaderButtonStyle::Full))
+                    .into(),
+            )
+        }
+    }
+
+    pub fn subscription(&self) -> Subscription<Message> {
+        let id = TypeId::of::<Self>();
+
+        channel(id, 10, |output| async move {
+            let output = Arc::new(RwLock::new(output));
+            loop {
+                let mut event_listener = AsyncEventListener::new();
+
+                event_listener.add_layout_changed_handler({
+                    let output = output.clone();
+                    move |e| {
+                        debug!("keymap changed: {:?}", e);
+                        let output = output.clone();
+                        Box::pin(async move {
+                            if let Ok(mut output) = output.write() {
+                                output
+                                    .try_send(Message::ActiveLayoutChanged(get_active_layout()))
+                                    .expect("error getting keymap: layout changed event");
+                            }
+                        })
+                    }
+                });
+
+                event_listener.add_config_reloaded_handler({
+                    let output = output.clone();
+                    move || {
+                        let output = output.clone();
+                        Box::pin(async move {
+                            if let Ok(mut output) = output.write() {
+                                output
+                                    .try_send(Message::LayoutConfigChanged(
+                                        get_multiple_layout_flag(),
+                                    ))
+                                    .expect("error sending message: layout config changed event");
+                            }
+                        })
+                    }
+                });
+
+                let res = event_listener.start_listener_async().await;
+
+                if let Err(e) = res {
+                    error!("restarting keymap listener due to error: {:?}", e);
+                }
+            }
+        })
+    }
+}

--- a/src/modules/keyboard_submap.rs
+++ b/src/modules/keyboard_submap.rs
@@ -1,0 +1,84 @@
+use crate::{config::KeyboardSubmapModule, style::header_pills};
+use hyprland::event_listener::AsyncEventListener;
+use iced::{
+    subscription::channel,
+    widget::{container, text},
+    Element, Subscription,
+};
+use log::{debug, error};
+use std::{
+    any::TypeId,
+    sync::{Arc, RwLock},
+};
+
+pub struct KeyboardSubmap {
+    submap: String,
+}
+
+impl Default for KeyboardSubmap {
+    fn default() -> Self {
+        Self {
+            submap: "".to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    SubmapChanged(String),
+}
+
+impl KeyboardSubmap {
+    pub fn update(&mut self, message: Message) {
+        match message {
+            Message::SubmapChanged(submap) => {
+                self.submap = submap;
+            }
+        }
+    }
+
+    pub fn view(&self, config: &KeyboardSubmapModule) -> Option<Element<Message>> {
+        if config.disabled || self.submap.is_empty() {
+            None
+        } else {
+            Some(
+                container(text(&self.submap))
+                    .padding([2, 8])
+                    .style(header_pills)
+                    .into(),
+            )
+        }
+    }
+
+    pub fn subscription(&self) -> Subscription<Message> {
+        let id = TypeId::of::<Self>();
+
+        channel(id, 10, |output| async move {
+            let output = Arc::new(RwLock::new(output));
+            loop {
+                let mut event_listener = AsyncEventListener::new();
+
+                event_listener.add_sub_map_changed_handler({
+                    let output = output.clone();
+                    move |new_submap| {
+                        debug!("submap changed: {:?}", new_submap);
+                        let output = output.clone();
+                        Box::pin(async move {
+                            if let Ok(mut output) = output.write() {
+                                output
+                                    .try_send(Message::SubmapChanged(new_submap))
+                                    .expect("error getting submap: submap changed event");
+                            }
+                        })
+                    }
+                });
+
+                let res = event_listener.start_listener_async().await;
+
+                if let Err(e) = res {
+                    error!("restarting submap listener due to error: {:?}", e);
+                }
+            }
+        })
+    }
+}

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,6 +1,7 @@
 pub mod clipboard;
 pub mod clock;
 pub mod keyboard_layout;
+pub mod keyboard_submap;
 pub mod launcher;
 pub mod privacy;
 pub mod settings;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,5 +1,6 @@
 pub mod clipboard;
 pub mod clock;
+pub mod keyboard_layout;
 pub mod launcher;
 pub mod privacy;
 pub mod settings;


### PR DESCRIPTION
## Description 
A simple module for displaying the current keyboard layout

![image](https://github.com/user-attachments/assets/0fdefaff-f07d-4f13-892c-6327afcc255a)

## Functionality 
- Display of the current layout
- Switching the layout by clicking on the module 

The module is displayed only if more than one keyboard layout is installed, but if necessary, it can be forcibly hidden 
```
language:
    disabled: true
```