### PR TITLE
MPRIS DBus integration & multiple media players

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ position: Top # optional, default Top
 #  - Tray
 #  - Clock
 #  - Privacy
+#  - MediaPlayer
 #  - Settings
 # optional, the following is the default configuration
 modules:

--- a/src/app.rs
+++ b/src/app.rs
@@ -273,7 +273,7 @@ impl App {
                 Some((MenuType::MediaPlayer, button_ui_ref)) => menu_wrapper(
                     id,
                     self.media_player.menu_view().map(Message::MediaPlayer),
-                    MenuSize::Normal,
+                    MenuSize::Large,
                     *button_ui_ref,
                     self.config.position,
                 ),

--- a/src/app.rs
+++ b/src/app.rs
@@ -227,7 +227,7 @@ impl App {
                 },
                 _ => Task::none(),
             },
-            Message::MediaPlayer(msg) => self.media_player.update(msg, &self.config.media_player),
+            Message::MediaPlayer(msg) => self.media_player.update(msg),
         }
     }
 
@@ -272,7 +272,9 @@ impl App {
                 ),
                 Some((MenuType::MediaPlayer, button_ui_ref)) => menu_wrapper(
                     id,
-                    self.media_player.menu_view().map(Message::MediaPlayer),
+                    self.media_player
+                        .menu_view(&self.config.media_player)
+                        .map(Message::MediaPlayer),
                     MenuSize::Large,
                     *button_ui_ref,
                     self.config.position,

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -68,6 +68,7 @@ pub enum Icons {
     SkipPrevious,
     PlayPause,
     SkipNext,
+    MusicNote,
 }
 
 impl From<Icons> for &'static str {
@@ -135,6 +136,7 @@ impl From<Icons> for &'static str {
             Icons::SkipPrevious => "󰒮",
             Icons::PlayPause => "󰐎",
             Icons::SkipNext => "󰒭",
+            Icons::MusicNote => "󰎇",
         }
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -60,8 +60,7 @@ impl MediaPlayer {
         match &self.service {
             None => text("Not connected to MPRIS service").into(),
             Some(s) => column(
-                s.deref()
-                    .iter()
+                s.iter()
                     .flat_map(|d| {
                         let d = d.clone();
                         let title = text(Self::get_title(&d, config));
@@ -138,20 +137,14 @@ impl Module for MediaPlayer {
         &self,
         config: Self::ViewData<'_>,
     ) -> Option<(Element<app::Message>, Option<OnModulePress>)> {
-        self.service.as_ref().and_then(|s| {
-            let data = s.deref();
-            match data.len() {
-                0 => None,
-                _ => Some((
-                    row![
-                        icon(Icons::MusicNote),
-                        text(Self::get_title(&data[0], config))
-                    ]
+        self.service.as_ref().and_then(|s| match s.len() {
+            0 => None,
+            _ => Some((
+                row![icon(Icons::MusicNote), text(Self::get_title(&s[0], config))]
                     .spacing(8)
                     .into(),
-                    Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
-                )),
-            }
+                Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
+            )),
         })
     }
 

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -129,6 +129,10 @@ impl MediaPlayer {
                             volume: d.volume,
                         })
                         .collect();
+
+                    if let Some(service) = self.service.as_mut() {
+                        service.update(d);
+                    }
                     Task::none()
                 }
                 ServiceEvent::Error(_) => Task::none(),

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -7,7 +7,7 @@ use crate::{
     config::MediaPlayerModuleConfig,
     menu::MenuType,
     services::{
-        mpris::{MprisPlayerCommand, MprisPlayerService, PlayerCommand},
+        mpris::{MprisPlayerCommand, MprisPlayerData, MprisPlayerService, PlayerCommand},
         ReadOnlyService, Service, ServiceEvent,
     },
     style::SettingsButtonStyle,
@@ -15,7 +15,7 @@ use crate::{
 };
 use iced::{
     widget::{button, column, container, row, slider, text},
-    Alignment::{self, Center},
+    Alignment::Center,
     Element, Subscription, Task,
 };
 
@@ -47,88 +47,18 @@ impl MediaPlayer {
         config: &MediaPlayerModuleConfig,
     ) -> Task<crate::app::Message> {
         match message {
-            Message::Prev(n) => {
-                if let Some(s) = self.service.as_mut() {
-                    s.command(MprisPlayerCommand {
-                        service: n,
-                        command: PlayerCommand::Prev,
-                    })
-                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
-                } else {
-                    Task::none()
-                }
-            }
-            Message::PlayPause(n) => {
-                if let Some(s) = self.service.as_mut() {
-                    s.command(MprisPlayerCommand {
-                        service: n,
-                        command: PlayerCommand::PlayPause,
-                    })
-                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
-                } else {
-                    Task::none()
-                }
-            }
-            Message::Next(n) => {
-                if let Some(s) = self.service.as_mut() {
-                    s.command(MprisPlayerCommand {
-                        service: n,
-                        command: PlayerCommand::Next,
-                    })
-                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
-                } else {
-                    Task::none()
-                }
-            }
-            Message::SetVolume(n, v) => {
-                if let Some(s) = self.service.as_mut() {
-                    s.command(MprisPlayerCommand {
-                        service: n,
-                        command: PlayerCommand::Volume(v),
-                    })
-                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
-                } else {
-                    Task::none()
-                }
-            }
-            Message::Event(d) => match d {
+            Message::Prev(s) => self.handle_command(s, PlayerCommand::Prev),
+            Message::PlayPause(s) => self.handle_command(s, PlayerCommand::PlayPause),
+            Message::Next(s) => self.handle_command(s, PlayerCommand::Next),
+            Message::SetVolume(s, v) => self.handle_command(s, PlayerCommand::Volume(v)),
+            Message::Event(event) => match event {
                 ServiceEvent::Init(s) => {
-                    let data = s.deref();
-                    self.data = data
-                        .iter()
-                        .map(|d| PlayerData {
-                            name: d.service.clone(),
-                            song: d.metadata.clone().and_then(|d| match (d.artists, d.title) {
-                                (None, None) => None,
-                                (None, Some(t)) => Some(truncate_text(&t, config.max_title_length)),
-                                (Some(a), None) => {
-                                    Some(truncate_text(&a.join(", "), config.max_title_length))
-                                }
-                                (Some(a), Some(t)) => Some(truncate_text(
-                                    &format!("{} - {}", a.join(", "), t),
-                                    config.max_title_length,
-                                )),
-                            }),
-                            volume: d.volume,
-                        })
-                        .collect();
+                    self.data = Self::map_service_to_module_data(s.deref(), config);
                     self.service = Some(s);
                     Task::none()
                 }
                 ServiceEvent::Update(d) => {
-                    self.data = d
-                        .iter()
-                        .map(|d| PlayerData {
-                            name: d.service.clone(),
-                            song: d.metadata.clone().and_then(|d| match (d.artists, d.title) {
-                                (None, None) => None,
-                                (None, Some(t)) => Some(t),
-                                (Some(a), None) => Some(a.join(", ")),
-                                (Some(a), Some(t)) => Some(format!("{} - {}", a.join(", "), t)),
-                            }),
-                            volume: d.volume,
-                        })
-                        .collect();
+                    self.data = Self::map_service_to_module_data(&d, config);
 
                     if let Some(service) = self.service.as_mut() {
                         service.update(d);
@@ -145,34 +75,34 @@ impl MediaPlayer {
             self.data
                 .iter()
                 .flat_map(|d| {
+                    let buttons = row![
+                        button(icon(Icons::SkipPrevious))
+                            .on_press(Message::Prev(d.name.clone()))
+                            .padding([5, 12])
+                            .style(SettingsButtonStyle.into_style()),
+                        button(icon(Icons::PlayPause))
+                            .on_press(Message::PlayPause(d.name.clone()))
+                            .style(SettingsButtonStyle.into_style()),
+                        button(icon(Icons::SkipNext))
+                            .on_press(Message::Next(d.name.clone()))
+                            .padding([5, 12])
+                            .style(SettingsButtonStyle.into_style())
+                    ]
+                    .spacing(8);
+
                     [
                         iced::widget::horizontal_rule(2).into(),
                         container(
                             column![]
-                                .push_maybe(d.song.clone().map(|s| text(s)))
+                                .push_maybe(d.song.clone().map(text))
                                 .push_maybe(d.volume.map(|v| {
                                     slider(0.0..=100.0, v, |v| {
                                         Message::SetVolume(d.name.clone(), v)
                                     })
                                 }))
-                                .push(
-                                    row![
-                                        button(icon(Icons::SkipPrevious))
-                                            .on_press(Message::Prev(d.name.clone()))
-                                            .padding([5, 12])
-                                            .style(SettingsButtonStyle.into_style()),
-                                        button(icon(Icons::PlayPause))
-                                            .on_press(Message::PlayPause(d.name.clone()))
-                                            .style(SettingsButtonStyle.into_style()),
-                                        button(icon(Icons::SkipNext))
-                                            .on_press(Message::Next(d.name.clone()))
-                                            .padding([5, 12])
-                                            .style(SettingsButtonStyle.into_style())
-                                    ]
-                                    .spacing(8),
-                                )
+                                .push(buttons)
                                 .width(iced::Length::Fill)
-                                .spacing(8)
+                                .spacing(12)
                                 .align_x(Center),
                         )
                         .padding(16)
@@ -182,8 +112,39 @@ impl MediaPlayer {
                 .skip(1),
         )
         .spacing(16)
-        .align_x(Alignment::Center)
         .into()
+    }
+
+    fn handle_command(
+        &mut self,
+        service_name: String,
+        command: PlayerCommand,
+    ) -> Task<crate::app::Message> {
+        if let Some(s) = self.service.as_mut() {
+            s.command(MprisPlayerCommand {
+                service_name,
+                command,
+            })
+            .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
+        } else {
+            Task::none()
+        }
+    }
+
+    fn map_service_to_module_data(
+        data: &[MprisPlayerData],
+        config: &MediaPlayerModuleConfig,
+    ) -> Vec<PlayerData> {
+        data.iter()
+            .map(|d| PlayerData {
+                name: d.service.clone(),
+                song: d
+                    .metadata
+                    .clone()
+                    .map(|d| truncate_text(&d.to_string(), config.max_title_length)),
+                volume: d.volume,
+            })
+            .collect()
     }
 }
 
@@ -195,10 +156,19 @@ impl Module for MediaPlayer {
         &self,
         (): Self::ViewData<'_>,
     ) -> Option<(Element<app::Message>, Option<OnModulePress>)> {
-        Some((
-            icon(Icons::MusicNote).into(),
-            Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
-        ))
+        match self.data.len() {
+            0 => None,
+            1 => self.data[0].song.clone().map(|s| {
+                (
+                    text(s).into(),
+                    Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
+                )
+            }),
+            _ => Some((
+                icon(Icons::MusicNote).into(),
+                Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
+            )),
+        }
     }
 
     fn subscription(&self, (): Self::SubscriptionData<'_>) -> Option<Subscription<app::Message>> {

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -1,4 +1,4 @@
-use std::{any::TypeId, ops::Not, process::Stdio, time::Duration};
+use std::ops::Deref;
 
 use super::{Module, OnModulePress};
 use crate::{
@@ -6,89 +6,38 @@ use crate::{
     components::icons::{icon, Icons},
     config::MediaPlayerModuleConfig,
     menu::MenuType,
+    services::{
+        mpris::{MprisPlayerCommand, MprisPlayerService, PlayerCommand},
+        ReadOnlyService, Service, ServiceEvent,
+    },
     style::SettingsButtonStyle,
-    utils::launcher::execute_command,
+    utils::truncate_text,
 };
 use iced::{
-    stream::channel,
-    widget::{button, column, row, slider, text},
-    Alignment::Center,
-    Element, Subscription, Task,
+    widget::{button, column, container, row, slider, text},
+    Alignment::{self, Center},
+    Element, Subscription, Task, Theme,
 };
-use log::error;
-use tokio::{process, time::sleep};
-
-async fn get_current_song() -> Option<String> {
-    let get_current_song_cmd = process::Command::new("bash")
-        .arg("-c")
-        .arg("playerctl metadata --format \"{{ artist }} - {{ title }}\"")
-        .stdout(Stdio::piped())
-        .output()
-        .await;
-
-    match get_current_song_cmd {
-        Ok(get_current_song_cmd) => {
-            if !get_current_song_cmd.status.success() {
-                return None;
-            }
-            let s = String::from_utf8_lossy(&get_current_song_cmd.stdout);
-            let trimmed = s.trim();
-            trimmed.is_empty().not().then(|| trimmed.into())
-        }
-        Err(e) => {
-            error!("Error: {:?}", e);
-            None
-        }
-    }
-}
-
-async fn get_volume() -> Option<f64> {
-    let get_volume_cmd = process::Command::new("bash")
-        .arg("-c")
-        .arg("playerctl volume")
-        .stdout(Stdio::piped())
-        .output()
-        .await;
-
-    match get_volume_cmd {
-        Ok(get_volume_cmd) => {
-            if !get_volume_cmd.status.success() {
-                return None;
-            }
-            let v = String::from_utf8_lossy(&get_volume_cmd.stdout);
-            let trimmed = v.trim();
-            if trimmed.is_empty() {
-                return None;
-            }
-            match trimmed.parse::<f64>() {
-                Ok(v) => Some(v * 100.0),
-                Err(e) => {
-                    error!("Error: {:?}", e);
-                    None
-                }
-            }
-        }
-        Err(e) => {
-            error!("Error: {:?}", e);
-            None
-        }
-    }
-}
 
 #[derive(Default)]
 pub struct MediaPlayer {
+    data: Vec<PlayerData>,
+    service: Option<MprisPlayerService>,
+}
+
+struct PlayerData {
+    name: String,
     song: Option<String>,
     volume: Option<f64>,
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    SetSong(Option<String>),
-    Prev,
-    Play,
-    Next,
-    SetVolume(Option<f64>),
-    SyncVolume(Option<f64>),
+    Prev(String),
+    PlayPause(String),
+    Next(String),
+    SetVolume(String, f64),
+    Event(ServiceEvent<MprisPlayerService>),
 }
 
 impl MediaPlayer {
@@ -98,81 +47,134 @@ impl MediaPlayer {
         config: &MediaPlayerModuleConfig,
     ) -> Task<crate::app::Message> {
         match message {
-            Message::SetSong(song) => {
-                if let Some(song) = song {
-                    let length = song.len();
-
-                    self.song = Some(if length > config.max_title_length as usize {
-                        let split = config.max_title_length as usize / 2;
-                        let first_part = song.chars().take(split).collect::<String>();
-                        let last_part = song.chars().skip(length - split).collect::<String>();
-                        format!("{}...{}", first_part, last_part)
-                    } else {
-                        song
-                    });
+            Message::Prev(n) => {
+                if let Some(s) = self.service.as_mut() {
+                    s.command(MprisPlayerCommand {
+                        service: n,
+                        command: PlayerCommand::Prev,
+                    })
+                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
                 } else {
-                    self.song = None;
+                    Task::none()
                 }
-
-                Task::none()
             }
-            Message::Prev => {
-                execute_command("playerctl previous".to_string());
-                Task::perform(async move { get_current_song().await }, move |song| {
-                    app::Message::MediaPlayer(Message::SetSong(song))
-                })
-            }
-            Message::Play => {
-                execute_command("playerctl play-pause".to_string());
-                Task::perform(async move { get_current_song().await }, move |song| {
-                    app::Message::MediaPlayer(Message::SetSong(song))
-                })
-            }
-            Message::Next => {
-                execute_command("playerctl next".to_string());
-                Task::perform(async move { get_current_song().await }, move |song| {
-                    app::Message::MediaPlayer(Message::SetSong(song))
-                })
-            }
-            Message::SetVolume(v) => {
-                if let Some(v) = v {
-                    execute_command(format!("playerctl volume {}", v / 100.0));
+            Message::PlayPause(n) => {
+                if let Some(s) = self.service.as_mut() {
+                    s.command(MprisPlayerCommand {
+                        service: n,
+                        command: PlayerCommand::PlayPause,
+                    })
+                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
+                } else {
+                    Task::none()
                 }
-                self.volume = v;
-                Task::none()
             }
-            Message::SyncVolume(v) => {
-                self.volume = v;
-                Task::none()
+            Message::Next(n) => {
+                if let Some(s) = self.service.as_mut() {
+                    s.command(MprisPlayerCommand {
+                        service: n,
+                        command: PlayerCommand::Next,
+                    })
+                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
+                } else {
+                    Task::none()
+                }
             }
+            Message::SetVolume(n, v) => {
+                if let Some(s) = self.service.as_mut() {
+                    s.command(MprisPlayerCommand {
+                        service: n,
+                        command: PlayerCommand::Volume(v),
+                    })
+                    .map(|event| crate::app::Message::MediaPlayer(Message::Event(event)))
+                } else {
+                    Task::none()
+                }
+            }
+            Message::Event(d) => match d {
+                ServiceEvent::Init(s) => {
+                    let data = s.deref();
+                    self.data = data
+                        .iter()
+                        .map(|d| PlayerData {
+                            name: d.service.clone(),
+                            song: d.metadata.clone().and_then(|d| match (d.artists, d.title) {
+                                (None, None) => None,
+                                (None, Some(t)) => Some(truncate_text(&t, config.max_title_length)),
+                                (Some(a), None) => {
+                                    Some(truncate_text(&a.join(", "), config.max_title_length))
+                                }
+                                (Some(a), Some(t)) => Some(truncate_text(
+                                    &format!("{} - {}", a.join(", "), t),
+                                    config.max_title_length,
+                                )),
+                            }),
+                            volume: d.volume,
+                        })
+                        .collect();
+                    self.service = Some(s);
+                    Task::none()
+                }
+                ServiceEvent::Update(d) => {
+                    self.data = d
+                        .iter()
+                        .map(|d| PlayerData {
+                            name: d.service.clone(),
+                            song: d.metadata.clone().and_then(|d| match (d.artists, d.title) {
+                                (None, None) => None,
+                                (None, Some(t)) => Some(t),
+                                (Some(a), None) => Some(a.join(", ")),
+                                (Some(a), Some(t)) => Some(format!("{} - {}", a.join(", "), t)),
+                            }),
+                            volume: d.volume,
+                        })
+                        .collect();
+                    Task::none()
+                }
+                ServiceEvent::Error(_) => Task::none(),
+            },
         }
     }
 
     pub fn menu_view(&self) -> Element<Message> {
-        column![]
-            .push_maybe(
-                self.volume
-                    .map(|v| slider(0.0..=100.0, v, |new_v| Message::SetVolume(Some(new_v)))),
+        column(self.data.iter().map(|d| {
+            container(
+                column![]
+                    .push_maybe(d.song.clone().map(|s| text(s)))
+                    .push_maybe(d.volume.map(|v| {
+                        slider(0.0..=100.0, v, |new_v| {
+                            Message::SetVolume(d.name.clone(), new_v)
+                        })
+                    }))
+                    .push(
+                        row![
+                            button(icon(Icons::SkipPrevious))
+                                .on_press(Message::Prev(d.name.clone()))
+                                .padding([5, 12])
+                                .style(SettingsButtonStyle.into_style()),
+                            button(icon(Icons::PlayPause))
+                                .on_press(Message::PlayPause(d.name.clone()))
+                                .style(SettingsButtonStyle.into_style()),
+                            button(icon(Icons::SkipNext))
+                                .on_press(Message::Next(d.name.clone()))
+                                .padding([5, 12])
+                                .style(SettingsButtonStyle.into_style())
+                        ]
+                        .spacing(8),
+                    )
+                    .spacing(8)
+                    .align_x(Center),
             )
-            .push(
-                row![
-                    button(icon(Icons::SkipPrevious))
-                        .on_press(Message::Prev)
-                        .padding([5, 12])
-                        .style(SettingsButtonStyle.into_style()),
-                    button(icon(Icons::PlayPause))
-                        .on_press(Message::Play)
-                        .style(SettingsButtonStyle.into_style()),
-                    button(icon(Icons::SkipNext))
-                        .on_press(Message::Next)
-                        .padding([5, 12])
-                        .style(SettingsButtonStyle.into_style())
-                ]
-                .spacing(8),
-            )
-            .spacing(8)
-            .align_x(Center)
+            .padding(4)
+            .style(|theme: &Theme| container::Style {
+                background: Some(iced::Background::Color(theme.palette().primary)),
+                ..container::Style::default()
+            })
             .into()
+        }))
+        .spacing(8)
+        .align_x(Alignment::Center)
+        .into()
     }
 }
 
@@ -184,31 +186,22 @@ impl Module for MediaPlayer {
         &self,
         (): Self::ViewData<'_>,
     ) -> Option<(Element<app::Message>, Option<OnModulePress>)> {
-        self.song.clone().map(|s| {
-            (
-                text(s).size(12).into(),
-                Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
-            )
-        })
+        Some((
+            text("media").into(),
+            Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
+        ))
+        // self.data[0].song.clone().map(|s| {
+        //     (
+        //         text(s).size(12).into(),
+        //         Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
+        //     )
+        // })
     }
 
     fn subscription(&self, (): Self::SubscriptionData<'_>) -> Option<Subscription<app::Message>> {
-        let id = TypeId::of::<Self>();
-
         Some(
-            Subscription::run_with_id(
-                id,
-                channel(10, |mut output| async move {
-                    loop {
-                        let song = get_current_song().await;
-                        let _ = output.try_send(Message::SetSong(song));
-                        let volume = get_volume().await;
-                        let _ = output.try_send(Message::SyncVolume(volume));
-                        sleep(Duration::from_secs(1)).await;
-                    }
-                }),
-            )
-            .map(app::Message::MediaPlayer),
+            MprisPlayerService::subscribe()
+                .map(|event| app::Message::MediaPlayer(Message::Event(event))),
         )
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -16,7 +16,7 @@ use crate::{
 use iced::{
     widget::{button, column, container, row, slider, text},
     Alignment::{self, Center},
-    Element, Subscription, Task, Theme,
+    Element, Subscription, Task,
 };
 
 #[derive(Default)]
@@ -137,42 +137,47 @@ impl MediaPlayer {
     }
 
     pub fn menu_view(&self) -> Element<Message> {
-        column(self.data.iter().map(|d| {
-            container(
-                column![]
-                    .push_maybe(d.song.clone().map(|s| text(s)))
-                    .push_maybe(d.volume.map(|v| {
-                        slider(0.0..=100.0, v, |new_v| {
-                            Message::SetVolume(d.name.clone(), new_v)
-                        })
-                    }))
-                    .push(
-                        row![
-                            button(icon(Icons::SkipPrevious))
-                                .on_press(Message::Prev(d.name.clone()))
-                                .padding([5, 12])
-                                .style(SettingsButtonStyle.into_style()),
-                            button(icon(Icons::PlayPause))
-                                .on_press(Message::PlayPause(d.name.clone()))
-                                .style(SettingsButtonStyle.into_style()),
-                            button(icon(Icons::SkipNext))
-                                .on_press(Message::Next(d.name.clone()))
-                                .padding([5, 12])
-                                .style(SettingsButtonStyle.into_style())
-                        ]
-                        .spacing(8),
-                    )
-                    .spacing(8)
-                    .align_x(Center),
-            )
-            .padding(4)
-            .style(|theme: &Theme| container::Style {
-                background: Some(iced::Background::Color(theme.palette().primary)),
-                ..container::Style::default()
-            })
-            .into()
-        }))
-        .spacing(8)
+        column(
+            self.data
+                .iter()
+                .flat_map(|d| {
+                    [
+                        iced::widget::horizontal_rule(2).into(),
+                        container(
+                            column![]
+                                .push_maybe(d.song.clone().map(|s| text(s)))
+                                .push_maybe(d.volume.map(|v| {
+                                    slider(0.0..=100.0, v, |v| {
+                                        Message::SetVolume(d.name.clone(), v)
+                                    })
+                                }))
+                                .push(
+                                    row![
+                                        button(icon(Icons::SkipPrevious))
+                                            .on_press(Message::Prev(d.name.clone()))
+                                            .padding([5, 12])
+                                            .style(SettingsButtonStyle.into_style()),
+                                        button(icon(Icons::PlayPause))
+                                            .on_press(Message::PlayPause(d.name.clone()))
+                                            .style(SettingsButtonStyle.into_style()),
+                                        button(icon(Icons::SkipNext))
+                                            .on_press(Message::Next(d.name.clone()))
+                                            .padding([5, 12])
+                                            .style(SettingsButtonStyle.into_style())
+                                    ]
+                                    .spacing(8),
+                                )
+                                .width(iced::Length::Fill)
+                                .spacing(8)
+                                .align_x(Center),
+                        )
+                        .padding(16)
+                        .into(),
+                    ]
+                })
+                .skip(1),
+        )
+        .spacing(16)
         .align_x(Alignment::Center)
         .into()
     }
@@ -187,15 +192,9 @@ impl Module for MediaPlayer {
         (): Self::ViewData<'_>,
     ) -> Option<(Element<app::Message>, Option<OnModulePress>)> {
         Some((
-            text("media").into(),
+            icon(Icons::MusicNote).into(),
             Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
         ))
-        // self.data[0].song.clone().map(|s| {
-        //     (
-        //         text(s).size(12).into(),
-        //         Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
-        //     )
-        // })
     }
 
     fn subscription(&self, (): Self::SubscriptionData<'_>) -> Option<Subscription<app::Message>> {

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -142,17 +142,13 @@ impl Module for MediaPlayer {
             let data = s.deref();
             match data.len() {
                 0 => None,
-                1 => Some((
+                _ => Some((
                     row![
                         icon(Icons::MusicNote),
                         text(Self::get_title(&data[0], config))
                     ]
                     .spacing(8)
                     .into(),
-                    Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
-                )),
-                _ => Some((
-                    icon(Icons::MusicNote).into(),
                     Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
                 )),
             }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -1,5 +1,3 @@
-use std::ops::Deref;
-
 use super::{Module, OnModulePress};
 use crate::{
     app,

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -224,7 +224,7 @@ impl App {
             ModuleName::Clock => self.clock.view(&self.config.clock.format),
             ModuleName::Privacy => self.privacy.view(()),
             ModuleName::Settings => self.settings.view(()),
-            ModuleName::MediaPlayer => self.media_player.view(()),
+            ModuleName::MediaPlayer => self.media_player.view(&self.config.media_player),
         }
     }
 

--- a/src/modules/window_title.rs
+++ b/src/modules/window_title.rs
@@ -1,4 +1,4 @@
-use crate::app;
+use crate::{app, utils::truncate_text};
 use hyprland::{data::Client, event_listener::AsyncEventListener, shared::HyprDataActiveOptional};
 use iced::{stream::channel, widget::text, Element, Subscription};
 use log::{debug, error};
@@ -31,16 +31,7 @@ impl WindowTitle {
         match message {
             Message::TitleChanged(value) => {
                 if let Some(value) = value {
-                    let length = value.len();
-
-                    self.value = Some(if length > truncate_title_after_length as usize {
-                        let split = truncate_title_after_length as usize / 2;
-                        let first_part = value.chars().take(split).collect::<String>();
-                        let last_part = value.chars().skip(length - split).collect::<String>();
-                        format!("{}...{}", first_part, last_part)
-                    } else {
-                        value
-                    });
+                    self.value = Some(truncate_text(&value, truncate_title_after_length));
                 } else {
                     self.value = None;
                 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,6 +4,7 @@ pub mod audio;
 pub mod bluetooth;
 pub mod brightness;
 pub mod idle_inhibitor;
+pub mod mpris;
 pub mod network;
 pub mod privacy;
 pub mod tray;

--- a/src/services/mpris/dbus.rs
+++ b/src/services/mpris/dbus.rs
@@ -1,0 +1,32 @@
+use std::collections::HashMap;
+use std::ops::Deref;
+use zbus::{proxy, zvariant::OwnedValue, Result};
+
+pub struct MprisPlayerDbus<'a>(MprisPlayerProxy<'a>);
+
+impl<'a> Deref for MprisPlayerDbus<'a> {
+    type Target = MprisPlayerProxy<'a>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[proxy(
+    interface = "org.mpris.MediaPlayer2.Player",
+    default_path = "/org/mpris/MediaPlayer2"
+)]
+pub trait MprisPlayer {
+    fn next(&self) -> Result<()>;
+    fn play_pause(&self) -> Result<()>;
+    fn previous(&self) -> Result<()>;
+
+    #[zbus(property)]
+    fn metadata(&self) -> Result<HashMap<String, OwnedValue>>;
+    #[zbus(property)]
+    fn set_volume(&self, v: f64) -> Result<()>;
+    #[zbus(property)]
+    fn volume(&self) -> Result<f64>;
+    #[zbus(property)]
+    fn can_control(&self) -> Result<bool>;
+}

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -1,0 +1,293 @@
+use super::{ReadOnlyService, Service, ServiceEvent};
+use dbus::MprisPlayerProxy;
+use iced::{
+    futures::{
+        channel::mpsc::Sender,
+        future::join_all,
+        stream::{pending, SelectAll},
+        SinkExt, Stream, StreamExt,
+    },
+    stream::channel,
+    Subscription,
+};
+use log::{error, info};
+use std::{any::TypeId, collections::HashMap, ops::Deref};
+use zbus::{fdo::DBusProxy, zvariant::OwnedValue};
+
+mod dbus;
+
+#[derive(Debug, Clone)]
+pub struct MprisPlayerData {
+    pub service: String,
+    pub metadata: Option<MprisPlayerMetadata>,
+    pub volume: Option<f64>,
+    proxy: MprisPlayerProxy<'static>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MprisPlayerMetadata {
+    pub artists: Option<Vec<String>>,
+    pub title: Option<String>,
+}
+
+impl From<HashMap<String, OwnedValue>> for MprisPlayerMetadata {
+    fn from(value: HashMap<String, OwnedValue>) -> Self {
+        let artists = match value.get("xesam:artist") {
+            Some(v) => match v.clone().try_into() {
+                Ok(v) => Some(v),
+                Err(_) => None,
+            },
+            None => None,
+        };
+        let title = match value.get("xesam:title") {
+            Some(v) => match v.clone().try_into() {
+                Ok(v) => Some(v),
+                Err(_) => None,
+            },
+            None => None,
+        };
+        Self { artists, title }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MprisPlayerService {
+    data: Vec<MprisPlayerData>,
+    conn: zbus::Connection,
+}
+
+impl Deref for MprisPlayerService {
+    type Target = Vec<MprisPlayerData>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.data
+    }
+}
+
+enum State {
+    Init,
+    Active(zbus::Connection),
+    Error,
+}
+
+impl ReadOnlyService for MprisPlayerService {
+    type UpdateEvent = Vec<MprisPlayerData>;
+    type Error = ();
+
+    fn update(&mut self, event: Self::UpdateEvent) {
+        self.data = event;
+    }
+
+    fn subscribe() -> Subscription<ServiceEvent<Self>> {
+        let id = TypeId::of::<Self>();
+
+        Subscription::run_with_id(
+            id,
+            channel(10, |mut output| async move {
+                let mut state = State::Init;
+
+                loop {
+                    state = MprisPlayerService::start_listening(state, &mut output).await;
+                }
+            }),
+        )
+    }
+}
+
+const MPRIS_PLAYER_SERVICE_PREFIX: &str = "org.mpris.MediaPlayer2.";
+
+impl MprisPlayerService {
+    async fn initialize_data(conn: &zbus::Connection) -> anyhow::Result<Vec<MprisPlayerData>> {
+        let dbus = DBusProxy::new(&conn).await?;
+        let names = dbus.list_names().await?;
+        Ok(join_all(
+            names
+                .iter()
+                .filter(|a| a.starts_with(MPRIS_PLAYER_SERVICE_PREFIX))
+                .map(|s| async {
+                    let service = s.to_string();
+                    match MprisPlayerProxy::new(conn, s.to_string()).await {
+                        Ok(player) => {
+                            let m = player
+                                .metadata()
+                                .await
+                                .map_or(None, |m| Some(MprisPlayerMetadata::from(m)));
+                            let v = player.volume().await.map(|v| v * 100.0).ok();
+                            Some(MprisPlayerData {
+                                service,
+                                metadata: m,
+                                volume: v,
+                                proxy: player,
+                            })
+                        }
+                        Err(_) => None,
+                    }
+                }),
+        )
+        .await
+        .iter()
+        .filter_map(|d| d.clone())
+        .collect())
+    }
+
+    async fn events(conn: &zbus::Connection) -> anyhow::Result<impl Stream<Item = ()>> {
+        let dbus = DBusProxy::new(conn).await?;
+        let services = join_all(
+            dbus.list_names()
+                .await?
+                .iter()
+                .map(|n| async move { MprisPlayerProxy::new(conn, n.clone()).await.unwrap() }),
+        )
+        .await;
+        let mut combined = SelectAll::new();
+        combined.push(
+            dbus.receive_name_owner_changed()
+                .await?
+                .filter_map(|s| {
+                    iced::futures::future::ready(match s.args() {
+                        Ok(a) => a.name.starts_with("org.mpris.MediaPlayer2.").then_some(()),
+                        Err(_) => None,
+                    })
+                })
+                .boxed(),
+        );
+        for s in services.iter() {
+            combined.push(s.receive_metadata_changed().await.map(|_| ()).boxed());
+        }
+        for s in services.iter() {
+            combined.push(s.receive_volume_changed().await.map(|_| ()).boxed());
+        }
+        Ok(combined)
+    }
+
+    async fn start_listening(state: State, output: &mut Sender<ServiceEvent<Self>>) -> State {
+        match state {
+            State::Init => match zbus::Connection::session().await {
+                Ok(conn) => {
+                    let data = MprisPlayerService::initialize_data(&conn).await;
+                    match data {
+                        Ok(data) => {
+                            info!("MPRIS player service initialized");
+
+                            let _ = output
+                                .send(ServiceEvent::Init(MprisPlayerService {
+                                    data,
+                                    conn: conn.clone(),
+                                }))
+                                .await;
+
+                            State::Active(conn)
+                        }
+                        Err(err) => {
+                            error!("Failed to initialize MPRIS player service: {}", err);
+
+                            State::Error
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!("Failed to connect to system bus for MPRIS player: {}", err);
+                    State::Error
+                }
+            },
+            State::Active(conn) => match MprisPlayerService::events(&conn).await {
+                Ok(mut events) => {
+                    while let Some(_) = events.next().await {
+                        let data = MprisPlayerService::initialize_data(&conn).await;
+                        match data {
+                            Ok(data) => {
+                                info!("MPRIS player service new data");
+
+                                let _ = output.send(ServiceEvent::Update(data)).await;
+                            }
+                            Err(err) => {
+                                error!("Failed to fetch MPRIS player data: {}", err);
+                            }
+                        }
+                    }
+
+                    State::Active(conn)
+                }
+                Err(err) => {
+                    error!("Failed to listen for MPRIS player events: {}", err);
+
+                    State::Error
+                }
+            },
+            State::Error => {
+                let _ = pending::<u8>().next().await;
+
+                State::Error
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct MprisPlayerCommand {
+    pub service: String,
+    pub command: PlayerCommand,
+}
+
+#[derive(Debug)]
+pub enum PlayerCommand {
+    Prev,
+    PlayPause,
+    Next,
+    Volume(f64),
+}
+
+impl Service for MprisPlayerService {
+    type Command = MprisPlayerCommand;
+
+    fn command(&mut self, command: Self::Command) -> iced::Task<ServiceEvent<Self>> {
+        {
+            let s = self.data.iter().find(|d| d.service == command.service);
+            if let Some(s) = s {
+                let mpris_player_proxy = s.proxy.clone();
+                let mpris_player_datas = self.data.clone();
+                let conn = self.conn.clone();
+                iced::Task::perform(
+                    async move {
+                        match command.command {
+                            PlayerCommand::Prev => {
+                                let _ = mpris_player_proxy
+                                    .previous()
+                                    .await
+                                    .inspect_err(|e| error!("Previous command error: {}", e));
+                            }
+                            PlayerCommand::PlayPause => {
+                                let _ = mpris_player_proxy
+                                    .play_pause()
+                                    .await
+                                    .inspect_err(|e| error!("Play/pause command error: {}", e));
+                            }
+                            PlayerCommand::Next => {
+                                let _ = mpris_player_proxy
+                                    .next()
+                                    .await
+                                    .inspect_err(|e| error!("Next command error: {}", e));
+                            }
+                            PlayerCommand::Volume(v) => {
+                                let _ = mpris_player_proxy
+                                    .set_volume(v / 100.0)
+                                    .await
+                                    .inspect_err(|e| error!("Set volume command error: {}", e));
+                            }
+                        }
+                        match MprisPlayerService::initialize_data(&conn).await {
+                            Ok(d) => d,
+                            Err(e) => {
+                                error!("initialize data failed: {}", e);
+                                mpris_player_datas
+                            }
+                        }
+                    },
+                    |data| ServiceEvent::Update(data),
+                )
+            } else {
+                iced::Task::none()
+            }
+        }
+    }
+}

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -10,7 +10,7 @@ use iced::{
     stream::channel,
     Subscription,
 };
-use log::{error, info};
+use log::{debug, error, info};
 use std::{any::TypeId, collections::HashMap, fmt::Display, ops::Deref};
 use zbus::{fdo::DBusProxy, zvariant::OwnedValue};
 
@@ -249,7 +249,7 @@ impl MprisPlayerService {
                         match event {
                             Event::NameOwner => match Self::initialize_data(&conn).await {
                                 Ok(data) => {
-                                    info!("MPRIS player service new data");
+                                    debug!("MPRIS player service new data");
                                     names = data.0;
                                     let _ = output.send(ServiceEvent::Update(data.1)).await;
                                 }

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -123,8 +123,13 @@ impl MprisPlayerService {
             .list_names()
             .await?
             .iter()
-            .filter(|&a| a.starts_with(MPRIS_PLAYER_SERVICE_PREFIX))
-            .map(|a| a.to_string())
+            .filter_map(|a| {
+                if a.starts_with(MPRIS_PLAYER_SERVICE_PREFIX) {
+                    Some(a.to_string())
+                } else {
+                    None
+                }
+            })
             .collect();
         Ok((
             names.clone(),

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -257,7 +257,7 @@ impl MprisPlayerService {
                                     error!("Failed to fetch MPRIS player data: {}", err);
                                 }
                             },
-                            _ => {
+                            Event::Metadata | Event::Volume => {
                                 let data = Self::get_mpris_player_data(&conn, &names).await;
                                 let _ = output.send(ServiceEvent::Update(data)).await;
                             }

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -171,14 +171,14 @@ impl MprisPlayerService {
         combined.push(
             dbus.receive_name_owner_changed()
                 .await?
-                .filter_map(|s| {
-                    iced::futures::future::ready(match s.args() {
+                .filter_map(|s| async move {
+                    match s.args() {
                         Ok(a) => a
                             .name
                             .starts_with(MPRIS_PLAYER_SERVICE_PREFIX)
                             .then_some(Event::NameOwner),
                         Err(_) => None,
-                    })
+                    }
                 })
                 .boxed(),
         );

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -26,7 +26,7 @@ pub fn truncate_text(value: &str, max_length: u32) -> String {
         let split = max_length as usize / 2;
         let first_part = value.chars().take(split).collect::<String>();
         let last_part = value.chars().skip(length - split).collect::<String>();
-        format!("{}...{}", first_part, last_part)
+        format!("{first_part}...{last_part}")
     } else {
         value.to_string()
     }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -18,3 +18,16 @@ pub fn format_duration(duration: &Duration) -> String {
         format!("{:>2}m", m)
     }
 }
+
+pub fn truncate_text(value: &str, max_length: u32) -> String {
+    let length = value.len();
+
+    if length > max_length as usize {
+        let split = max_length as usize / 2;
+        let first_part = value.chars().take(split).collect::<String>();
+        let last_part = value.chars().skip(length - split).collect::<String>();
+        format!("{}...{}", first_part, last_part)
+    } else {
+        value.to_string()
+    }
+}


### PR DESCRIPTION
Directly integrate with MPRIS DBus interface instead of using `playerctl`. With this, CPU time is significantly lower (simple check through `top`).

This PR also implements support for displaying more than 1 player at a time in the Media Player module menu.