### PR TITLE
feat: add option to remove idle inhibitor button in settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,6 +352,9 @@ bluetooth_more_cmd = "blueman-manager"
 # option to remove the airtplane button
 # optional, default false
 remove_airplane_btn = true
+# option to remove the idle inhibitor button
+# optional, default false
+remove_idle_btn = true
 
 # Appearance config
 # Each color could be a simple hex color like #228800 or an

--- a/src/config.rs
+++ b/src/config.rs
@@ -253,6 +253,8 @@ pub struct SettingsModuleConfig {
     pub bluetooth_more_cmd: Option<String>,
     #[serde(default)]
     pub remove_airplane_btn: bool,
+    #[serde(default)]
+    pub remove_idle_btn: bool,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -533,23 +533,27 @@ impl Settings {
                             Some(n.get_airplane_mode_quick_setting_button(opacity))
                         }
                     }),
-                    self.idle_inhibitor.as_ref().map(|idle_inhibitor| {
-                        (
-                            quick_setting_button(
-                                if idle_inhibitor.is_inhibited() {
-                                    Icons::EyeOpened
-                                } else {
-                                    Icons::EyeClosed
-                                },
-                                "Idle Inhibitor".to_string(),
+                    self.idle_inhibitor.as_ref().and_then(|i| {
+                        if config.remove_idle_btn {
+                            None
+                        } else {
+                            Some((
+                                quick_setting_button(
+                                    if i.is_inhibited() {
+                                        Icons::EyeOpened
+                                    } else {
+                                        Icons::EyeClosed
+                                    },
+                                    "Idle Inhibitor".to_string(),
+                                    None,
+                                    i.is_inhibited(),
+                                    Message::ToggleInhibitIdle,
+                                    None,
+                                    opacity,
+                                ),
                                 None,
-                                idle_inhibitor.is_inhibited(),
-                                Message::ToggleInhibitIdle,
-                                None,
-                                opacity,
-                            ),
-                            None,
-                        )
+                            ))
+                        }
                     }),
                     self.upower
                         .as_ref()

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -50,10 +50,12 @@ With the `audio_sinks_more_cmd` and `audio_sources_more_cmd`
 options you can set commands to open the audio settings  
 for sinks and sources, if not set the related buttons will not appear.
 
-With the `network_more_cmd`, `vpn_more_cmd` and `bluetooth_more_cmd` options  
+With the `wifi_more_cmd`, `vpn_more_cmd` and `bluetooth_more_cmd` options  
 you can set commands to open the network, VPN and bluetooth settings.
 
 With the `remove_airplane_btn` option you can remove the airplane mode button.
+
+With the `remove_idle_btn` option you can remove the idle inhibitor button.
 
 ## Example
 
@@ -62,10 +64,10 @@ In the following example we use:
 - `hyprlock` to lock the screen
 - `pavucontrol` to open the audio settings for sinks and sources  
   directly in the correct tab.
-- `nm-connection-editor` to open the network and VPN settings
+- `nm-connection-editor` to open the wifi and VPN settings
 - `blueman-manager` to open the bluetooth settings
 
-We also disable the airplane mode button.
+We also disable the airplane mode button and the idle inhibitor button.
 
 ```toml
 [settings]
@@ -76,4 +78,5 @@ wifi_more_cmd = "nm-connection-editor"
 vpn_more_cmd = "nm-connection-editor"
 bluetooth_more_cmd = "blueman-manager"
 remove_airplane_btn = true
+remove_idle_btn = true
 ```


### PR DESCRIPTION
Add a simple config option to disable idle inhibitor button in settings. The implementation follows the exact same pattern as the existing `remove_airplane_btn`