### PR TITLE
Fuzzy search output names from config

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -362,7 +362,7 @@ impl App {
                     info!("Output created: {info:?}");
                     let name = info
                         .as_ref()
-                        .and_then(|info| info.name.as_deref())
+                        .and_then(|info| info.description.as_deref())
                         .unwrap_or("");
 
                     self.outputs.add(


### PR DESCRIPTION
My system and I can only assume plenty of others, has dynamic names for outputs. My second monitor some boots shows up as HDMI-A-2, sometimes as HDMI-A-3, on rare occasions it can even show up as HDMI-A-1 and switch with my primary monitor.
This PR makes it so you can set the config name to fuzzy search from the outputs description for example "PNP(GWD) - ARZOPA - HDMI-A-2"
So if my config has the output as "ARZOPA" it will always only match to my second monitor.
This shouldn't change anything for existing setups as it will still also match to the output name.
The PR also simplifies outputs to not use an Option<String> as the fallback ones which set that to None already have the WlOutput as None so it makes sense imo to always supply a name to simplify the code.