### PR TITLE
Fixed media player not updating

### DIFF
--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -46,6 +46,7 @@ impl MediaPlayer {
                 ServiceEvent::Update(d) => {
                     if let Some(service) = self.service.as_mut() {
                         service.update(d);
+                        self.service = Some(service.clone());
                     }
                     Task::none()
                 }


### PR DESCRIPTION
Simply mutating state doesn't cause a re-render, causing background changes to not get re-rendered.