### PR TITLE
feat: config keys for custom shutdown, suspend, reboot and logout commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,12 @@ alert = ".*notification"
 # without a value the related button will not appear
 # optional, default None
 lock_cmd = "hyprlock &"
+# commands used to respectively shutdown, suspend, reboot and logout
+# all optional, without values the defaults shown here will be used
+shutdown_cmd = "shutdown now"
+suspend_cmd = "systemctl suspend"
+reboot_cmd = "systemctl reboot"
+logout_cmd = "loginctl kill-user $(whoami)"
 # command used to open the sinks audio settings
 # without a value the related button will not appear
 # optional default None

--- a/src/config.rs
+++ b/src/config.rs
@@ -206,9 +206,33 @@ impl Default for ClockModuleConfig {
     }
 }
 
+fn default_shutdown_cmd() -> String {
+    return "shutdown now".to_string();
+}
+
+fn default_suspend_cmd() -> String {
+    return "systemctl suspend".to_string();
+}
+
+fn default_reboot_cmd() -> String {
+    return "systemctl reboot".to_string();
+}
+
+fn default_logout_cmd() -> String {
+    return "loginctl kill-user $(whoami)".to_string();
+}
+
 #[derive(Deserialize, Default, Clone, Debug)]
 pub struct SettingsModuleConfig {
     pub lock_cmd: Option<String>,
+    #[serde(default = "default_shutdown_cmd")]
+    pub shutdown_cmd: String,
+    #[serde(default = "default_suspend_cmd")]
+    pub suspend_cmd: String,
+    #[serde(default = "default_reboot_cmd")]
+    pub reboot_cmd: String,
+    #[serde(default = "default_logout_cmd")]
+    pub logout_cmd: String,
     pub audio_sinks_more_cmd: Option<String>,
     pub audio_sources_more_cmd: Option<String>,
     pub wifi_more_cmd: Option<String>,

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -576,7 +576,10 @@ impl Settings {
                     self.sub_menu
                         .filter(|menu_type| *menu_type == SubMenu::Power)
                         .map(|_| {
-                            sub_menu_wrapper(power_menu(opacity).map(Message::Power), opacity)
+                            sub_menu_wrapper(
+                                power_menu(opacity, config).map(Message::Power),
+                                opacity,
+                            )
                         }),
                 )
                 .push_maybe(top_sink_slider)

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -1,5 +1,6 @@
 use crate::{
     components::icons::{Icons, icon},
+    config::SettingsModuleConfig,
     style::ghost_button_style,
     utils,
 };
@@ -10,52 +11,52 @@ use iced::{
 
 #[derive(Debug, Clone)]
 pub enum PowerMessage {
-    Suspend,
-    Reboot,
-    Shutdown,
-    Logout,
+    Suspend(String),
+    Reboot(String),
+    Shutdown(String),
+    Logout(String),
 }
 
 impl PowerMessage {
     pub fn update(self) {
         match self {
-            PowerMessage::Suspend => {
-                utils::launcher::suspend();
+            PowerMessage::Suspend(cmd) => {
+                utils::launcher::suspend(cmd);
             }
-            PowerMessage::Reboot => {
-                utils::launcher::reboot();
+            PowerMessage::Reboot(cmd) => {
+                utils::launcher::reboot(cmd);
             }
-            PowerMessage::Shutdown => {
-                utils::launcher::shutdown();
+            PowerMessage::Shutdown(cmd) => {
+                utils::launcher::shutdown(cmd);
             }
-            PowerMessage::Logout => {
-                utils::launcher::logout();
+            PowerMessage::Logout(cmd) => {
+                utils::launcher::logout(cmd);
             }
         }
     }
 }
 
-pub fn power_menu<'a>(opacity: f32) -> Element<'a, PowerMessage> {
+pub fn power_menu<'a>(opacity: f32, config: &SettingsModuleConfig) -> Element<'a, PowerMessage> {
     column!(
         button(row!(icon(Icons::Suspend), text("Suspend")).spacing(16))
             .padding([4, 12])
-            .on_press(PowerMessage::Suspend)
+            .on_press(PowerMessage::Suspend(config.suspend_cmd.clone()))
             .width(Length::Fill)
             .style(ghost_button_style(opacity)),
         button(row!(icon(Icons::Reboot), text("Reboot")).spacing(16))
             .padding([4, 12])
-            .on_press(PowerMessage::Reboot)
+            .on_press(PowerMessage::Reboot(config.reboot_cmd.clone()))
             .width(Length::Fill)
             .style(ghost_button_style(opacity)),
         button(row!(icon(Icons::Power), text("Shutdown")).spacing(16))
             .padding([4, 12])
-            .on_press(PowerMessage::Shutdown)
+            .on_press(PowerMessage::Shutdown(config.shutdown_cmd.clone()))
             .width(Length::Fill)
             .style(ghost_button_style(opacity)),
         horizontal_rule(1),
         button(row!(icon(Icons::Logout), text("Logout")).spacing(16))
             .padding([4, 12])
-            .on_press(PowerMessage::Logout)
+            .on_press(PowerMessage::Logout(config.logout_cmd.clone()))
             .width(Length::Fill)
             .style(ghost_button_style(opacity)),
     )

--- a/src/utils/launcher.rs
+++ b/src/utils/launcher.rs
@@ -11,44 +11,44 @@ pub fn execute_command(command: String) {
     });
 }
 
-pub fn suspend() {
+pub fn suspend(cmd: String) {
     tokio::spawn(async move {
         let _ = Command::new("bash")
             .arg("-c")
-            .arg("systemctl suspend")
+            .arg(cmd)
             .spawn()
             .expect("Failed to execute command.")
             .wait();
     });
 }
 
-pub fn shutdown() {
+pub fn shutdown(cmd: String) {
     tokio::spawn(async move {
         let _ = Command::new("bash")
             .arg("-c")
-            .arg("shutdown now")
+            .arg(cmd)
             .spawn()
             .expect("Failed to execute command.")
             .wait();
     });
 }
 
-pub fn reboot() {
+pub fn reboot(cmd: String) {
     tokio::spawn(async move {
         let _ = Command::new("bash")
             .arg("-c")
-            .arg("systemctl reboot")
+            .arg(cmd)
             .spawn()
             .expect("Failed to execute command.")
             .wait();
     });
 }
 
-pub fn logout() {
+pub fn logout(cmd: String) {
     tokio::spawn(async move {
         let _ = Command::new("bash")
             .arg("-c")
-            .arg("loginctl kill-user $(whoami)")
+            .arg(cmd)
             .spawn()
             .expect("Failed to execute command.")
             .wait();


### PR DESCRIPTION
As the title states. This was prompted by the command used for logout being incorrect when using `uwsm` for session management (it should be `uwsm stop` according to [hyprland's wiki](https://wiki.hypr.land/Configuring/Dispatchers/#list-of-dispatchers)).

This allows to set appropriate commands depending on the particular user's setup, and if left empty it would just use the defaults.