### PR TITLE
Pipewire boot check

### DIFF
--- a/src/services/privacy.rs
+++ b/src/services/privacy.rs
@@ -216,7 +216,6 @@ impl PrivacyService {
                             }
                             None => {
                                 error!("Pipewire listener exited");
-                                panic!();
                             }
                         }
                     },


### PR DESCRIPTION
Create macro to unwrap or send pipewire listener creation errors via a oneshot channel. 

Handles the case where pipewire is not active on program launch. Otherwise the unbounded sender gets dropped when the pipewire thread exits. The state will still return state::Active but each PrivacyService::start_listening call will poll pipewire.recv(). Since all the channel's senders have dropped, this will always return None immediately. An error gets printed, the state returns unchanged. The loop starts again. Errors keep printing.