### PR TITLE
Fix nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,62 +1,45 @@
 {
   "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1737563566,
+        "narHash": "sha256-GLJvkOG29XCynQm8XWPyykMRqIhxKcBARVu7Ydrz02M=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "849376434956794ebc7a6b487d31aace395392ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1726560853,
-        "narHash": "sha256-X6rJYSESBVr3hBoH0WbKE5KvhPU5bloyZ2L4K60/fPQ=",
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c1dfcf08411b08f6b8615f7d8971a2bfa81d5e8a",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
         "type": "github"
       },
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "naersk": {
-      "inputs": {
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1721727458,
-        "narHash": "sha256-r/xppY958gmZ4oTfLiHN0ZGuQ+RSTijDblVgVLFi1mw=",
-        "owner": "nix-community",
-        "repo": "naersk",
-        "rev": "3fb418eaf352498f6b6c30592e3beb63df42ef11",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "naersk",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1729980323,
-        "narHash": "sha256-eWPRZAlhf446bKSmzw6x7RWEE4IuZgAp8NW3eXZwRAY=",
+        "lastModified": 1737469691,
+        "narHash": "sha256-nmKOgAU48S41dTPIXAq0AHZSehWUn6ZPrUKijHAMmIk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "86e78d3d2084ff87688da662cf78c2af085d8e73",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1729880355,
-        "narHash": "sha256-RP+OQ6koQQLX5nw0NmcDrzvGL8HDLnyXt/jHhL1jwjM=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "18536bf04cd71abd345f9579158841376fdd0c5a",
+        "rev": "9e4d5190a9482a1fb9d18adf0bdb83c6e506eaab",
         "type": "github"
       },
       "original": {
@@ -68,9 +51,9 @@
     },
     "root": {
       "inputs": {
+        "crane": "crane",
         "flake-utils": "flake-utils",
-        "naersk": "naersk",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
     },
@@ -81,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1729996302,
-        "narHash": "sha256-QEU1NQq1+7s1na69Chig9K0iDDTKN0O4Zreo9A9rccA=",
+        "lastModified": 1737599167,
+        "narHash": "sha256-S2rHCrQWCDVp63XxL/AQbGr1g5M8Zx14C7Jooa4oM8o=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "a1b337569f334ff0a01b57627f17b201d746d24c",
+        "rev": "38374302ae9edf819eac666d1f276d62c712dd06",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -50,7 +50,10 @@
           defaultPackage = craneLib.buildPackage {
             src = ./.;
 
-            nativeBuildInputs = [ pkgs.makeWrapper ];
+            nativeBuildInputs = with pkgs; [
+              makeWrapper
+              pkg-config
+            ];
 
             buildInputs = deps;
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,7 +13,7 @@
     };
   };
 
-  outputs = { self, crane, nixpkgs, flake-utils, rust-overlay }:
+  outputs = { crane, nixpkgs, flake-utils, rust-overlay, ... }:
     flake-utils.lib.eachDefaultSystem
       (system:
         let
@@ -24,7 +24,7 @@
           
           craneLib = crane.mkLib pkgs;
 
-          deps = with pkgs; [
+          buildInputs = with pkgs; [
             rust-bin.stable.latest.default
             rustPlatform.bindgenHook
             pkg-config
@@ -36,7 +36,7 @@
             vulkan-loader
           ];
 
-          libPath = with pkgs; lib.makeLibraryPath [
+          runtimeDependencies = with pkgs; [
             libpulseaudio
             wayland
             mesa.drivers
@@ -44,7 +44,6 @@
             libGL
           ];
         in
-        with pkgs;
         {
           # `nix build` and `nix run`
           defaultPackage = craneLib.buildPackage {
@@ -53,20 +52,17 @@
             nativeBuildInputs = with pkgs; [
               makeWrapper
               pkg-config
+              autoPatchelfHook # Add runtimeDependencies to rpath
             ];
 
-            buildInputs = deps;
-
-            postInstall = ''
-              wrapProgram "$out/bin/ashell" --prefix LD_LIBRARY_PATH : "${libPath}"
-            '';
+            inherit buildInputs runtimeDependencies;
           };
 
           # `nix develop`
-          devShells.default = mkShell {
-            buildInputs = deps;
+          devShells.default = pkgs.mkShell {
+            inherit buildInputs;
 
-            LD_LIBRARY_PATH = libPath;
+            LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath runtimeDependencies;
           };
         }
       );


### PR DESCRIPTION
* Flake was broken, updated flake.lock (it was in a strange semi-broken state) and added missing `pkg-config` dependency
* Flake used improper way to add libwayland and other runtime dependencies. Replaced hack with wrapper with `runtimeDependencies` (via `autoPatchElfHook`)

Awesome project, really enjoyed using it!