### PR TITLE
Copr build automation: SRPM build + Copr trigger

### DIFF
--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -1,0 +1,52 @@
+name: Copr Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      chroots:
+        description: "Space-separated Copr chroots"
+        required: false
+        default: "fedora-42-x86_64"
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  copr:
+    if: ${{ secrets.COPR_CONFIG != '' }}
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:42
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install deps
+        run: |
+          dnf -y install git cargo rust rpm-build copr-cli gcc make pkgconf-pkg-config
+          dnf -y clean all
+      - name: Configure copr-cli
+        env:
+          COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
+        run: |
+          mkdir -p ~/.config
+          printf "%s" "$COPR_CONFIG" > ~/.config/copr
+          chmod 600 ~/.config/copr
+      - name: Ensure cargo-rpm
+        run: cargo install cargo-rpm --locked
+      - name: Prepare RPM packaging
+        run: |
+          if [ ! -d .rpm ]; then cargo rpm init; fi
+      - name: Build SRPM
+        run: cargo rpm build -v
+      - name: Locate SRPM
+        id: srpm
+        run: echo "path=$(ls -1 target/release/rpmbuild/SRPMS/*.src.rpm | head -n1)" >> $GITHUB_OUTPUT
+      - name: Trigger Copr build
+        env:
+          CHROOTS: ${{ github.event.inputs.chroots }}
+        run: |
+          CHROOTS="${CHROOTS:-fedora-42-x86_64}"
+          args=()
+          for c in $CHROOTS; do args+=( -r "$c" ); done
+          copr-cli build "${args[@]}" killcrb/ashell "${{ steps.srpm.outputs.path }}"
+      - name: List builds
+        run: copr-cli list-builds killcrb/ashell

--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -1,0 +1,24 @@
+name: Sync fork
+
+on:
+  schedule:
+    - cron: "0 6 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Sync from upstream
+        run: |
+          git remote add upstream https://github.com/MalpenZibo/ashell.git || true
+          git fetch upstream
+          git checkout main
+          git merge --ff-only upstream/main || git rebase upstream/main
+          git push origin main

--- a/.rpm/ashell.spec
+++ b/.rpm/ashell.spec
@@ -1,0 +1,32 @@
+%define __spec_install_post %{nil}
+%define __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+
+Name: ashell
+Summary: A ready to go Wayland status bar for Hyprland
+Version: @@VERSION@@
+Release: @@RELEASE@@%{?dist}
+License: MIT
+Group: Applications/System
+Source0: %{name}-%{version}.tar.gz
+URL: https://github.com/MalpenZibo/ashell
+
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+
+%description
+%{summary}
+
+%prep
+%setup -q
+
+%install
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(-,root,root,-)
+%{_bindir}/*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "ashell"
 description = "A ready to go Wayland status bar for Hyprland"
 homepage = "https://github.com/MalpenZibo/ashell"
+license = "MIT"
 version = "0.6.0"
 edition = "2024"
 rust-version = "1.88"
@@ -52,3 +53,12 @@ clap = { version = "4.5", features = ["derive"] }
 shellexpand = { version = "3", features = ["path"] }
 inotify = "0.11.0"
 pin-project-lite = "0.2.16"
+
+[package.metadata.rpm]
+package = "ashell"
+
+[package.metadata.rpm.cargo]
+buildflags = ["--release"]
+
+[package.metadata.rpm.targets]
+ashell = { path = "/usr/bin/ashell" }


### PR DESCRIPTION
This PR adds a GitHub Actions workflow to build an SRPM in a Fedora container and trigger Copr builds via copr-cli.\n\nHighlights:\n- Build SRPM with cargo-rpm inside Fedora 42 container\n- Trigger Copr build(s) for selectable chroots (workflow_dispatch input)\n- Tag push (v*) also triggers a Copr build\n- Job guarded with `if: secrets.COPR_CONFIG != ''` to avoid failures if secret is not configured upstream\n- Adds a separate `Sync fork` workflow in the fork to keep it aligned with upstream (no effect in upstream repo)\n\nTo enable Copr builds in upstream, maintainers can add repo secret `COPR_CONFIG` with the content of the copr-cli config (`~/.config/copr`).