### PR TITLE
Remove more underscores in tray's menus

### DIFF
--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -113,7 +113,7 @@ impl TrayModule {
                 Column::new()
                     .push(
                         button(row!(
-                            text(label.to_owned()).width(Length::Fill),
+                            text(label.replace("_", "").to_owned()).width(Length::Fill),
                             icon(if is_open {
                                 Icons::MenuOpen
                             } else {


### PR DESCRIPTION
Changes this:
![2025-05-24_11:02:52](https://github.com/user-attachments/assets/c56350f4-08fa-4ade-b431-66c95c481c2c)
To this:
![2025-05-24_11:03:51](https://github.com/user-attachments/assets/f8f35e67-6305-4205-a6f1-51d89e6c75c1)
