### PR TITLE
Improve nixos experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 vendor
+/result

--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,21 @@
         "type": "github"
       }
     },
-    "flake-utils": {
+    "flake-parts": {
       "inputs": {
-        "systems": "systems"
+        "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "lastModified": 1754091436,
+        "narHash": "sha256-XKqDMN1/Qj1DKivQvscI4vmHfDfvYR2pfuFOJiCeewM=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "67df8c627c2c39c41dbec76a1f201929929ab0bd",
         "type": "github"
       },
       "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
         "type": "github"
       }
     },
@@ -49,10 +49,25 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1753579242,
+        "narHash": "sha256-zvaMGVn14/Zz8hnp4VWT9xVnhc8vuL3TStRqwk22biA=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "0f36c44e01a6129be94e3ade315a5883f0228a6e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-utils": "flake-utils",
+        "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }
@@ -74,21 +89,6 @@
       "original": {
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -4,75 +4,134 @@
   inputs = {
     crane.url = "github:ipetkov/crane";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
     rust-overlay = {
       url = "github:oxalica/rust-overlay";
-      inputs = {
-        nixpkgs.follows = "nixpkgs";
-      };
+      inputs.nixpkgs.follows = "nixpkgs";
     };
   };
 
-  outputs = { crane, nixpkgs, flake-utils, rust-overlay, ... }:
-    flake-utils.lib.eachDefaultSystem
-      (system:
-        let
-          overlays = [ (import rust-overlay) ];
-          pkgs = import nixpkgs {
-            inherit system overlays;
+  outputs =
+    {
+      crane,
+      nixpkgs,
+      flake-parts,
+      rust-overlay,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { withSystem, ... }:
+      {
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "aarch64-darwin"
+        ];
+        flake.modules.homeManager.ashell =
+          {
+            lib,
+            pkgs,
+            config,
+            ...
+          }:
+          let
+            cfg = config.services.ashell;
+            tomlConfig = (pkgs.formats.toml { }).generate;
+            settings = tomlConfig "ashell/config.toml" cfg.settings;
+          in
+          {
+            options.services.ashell = {
+              enable = lib.mkEnableOption "Enable ashell";
+              package = lib.mkOption {
+                type = lib.types.package;
+                default = withSystem pkgs.stdenv.hostPlatform.system ({ config, ... }: config.packages.default);
+              };
+              settings = lib.mkOption {
+                type = lib.types.attrs;
+                default = { };
+              };
+            };
+
+            config = lib.mkIf cfg.enable {
+              systemd.user.services.ashell = {
+                Install.WantedBy = [ "graphical-session.target" ];
+                Unit = {
+                  After = [ "graphical-session.target" ];
+                  ConditionEnvironment = "WAYLAND_DISPLAY";
+                  Description = "Ready to go Wayland status bar for Hyprland";
+                  PartOf = [ "graphical-session.target" ];
+                };
+                Service = {
+                  ExecStart = lib.getExe cfg.package;
+                  X-Restart-Trigger = [ settings ];
+                };
+              };
+
+              xdg.configFile."ashell/config.toml".source = settings;
+            };
           };
-          
-          craneLib = crane.mkLib pkgs;
+        perSystem =
+          { system, ... }:
+          let
+            overlays = [ (import rust-overlay) ];
+            pkgs = import nixpkgs {
+              inherit system overlays;
+            };
+            craneLib = crane.mkLib pkgs;
 
-          buildInputs = with pkgs; [
-            rust-bin.stable.latest.default
-            rustPlatform.bindgenHook
-            pkg-config
-            libxkbcommon
-            libGL
-            pipewire
-            libpulseaudio
-            wayland
-            vulkan-loader
-            udev
-          ];
-
-          runtimeDependencies = with pkgs; [
-            libpulseaudio
-            wayland
-            mesa
-            vulkan-loader
-            libGL
-            libglvnd
-          ];
-            
-          ldLibraryPath = pkgs.lib.makeLibraryPath runtimeDependencies;
-        in
-        {
-          # `nix build` and `nix run`
-          defaultPackage = craneLib.buildPackage {
-            src = ./.;
-
-            nativeBuildInputs = with pkgs; [
-              makeWrapper
+            buildInputs = with pkgs; [
+              rust-bin.stable.latest.default
+              rustPlatform.bindgenHook
               pkg-config
-              autoPatchelfHook # Add runtimeDependencies to rpath
+              libxkbcommon
+              libGL
+              pipewire
+              libpulseaudio
+              wayland
+              vulkan-loader
+              udev
             ];
 
-            inherit buildInputs runtimeDependencies ldLibraryPath;
+            runtimeDependencies = with pkgs; [
+              libpulseaudio
+              wayland
+              mesa
+              vulkan-loader
+              libGL
+              libglvnd
+            ];
 
-            postInstall = ''
-              wrapProgram "$out/bin/ashell" --prefix LD_LIBRARY_PATH : "${ldLibraryPath}"
-            '';
+            ldLibraryPath = pkgs.lib.makeLibraryPath runtimeDependencies;
+          in
+          {
+            # `nix build` and `nix run`
+            packages.default = craneLib.buildPackage {
+              src = ./.;
+
+              nativeBuildInputs = with pkgs; [
+                makeWrapper
+                pkg-config
+                autoPatchelfHook # Add runtimeDependencies to rpath
+              ];
+
+              inherit buildInputs runtimeDependencies ldLibraryPath;
+
+              postInstall = ''
+                wrapProgram "$out/bin/ashell" --prefix LD_LIBRARY_PATH : "${ldLibraryPath}"
+              '';
+            };
+
+            # `nix develop`
+            devShells.default = pkgs.mkShell {
+              inherit buildInputs ldLibraryPath;
+
+              LD_LIBRARY_PATH = ldLibraryPath;
+            };
           };
-
-          # `nix develop`
-          devShells.default = pkgs.mkShell {
-            inherit buildInputs ldLibraryPath;
-
-            LD_LIBRARY_PATH = ldLibraryPath;
-          };
-        }
-      );
+      }
+    );
 }
-

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -69,13 +69,30 @@ And in your `configuration.nix`:
 { pkgs, inputs, ... }:
 
 {
-  environment.systemPackages = [inputs.ashell.defaultPackage.${pkgs.system}];
+  environment.systemPackages = [inputs.ashell.packages.${pkgs.system}.default];
   # or home.packages = ...
 }
 ```
 
-This will build Ashell from source.  
+This will build Ashell from source.
 Alternatively, you can use `pkgs.ashell` from `nixpkgs`, which is cached.
+
+You can also use the Home Manager module:
+
+```nix
+{ pkgs, inputs, ... }:
+
+{
+  imports = [inputs.ashell.modules.homeManager.ashell];
+  services.ashell = {
+    enable = true;
+    # package = pkgs.ashell; # to use the chached package from nixpkgs
+    settings = {
+      # ... your configuration as a nix attrset
+    };
+  };
+}
+```
 
 ## Building from Source
 


### PR DESCRIPTION
This streamlines the NixOS experience so that it will use the standard way of defining package outputs and defines a simple home manager module which will run ashell in a systemd user service and allow configuring it from within the home configuration.