### PR TITLE
Add support for closing all menus with Escape key

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -515,7 +515,7 @@ impl App {
             Subscription::batch(self.modules_subscriptions(&self.config.modules.center)),
             Subscription::batch(self.modules_subscriptions(&self.config.modules.right)),
             config::subscription(&self.config_path),
-            listen_with(|evt, _, _| match evt {
+            listen_with(move |evt, _, _| match evt {
                 iced::Event::PlatformSpecific(iced::event::PlatformSpecific::Wayland(
                     WaylandEvent::Output(event, wl_output),
                 )) => {

--- a/src/app.rs
+++ b/src/app.rs
@@ -527,7 +527,7 @@ impl App {
                     Some(Message::OutputEvent((event, wl_output)))
                 }
                 iced::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
-                    debug!("Keyboard event received: {:?}", key);
+                    debug!("Keyboard event received: {key:?}");
                     if matches!(key, keyboard::Key::Named(keyboard::key::Named::Escape)) {
                         debug!("ESC key pressed, closing all menus");
                         Some(Message::CloseAllMenus)

--- a/src/app.rs
+++ b/src/app.rs
@@ -95,11 +95,7 @@ impl App {
         (logger, config, config_path): (LoggerHandle, Config, PathBuf),
     ) -> impl FnOnce() -> (Self, Task<Message>) {
         || {
-            let (outputs, task) = Outputs::new(
-                config.appearance.style,
-                config.position,
-                config.appearance.scale_factor,
-            );
+            let (outputs, task) = Outputs::new(config.appearance.style, config.position, &config);
 
             let custom = config
                 .custom_modules
@@ -172,7 +168,7 @@ impl App {
                         config.appearance.style,
                         &config.outputs,
                         config.position,
-                        config.appearance.scale_factor,
+                        &config,
                     ));
                 }
                 let custom = config
@@ -219,14 +215,14 @@ impl App {
                     }
                     _ => {}
                 };
-                cmd.push(self.outputs.toggle_menu(id, menu_type, button_ui_ref));
+                cmd.push(self.outputs.toggle_menu(id, menu_type, button_ui_ref, &self.config));
 
                 Task::batch(cmd)
             }
-            Message::CloseMenu(id) => self.outputs.close_menu(id),
+            Message::CloseMenu(id) => self.outputs.close_menu(id, &self.config),
             Message::CloseAllMenus => {
                 if self.outputs.menu_is_open() {
-                    self.outputs.close_all_menus()
+                    self.outputs.close_all_menus(&self.config)
                 } else {
                     Task::none()
                 }
@@ -234,7 +230,7 @@ impl App {
             Message::Updates(message) => {
                 if let Some(updates_config) = self.config.updates.as_ref() {
                     self.updates
-                        .update(message, updates_config, &mut self.outputs)
+                        .update(message, updates_config, &mut self.outputs, &self.config)
                 } else {
                     Task::none()
                 }
@@ -285,7 +281,7 @@ impl App {
                     TrayMessage::Event(event) => {
                         if let ServiceEvent::Update(TrayEvent::Unregistered(name)) = event.as_ref()
                         {
-                            self.outputs.close_all_menu_if(MenuType::Tray(name.clone()))
+                            self.outputs.close_all_menu_if(MenuType::Tray(name.clone()), &self.config)
                         } else {
                             Task::none()
                         }
@@ -302,7 +298,7 @@ impl App {
             Message::Privacy(msg) => self.privacy.update(msg),
             Message::Settings(message) => {
                 self.settings
-                    .update(message, &self.config.settings, &mut self.outputs)
+                    .update(message, &self.config.settings, &mut self.outputs, &self.config)
             }
             Message::OutputEvent((event, wl_output)) => match event {
                 iced::event::wayland::OutputEvent::Created(info) => {
@@ -318,7 +314,7 @@ impl App {
                         self.config.position,
                         name,
                         wl_output,
-                        self.config.appearance.scale_factor,
+                        &self.config,
                     )
                 }
                 iced::event::wayland::OutputEvent::Removed => {
@@ -327,7 +323,7 @@ impl App {
                         self.config.appearance.style,
                         self.config.position,
                         wl_output,
-                        self.config.appearance.scale_factor,
+                        &self.config,
                     )
                 }
                 _ => Task::none(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -702,10 +702,16 @@ pub struct Config {
     pub media_player: MediaPlayerModuleConfig,
     #[serde(default)]
     pub keyboard_layout: KeyboardLayoutModuleConfig,
+    #[serde(default)]
+    pub menu_keyboard_focus: bool,
 }
 
 fn default_log_level() -> String {
     "warn".to_owned()
+}
+
+fn default_menu_keyboard_focus() -> bool {
+    true
 }
 
 fn default_truncate_title_after_length() -> u32 {
@@ -731,6 +737,7 @@ impl Default for Config {
             media_player: MediaPlayerModuleConfig::default(),
             keyboard_layout: KeyboardLayoutModuleConfig::default(),
             custom_modules: vec![],
+            menu_keyboard_focus: default_menu_keyboard_focus(),
         }
     }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -98,16 +98,16 @@ impl Menu {
         }
     }
 
-    pub fn request_keyboard<Message: 'static>(&self, config: &crate::config::Config) -> Task<Message> {
-        if config.menu_keyboard_focus {
+    pub fn request_keyboard<Message: 'static>(&self, menu_keyboard_focus: bool) -> Task<Message> {
+        if menu_keyboard_focus {
             set_keyboard_interactivity(self.id, KeyboardInteractivity::OnDemand)
         } else {
             Task::none()
         }
     }
 
-    pub fn release_keyboard<Message: 'static>(&self, config: &crate::config::Config) -> Task<Message> {
-        if config.menu_keyboard_focus {
+    pub fn release_keyboard<Message: 'static>(&self, menu_keyboard_focus: bool) -> Task<Message> {
+        if menu_keyboard_focus {
             set_keyboard_interactivity(self.id, KeyboardInteractivity::None)
         } else {
             Task::none()

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -44,7 +44,7 @@ impl Menu {
 
         Task::batch(vec![
             set_layer(self.id, Layer::Overlay),
-            set_keyboard_interactivity(self.id, KeyboardInteractivity::None),
+            set_keyboard_interactivity(self.id, KeyboardInteractivity::OnDemand),
         ])
     }
 

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -98,12 +98,13 @@ impl Settings {
         message: Message,
         config: &SettingsModuleConfig,
         outputs: &mut Outputs,
+        main_config: &crate::config::Config,
     ) -> Task<crate::app::Message> {
         match message {
             Message::ToggleMenu(id, button_ui_ref) => {
                 self.sub_menu = None;
                 self.password_dialog = None;
-                outputs.toggle_menu(id, MenuType::Settings, button_ui_ref)
+                outputs.toggle_menu(id, MenuType::Settings, button_ui_ref, main_config)
             }
             Message::Audio(msg) => match msg {
                 AudioMessage::Event(event) => match event {
@@ -166,7 +167,7 @@ impl Settings {
                 AudioMessage::SinksMore(id) => {
                     if let Some(cmd) = &config.audio_sinks_more_cmd {
                         crate::utils::launcher::execute_command(cmd.to_string());
-                        outputs.close_menu(id)
+                        outputs.close_menu(id, main_config)
                     } else {
                         Task::none()
                     }
@@ -174,7 +175,7 @@ impl Settings {
                 AudioMessage::SourcesMore(id) => {
                     if let Some(cmd) = &config.audio_sources_more_cmd {
                         crate::utils::launcher::execute_command(cmd.to_string());
-                        outputs.close_menu(id)
+                        outputs.close_menu(id, main_config)
                     } else {
                         Task::none()
                     }
@@ -261,7 +262,7 @@ impl Settings {
                 NetworkMessage::RequestWiFiPassword(id, ssid) => {
                     info!("Requesting password for {ssid}");
                     self.password_dialog = Some((ssid, "".to_string()));
-                    outputs.request_keyboard(id)
+                    outputs.request_keyboard(id, main_config)
                 }
                 NetworkMessage::ScanNearByWiFi => match self.network.as_mut() {
                     Some(network) => network
@@ -276,7 +277,7 @@ impl Settings {
                 NetworkMessage::WiFiMore(id) => {
                     if let Some(cmd) = &config.wifi_more_cmd {
                         crate::utils::launcher::execute_command(cmd.to_string());
-                        outputs.close_menu(id)
+                        outputs.close_menu(id, main_config)
                     } else {
                         Task::none()
                     }
@@ -284,7 +285,7 @@ impl Settings {
                 NetworkMessage::VpnMore(id) => {
                     if let Some(cmd) = &config.vpn_more_cmd {
                         crate::utils::launcher::execute_command(cmd.to_string());
-                        outputs.close_menu(id)
+                        outputs.close_menu(id, main_config)
                     } else {
                         Task::none()
                     }
@@ -331,7 +332,7 @@ impl Settings {
                 BluetoothMessage::More(id) => {
                     if let Some(cmd) = &config.bluetooth_more_cmd {
                         crate::utils::launcher::execute_command(cmd.to_string());
-                        outputs.close_menu(id)
+                        outputs.close_menu(id, main_config)
                     } else {
                         Task::none()
                     }
@@ -435,15 +436,15 @@ impl Settings {
                             }
                             _ => Task::none(),
                         };
-                        Task::batch(vec![network_command, outputs.release_keyboard(id)])
+                        Task::batch(vec![network_command, outputs.release_keyboard(id, main_config)])
                     } else {
-                        outputs.release_keyboard(id)
+                        outputs.release_keyboard(id, main_config)
                     }
                 }
                 password_dialog::Message::DialogCancelled(id) => {
                     self.password_dialog = None;
 
-                    outputs.release_keyboard(id)
+                    outputs.release_keyboard(id, main_config)
                 }
             },
         }

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -262,7 +262,7 @@ impl Settings {
                 NetworkMessage::RequestWiFiPassword(id, ssid) => {
                     info!("Requesting password for {ssid}");
                     self.password_dialog = Some((ssid, "".to_string()));
-                    outputs.request_keyboard(id, main_config)
+                    outputs.request_keyboard(id, main_config.menu_keyboard_focus)
                 }
                 NetworkMessage::ScanNearByWiFi => match self.network.as_mut() {
                     Some(network) => network
@@ -436,15 +436,15 @@ impl Settings {
                             }
                             _ => Task::none(),
                         };
-                        Task::batch(vec![network_command, outputs.release_keyboard(id, main_config)])
+                        Task::batch(vec![network_command, outputs.release_keyboard(id, main_config.menu_keyboard_focus)])
                     } else {
-                        outputs.release_keyboard(id, main_config)
+                        outputs.release_keyboard(id, main_config.menu_keyboard_focus)
                     }
                 }
                 password_dialog::Message::DialogCancelled(id) => {
                     self.password_dialog = None;
 
-                    outputs.release_keyboard(id, main_config)
+                    outputs.release_keyboard(id, main_config.menu_keyboard_focus)
                 }
             },
         }

--- a/src/modules/updates.rs
+++ b/src/modules/updates.rs
@@ -101,6 +101,7 @@ impl Updates {
         message: Message,
         config: &UpdatesModuleConfig,
         outputs: &mut Outputs,
+        main_config: &crate::config::Config,
     ) -> Task<crate::app::Message> {
         match message {
             Message::UpdatesCheckCompleted(updates) => {
@@ -142,7 +143,7 @@ impl Updates {
                     move |_| app::Message::Updates(Message::UpdateFinished),
                 )];
 
-                cmds.push(outputs.close_menu_if(id, MenuType::Updates));
+                cmds.push(outputs.close_menu_if(id, MenuType::Updates, main_config));
 
                 Task::batch(cmds)
             }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -40,7 +40,7 @@ impl Outputs {
         position: Position,
         config: &crate::config::Config,
     ) -> (Self, Task<Message>) {
-        let (id, menu_id, task) = Self::create_output_layers(style, None, position, config.menu_keyboard_focus);
+        let (id, menu_id, task) = Self::create_output_layers(style, None, position, config.menu_keyboard_focus, config.appearance.scale_factor);
 
         (
             Self(vec![(
@@ -72,9 +72,10 @@ impl Outputs {
         wl_output: Option<WlOutput>,
         position: Position,
         menu_keyboard_focus: bool,
+        scale_factor: f64,
     ) -> (Id, Id, Task<Message>) {
         let id = Id::unique();
-        let height = Self::get_height(style, config.appearance.scale_factor);
+        let height = Self::get_height(style, scale_factor);
 
         let task = get_layer_surface(SctkLayerSurfaceSettings {
             id,
@@ -178,7 +179,7 @@ impl Outputs {
             debug!("Found target output, creating a new layer surface");
 
             let (id, menu_id, task) =
-                Self::create_output_layers(style, Some(wl_output.clone()), position, config.menu_keyboard_focus);
+                Self::create_output_layers(style, Some(wl_output.clone()), position, config.menu_keyboard_focus, config.appearance.scale_factor);
 
             let destroy_task = match self
                 .0
@@ -275,7 +276,7 @@ impl Outputs {
                 if !self.0.iter().any(|(_, shell_info, _)| shell_info.is_some()) {
                     debug!("No outputs left, creating a fallback layer surface");
 
-                    let (id, menu_id, task) = Self::create_output_layers(style, None, position, config.menu_keyboard_focus);
+                    let (id, menu_id, task) = Self::create_output_layers(style, None, position, config.menu_keyboard_focus, config.appearance.scale_factor);
 
                     self.0.push((
                         None,

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -82,7 +82,7 @@ impl Outputs {
             size: Some((None, Some(height as u32))),
             layer: Layer::Bottom,
             pointer_interactivity: true,
-            keyboard_interactivity: KeyboardInteractivity::None,
+            keyboard_interactivity: KeyboardInteractivity::OnDemand,
             exclusive_zone: height as i32,
             output: wl_output.clone().map_or(IcedOutput::Active, |wl_output| {
                 IcedOutput::Output(wl_output)
@@ -479,6 +479,25 @@ impl Outputs {
                 .map(|(_, shell_info, _)| {
                     if let Some(shell_info) = shell_info {
                         shell_info.menu.close_if(menu_type.clone())
+                    } else {
+                        Task::none()
+                    }
+                })
+                .collect::<Vec<_>>(),
+        )
+    }
+
+    pub fn close_all_menus<Message: 'static>(&mut self) -> Task<Message> {
+        Task::batch(
+            self.0
+                .iter_mut()
+                .map(|(_, shell_info, _)| {
+                    if let Some(shell_info) = shell_info {
+                        if shell_info.menu.menu_info.is_some() {
+                            shell_info.menu.close()
+                        } else {
+                            Task::none()
+                        }
                     } else {
                         Task::none()
                     }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -40,7 +40,7 @@ impl Outputs {
         position: Position,
         config: &crate::config::Config,
     ) -> (Self, Task<Message>) {
-        let (id, menu_id, task) = Self::create_output_layers(style, None, position, config);
+        let (id, menu_id, task) = Self::create_output_layers(style, None, position, config.menu_keyboard_focus);
 
         (
             Self(vec![(
@@ -71,7 +71,7 @@ impl Outputs {
         style: AppearanceStyle,
         wl_output: Option<WlOutput>,
         position: Position,
-        config: &crate::config::Config,
+        menu_keyboard_focus: bool,
     ) -> (Id, Id, Task<Message>) {
         let id = Id::unique();
         let height = Self::get_height(style, config.appearance.scale_factor);
@@ -82,7 +82,7 @@ impl Outputs {
             size: Some((None, Some(height as u32))),
             layer: Layer::Bottom,
             pointer_interactivity: true,
-            keyboard_interactivity: if config.menu_keyboard_focus {
+            keyboard_interactivity: if menu_keyboard_focus {
                 KeyboardInteractivity::OnDemand
             } else {
                 KeyboardInteractivity::None
@@ -178,7 +178,7 @@ impl Outputs {
             debug!("Found target output, creating a new layer surface");
 
             let (id, menu_id, task) =
-                Self::create_output_layers(style, Some(wl_output.clone()), position, config);
+                Self::create_output_layers(style, Some(wl_output.clone()), position, config.menu_keyboard_focus);
 
             let destroy_task = match self
                 .0
@@ -275,7 +275,7 @@ impl Outputs {
                 if !self.0.iter().any(|(_, shell_info, _)| shell_info.is_some()) {
                     debug!("No outputs left, creating a fallback layer surface");
 
-                    let (id, menu_id, task) = Self::create_output_layers(style, None, position, config);
+                    let (id, menu_id, task) = Self::create_output_layers(style, None, position, config.menu_keyboard_focus);
 
                     self.0.push((
                         None,
@@ -511,22 +511,22 @@ impl Outputs {
         )
     }
 
-    pub fn request_keyboard<Message: 'static>(&self, id: Id, config: &crate::config::Config) -> Task<Message> {
+    pub fn request_keyboard<Message: 'static>(&self, id: Id, menu_keyboard_focus: bool) -> Task<Message> {
         match self.0.iter().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
-            Some((_, Some(shell_info), _)) => shell_info.menu.request_keyboard(config),
+            Some((_, Some(shell_info), _)) => shell_info.menu.request_keyboard(menu_keyboard_focus),
             _ => Task::none(),
         }
     }
 
-    pub fn release_keyboard<Message: 'static>(&self, id: Id, config: &crate::config::Config) -> Task<Message> {
+    pub fn release_keyboard<Message: 'static>(&self, id: Id, menu_keyboard_focus: bool) -> Task<Message> {
         match self.0.iter().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
-            Some((_, Some(shell_info), _)) => shell_info.menu.release_keyboard(config),
+            Some((_, Some(shell_info), _)) => shell_info.menu.release_keyboard(menu_keyboard_focus),
             _ => Task::none(),
         }
     }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -38,9 +38,9 @@ impl Outputs {
     pub fn new<Message: 'static>(
         style: AppearanceStyle,
         position: Position,
-        scale_factor: f64,
+        config: &crate::config::Config,
     ) -> (Self, Task<Message>) {
-        let (id, menu_id, task) = Self::create_output_layers(style, None, position, scale_factor);
+        let (id, menu_id, task) = Self::create_output_layers(style, None, position, config);
 
         (
             Self(vec![(
@@ -50,7 +50,7 @@ impl Outputs {
                     menu: Menu::new(menu_id),
                     position,
                     style,
-                    scale_factor,
+                    scale_factor: config.appearance.scale_factor,
                 }),
                 None,
             )]),
@@ -71,10 +71,10 @@ impl Outputs {
         style: AppearanceStyle,
         wl_output: Option<WlOutput>,
         position: Position,
-        scale_factor: f64,
+        config: &crate::config::Config,
     ) -> (Id, Id, Task<Message>) {
         let id = Id::unique();
-        let height = Self::get_height(style, scale_factor);
+        let height = Self::get_height(style, config.appearance.scale_factor);
 
         let task = get_layer_surface(SctkLayerSurfaceSettings {
             id,
@@ -82,7 +82,11 @@ impl Outputs {
             size: Some((None, Some(height as u32))),
             layer: Layer::Bottom,
             pointer_interactivity: true,
-            keyboard_interactivity: KeyboardInteractivity::OnDemand,
+            keyboard_interactivity: if config.menu_keyboard_focus {
+                KeyboardInteractivity::OnDemand
+            } else {
+                KeyboardInteractivity::None
+            },
             exclusive_zone: height as i32,
             output: wl_output.clone().map_or(IcedOutput::Active, |wl_output| {
                 IcedOutput::Output(wl_output)
@@ -166,7 +170,7 @@ impl Outputs {
         position: Position,
         name: &str,
         wl_output: WlOutput,
-        scale_factor: f64,
+        config: &crate::config::Config,
     ) -> Task<Message> {
         let target = Self::name_in_config(Some(name), request_outputs);
 
@@ -174,7 +178,7 @@ impl Outputs {
             debug!("Found target output, creating a new layer surface");
 
             let (id, menu_id, task) =
-                Self::create_output_layers(style, Some(wl_output.clone()), position, scale_factor);
+                Self::create_output_layers(style, Some(wl_output.clone()), position, config);
 
             let destroy_task = match self
                 .0
@@ -204,7 +208,7 @@ impl Outputs {
                     menu: Menu::new(menu_id),
                     position,
                     style,
-                    scale_factor,
+                    scale_factor: config.appearance.scale_factor,
                 }),
                 Some(wl_output),
             ));
@@ -244,7 +248,7 @@ impl Outputs {
         style: AppearanceStyle,
         position: Position,
         wl_output: WlOutput,
-        scale_factor: f64,
+        config: &crate::config::Config,
     ) -> Task<Message> {
         match self.0.iter().position(|(_, _, assigned_wl_output)| {
             assigned_wl_output
@@ -271,8 +275,7 @@ impl Outputs {
                 if !self.0.iter().any(|(_, shell_info, _)| shell_info.is_some()) {
                     debug!("No outputs left, creating a fallback layer surface");
 
-                    let (id, menu_id, task) =
-                        Self::create_output_layers(style, None, position, scale_factor);
+                    let (id, menu_id, task) = Self::create_output_layers(style, None, position, config);
 
                     self.0.push((
                         None,
@@ -281,7 +284,7 @@ impl Outputs {
                             menu: Menu::new(menu_id),
                             position,
                             style,
-                            scale_factor,
+                            scale_factor: config.appearance.scale_factor,
                         }),
                         None,
                     ));
@@ -300,7 +303,7 @@ impl Outputs {
         style: AppearanceStyle,
         request_outputs: &config::Outputs,
         position: Position,
-        scale_factor: f64,
+        config: &crate::config::Config,
     ) -> Task<Message> {
         debug!("Syncing outputs: {self:?}, request_outputs: {request_outputs:?}");
 
@@ -346,14 +349,14 @@ impl Outputs {
                         position,
                         name.as_str(),
                         wl_output,
-                        scale_factor,
+                        config,
                     ));
                 }
             }
         }
 
         for wl_output in to_remove {
-            tasks.push(self.remove(style, position, wl_output, scale_factor));
+            tasks.push(self.remove(style, position, wl_output, config));
         }
 
         for shell_info in self.0.iter_mut().filter_map(|(_, shell_info, _)| {
@@ -382,7 +385,7 @@ impl Outputs {
 
         for shell_info in self.0.iter_mut().filter_map(|(_, shell_info, _)| {
             if let Some(shell_info) = shell_info
-                && (shell_info.style != style || shell_info.scale_factor != scale_factor)
+                && (shell_info.style != style || shell_info.scale_factor != config.appearance.scale_factor)
             {
                 Some(shell_info)
             } else {
@@ -391,11 +394,11 @@ impl Outputs {
         }) {
             debug!(
                 "Change style or scale_factor for output: {:?}, new style {:?}, new scale_factor {:?}",
-                shell_info.id, style, scale_factor
+                shell_info.id, style, config.appearance.scale_factor
             );
             shell_info.style = style;
-            shell_info.scale_factor = scale_factor;
-            let height = Self::get_height(style, scale_factor);
+            shell_info.scale_factor = config.appearance.scale_factor;
+            let height = Self::get_height(style, config.appearance.scale_factor);
             tasks.push(Task::batch(vec![
                 set_size(shell_info.id, None, Some(height as u32)),
                 set_exclusive_zone(shell_info.id, height as i32),
@@ -419,20 +422,21 @@ impl Outputs {
         id: Id,
         menu_type: MenuType,
         button_ui_ref: ButtonUIRef,
+        config: &crate::config::Config,
     ) -> Task<Message> {
         match self.0.iter_mut().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
             Some((_, Some(shell_info), _)) => {
-                let toggle_task = shell_info.menu.toggle(menu_type, button_ui_ref);
+                let toggle_task = shell_info.menu.toggle(menu_type, button_ui_ref, config);
                 let mut tasks = self
                     .0
                     .iter_mut()
                     .filter_map(|(_, shell_info, _)| {
                         if let Some(shell_info) = shell_info {
                             if shell_info.id != id && shell_info.menu.id != id {
-                                Some(shell_info.menu.close())
+                                Some(shell_info.menu.close(config))
                             } else {
                                 None
                             }
@@ -448,12 +452,12 @@ impl Outputs {
         }
     }
 
-    pub fn close_menu<Message: 'static>(&mut self, id: Id) -> Task<Message> {
+    pub fn close_menu<Message: 'static>(&mut self, id: Id, config: &crate::config::Config) -> Task<Message> {
         match self.0.iter_mut().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
-            Some((_, Some(shell_info), _)) => shell_info.menu.close(),
+            Some((_, Some(shell_info), _)) => shell_info.menu.close(config),
             _ => Task::none(),
         }
     }
@@ -462,23 +466,24 @@ impl Outputs {
         &mut self,
         id: Id,
         menu_type: MenuType,
+        config: &crate::config::Config,
     ) -> Task<Message> {
         match self.0.iter_mut().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
-            Some((_, Some(shell_info), _)) => shell_info.menu.close_if(menu_type),
+            Some((_, Some(shell_info), _)) => shell_info.menu.close_if(menu_type, config),
             _ => Task::none(),
         }
     }
 
-    pub fn close_all_menu_if<Message: 'static>(&mut self, menu_type: MenuType) -> Task<Message> {
+    pub fn close_all_menu_if<Message: 'static>(&mut self, menu_type: MenuType, config: &crate::config::Config) -> Task<Message> {
         Task::batch(
             self.0
                 .iter_mut()
                 .map(|(_, shell_info, _)| {
                     if let Some(shell_info) = shell_info {
-                        shell_info.menu.close_if(menu_type.clone())
+                        shell_info.menu.close_if(menu_type.clone(), config)
                     } else {
                         Task::none()
                     }
@@ -487,14 +492,14 @@ impl Outputs {
         )
     }
 
-    pub fn close_all_menus<Message: 'static>(&mut self) -> Task<Message> {
+    pub fn close_all_menus<Message: 'static>(&mut self, config: &crate::config::Config) -> Task<Message> {
         Task::batch(
             self.0
                 .iter_mut()
                 .map(|(_, shell_info, _)| {
                     if let Some(shell_info) = shell_info {
                         if shell_info.menu.menu_info.is_some() {
-                            shell_info.menu.close()
+                            shell_info.menu.close(config)
                         } else {
                             Task::none()
                         }
@@ -506,22 +511,22 @@ impl Outputs {
         )
     }
 
-    pub fn request_keyboard<Message: 'static>(&self, id: Id) -> Task<Message> {
+    pub fn request_keyboard<Message: 'static>(&self, id: Id, config: &crate::config::Config) -> Task<Message> {
         match self.0.iter().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
-            Some((_, Some(shell_info), _)) => shell_info.menu.request_keyboard(),
+            Some((_, Some(shell_info), _)) => shell_info.menu.request_keyboard(config),
             _ => Task::none(),
         }
     }
 
-    pub fn release_keyboard<Message: 'static>(&self, id: Id) -> Task<Message> {
+    pub fn release_keyboard<Message: 'static>(&self, id: Id, config: &crate::config::Config) -> Task<Message> {
         match self.0.iter().find(|(_, shell_info, _)| {
             shell_info.as_ref().map(|shell_info| shell_info.id) == Some(id)
                 || shell_info.as_ref().map(|shell_info| shell_info.menu.id) == Some(id)
         }) {
-            Some((_, Some(shell_info), _)) => shell_info.menu.release_keyboard(),
+            Some((_, Some(shell_info), _)) => shell_info.menu.release_keyboard(config),
             _ => Task::none(),
         }
     }


### PR DESCRIPTION
- Introduced `CloseAllMenus` message to handle bulk menu closure
- Implemented `close_all_menus` in `Outputs`
- ESC key now triggers `CloseAllMenus` if any menu is open
- Changed keyboard interactivity to `OnDemand` for menus
- Implements #176 