### PR TITLE
Use 'alias' instead of 'name' for bluetooth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Bluetooth: use alias instead of name for device name
+
 ## [0.5.0] - 2025-05-20
 
 ### WARNING BREAKING CHANGES

--- a/src/services/bluetooth/dbus.rs
+++ b/src/services/bluetooth/dbus.rs
@@ -82,7 +82,7 @@ impl BluetoothDbus<'_> {
                 .build()
                 .await?;
 
-            let name = device.name().await?;
+            let name = device.alias().await?;
             let connected = device.connected().await?;
 
             if connected {
@@ -140,7 +140,7 @@ pub trait Adapter {
 #[proxy(default_service = "org.bluez", interface = "org.bluez.Device1")]
 trait Device {
     #[zbus(property)]
-    fn name(&self) -> zbus::Result<String>;
+    fn alias(&self) -> zbus::Result<String>;
 
     #[zbus(property)]
     fn connected(&self) -> zbus::Result<bool>;


### PR DESCRIPTION
'name' may not exist and errors will be reported like:

"""
ERROR [ashell::services::bluetooth] Failed to initialize bluetooth service: org.freedesktop.DBus.Error.InvalidArgs: No such property 'Name'
ERROR [ashell::services::bluetooth] Bluetooth service error
"""

'Alias' is recommended by bluez doc:
https://git.kernel.org/pub/scm/bluetooth/bluez.git/tree/doc/org.bluez.Device.rst#n238
