### PR TITLE
feat: add temperature sensor configuration option

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,8 @@ pub struct SystemInfoTemperature {
     pub warn_threshold: i32,
     #[serde(default = "default_temp_alert_threshold")]
     pub alert_threshold: i32,
+    #[serde(default = "default_temp_sensor")]
+    pub sensor: String,
 }
 
 impl Default for SystemInfoTemperature {
@@ -109,6 +111,7 @@ impl Default for SystemInfoTemperature {
         Self {
             warn_threshold: default_temp_warn_threshold(),
             alert_threshold: default_temp_alert_threshold(),
+            sensor: default_temp_sensor(),
         }
     }
 }
@@ -186,6 +189,10 @@ fn default_temp_warn_threshold() -> i32 {
 
 fn default_temp_alert_threshold() -> i32 {
     80
+}
+
+fn default_temp_sensor() -> String {
+    "acpitz temp1".to_string()
 }
 
 fn default_disk_warn_threshold() -> u32 {

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -33,6 +33,7 @@ fn get_system_info(
     components: &mut Components,
     disks: &mut Disks,
     (networks, last_check): (&mut Networks, Option<Instant>),
+    temperature_sensor: &str,
 ) -> SystemInfoData {
     system.refresh_memory();
     system.refresh_cpu_specifics(sysinfo::CpuRefreshKind::everything());
@@ -52,7 +53,7 @@ fn get_system_info(
 
     let temperature = components
         .iter()
-        .find(|c| c.label() == "acpitz temp1")
+        .find(|c| c.label() == temperature_sensor)
         .and_then(|c| c.temperature().map(|t| t as i32));
 
     let disks = disks
@@ -139,6 +140,7 @@ impl SystemInfo {
             &mut components,
             &mut disks,
             (&mut networks, None),
+            &config.temperature.sensor,
         );
 
         Self {
@@ -162,6 +164,7 @@ impl SystemInfo {
                         &mut self.networks,
                         self.data.network.as_ref().map(|n| n.last_check),
                     ),
+                    &self.config.temperature.sensor,
                 );
             }
         }

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -85,6 +85,17 @@ The Temperature indicator displays the current temperature of the system's CPU.
 
 To enable this indicator, add `Temperature` to the `indicators` configuration.
 
+By default, the temperature sensor used is `acpitz temp1` (ACPI thermal zone).
+You can configure which sensor to use with the `sensor` option in the `[system.temperature]` section.
+
+To see available sensors on your system, you can check the output of `sensors` command or
+look at the component labels returned by the sysinfo library.
+
+Common sensor labels include:
+- `acpitz temp1` - ACPI thermal zone
+- `coretemp Package id 0` - Average CPU temperature
+- `k10temp Tctl` - AMD Ryzen CPU temperature
+
 ## Warning and Alert Thresholds
 
 You can also configure the warning and alert thresholds for the following indicators:
@@ -131,4 +142,5 @@ alert_threshold = 90
 [system.temperature]
 warn_threshold = 60
 alert_threshold = 80
+sensor = "coretemp Package id 0"
 ```


### PR DESCRIPTION
This PR intend to add an option to configure the temperature sensor used by system info module

configure like so:
```toml
[system.temperature]
sensor = "coretemp Package id 0"
```