### PR TITLE
Feature: VPN service extensions for Tailscale support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,10 @@ dependencies = [
  "flexi_logger",
  "freedesktop-icons",
  "hex_color",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "hyperlocal",
  "hyprland",
  "iced",
  "inotify",
@@ -2387,6 +2391,109 @@ name = "hexf-parse"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hyper"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "pin-utils",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727805d60e7938b76b826a6ef209eb70eaa1812794f9424d4a4e2d740662df5f"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "libc",
+ "pin-project-lite",
+ "socket2 0.6.1",
+ "tokio",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
+dependencies = [
+ "hex",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-service",
+]
 
 [[package]]
 name = "hyprland"
@@ -5501,6 +5608,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
 name = "tracing"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5531,6 +5644,12 @@ checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "ttf-parser"
@@ -5760,6 +5879,15 @@ checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
 dependencies = [
  "same-file",
  "winapi-util",
+]
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,10 @@ inotify = "0.11.0"
 pin-project-lite = "0.2.16"
 niri-ipc = "25.11.0"
 parking_lot = "0.12.5"
+hyper = { version = "1", features = ["client", "http1"] }
+hyper-util = { version = "0.1", features = ["client-legacy", "tokio"] }
+hyperlocal = "0.9"
+http-body-util = "0.1"
 
 [build-dependencies]
 allsorts = "0.15"

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -113,6 +113,8 @@ pub enum StaticIcon {
     GamepadBatteryAlert,
     GamepadBatteryCharging,
     Remove,
+    Tailscale,
+    TailscaleOff,
 }
 
 impl StaticIcon {
@@ -213,6 +215,8 @@ impl StaticIcon {
             StaticIcon::GamepadBatteryAlert => "\u{f074b}",
             StaticIcon::GamepadBatteryCharging => "\u{f0a22}",
             StaticIcon::Remove => "\u{f0377}",
+            StaticIcon::Tailscale => "\u{f0582}",  // Using VPN shield icon
+            StaticIcon::TailscaleOff => "\u{f0783}", // VPN off icon
         }
     }
 

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -21,6 +21,7 @@ pub enum MenuType {
     SystemInfo,
 }
 
+
 #[derive(Clone, Debug)]
 pub struct Menu {
     pub id: Id,

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -5,18 +5,19 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         network::{
             AccessPoint, ActiveConnectionInfo, KnownConnection, NetworkCommand, NetworkEvent,
-            NetworkService, Vpn, dbus::ConnectivityState,
+            NetworkService, Vpn, dbus::ConnectivityState, ExitNode,
         },
     },
     theme::AshellTheme,
     utils::IndicatorState,
 };
 use iced::{
-    Alignment, Element, Length, Subscription, Task, Theme,
-    widget::{Column, button, column, container, horizontal_rule, row, scrollable, text, toggler},
+    Alignment, Border, Element, Length, Subscription, Task, Theme,
+    widget::{Column, button, column, container, horizontal_rule, horizontal_space, row, scrollable, text, toggler},
     window::Id,
 };
 use log::info;
+use std::collections::HashMap;
 
 static WIFI_SIGNAL_ICONS: [StaticIcon; 6] = [
     StaticIcon::Wifi0,
@@ -62,6 +63,18 @@ impl ActiveConnectionInfo {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub enum VpnTab {
+    System,
+    Tailscale,
+}
+
+impl Default for VpnTab {
+    fn default() -> Self {
+        VpnTab::System
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(ServiceEvent<NetworkService>),
@@ -69,6 +82,7 @@ pub enum Message {
     ScanNearByWiFi,
     WiFiMore(Id),
     VpnMore(Id),
+    TailscaleMore(Id),
     SelectAccessPoint(AccessPoint),
     RequestWiFiPassword(Id, String),
     ToggleVpn(Vpn),
@@ -78,6 +92,15 @@ pub enum Message {
     WifiMenuOpened,
     PasswordDialogConfirmed(String, String),
     ConfigReloaded(NetworkSettingsConfig),
+    // VPN tab
+    SwitchVpnTab(VpnTab),
+    // Tailscale messages
+    TailscaleConnect,
+    TailscaleDisconnect,
+    TailscaleSwitchProfile(String),
+    TailscaleSetExitNode(Option<String>),
+    TailscaleSetAllowLan(bool),
+    TailscaleToggleCountry(String),
 }
 
 pub enum Action {
@@ -115,6 +138,18 @@ impl NetworkSettingsConfig {
 pub struct NetworkSettings {
     config: NetworkSettingsConfig,
     service: Option<NetworkService>,
+    /// Tracks which countries are expanded in exit node list
+    expanded_countries: Vec<String>,
+    /// Currently selected VPN tab
+    vpn_tab: VpnTab,
+    /// Last active VPN (if any)
+    last_active_vpn: Option<LastActiveVpn>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+enum LastActiveVpn {
+    System(Vpn),
+    Tailscale,
 }
 
 impl NetworkSettings {
@@ -122,6 +157,9 @@ impl NetworkSettings {
         Self {
             config,
             service: None,
+            expanded_countries: Vec::new(),
+            vpn_tab: VpnTab::default(),
+            last_active_vpn: None,
         }
     }
 
@@ -138,6 +176,26 @@ impl NetworkSettings {
                 ServiceEvent::Update(data) => {
                     if let Some(service) = self.service.as_mut() {
                         service.update(data);
+                        
+                        // Update last active VPN
+                        if service.tailscale.is_running {
+                            self.last_active_vpn = Some(LastActiveVpn::Tailscale);
+                        } else {
+                            // Check for NM VPNs
+                            let active_nm_vpn = service.active_connections.iter().find_map(|c| match c {
+                                ActiveConnectionInfo::Vpn { name, .. } => {
+                                    service.known_connections.iter().find_map(|k| match k {
+                                        KnownConnection::Vpn(v) if v.name == *name => Some(v.clone()),
+                                        _ => None
+                                    })
+                                }
+                                _ => None
+                            });
+                            
+                            if let Some(vpn) = active_nm_vpn {
+                                self.last_active_vpn = Some(LastActiveVpn::System(vpn));
+                            }
+                        }
                     }
                     Action::None
                 }
@@ -195,6 +253,10 @@ impl NetworkSettings {
                     Action::None
                 }
             }
+            Message::TailscaleMore(id) => {
+                crate::utils::launcher::execute_command("xdg-open http://100.100.100.100/".to_string());
+                Action::CloseMenu(id)
+            }
             Message::ToggleVpn(vpn) => match self.service.as_mut() {
                 Some(service) => Action::Command(
                     service
@@ -237,6 +299,70 @@ impl NetworkSettings {
             },
             Message::ConfigReloaded(config) => {
                 self.config = config;
+                Action::None
+            }
+            // Tailscale handlers
+            Message::TailscaleConnect => match self.service.as_mut() {
+                Some(service) => Action::Command(
+                    service
+                        .command(NetworkCommand::TailscaleConnect)
+                        .map(Message::Event),
+                ),
+                _ => Action::None,
+            },
+            Message::TailscaleDisconnect => match self.service.as_mut() {
+                Some(service) => Action::Command(
+                    service
+                        .command(NetworkCommand::TailscaleDisconnect)
+                        .map(Message::Event),
+                ),
+                _ => Action::None,
+            },
+            Message::TailscaleSwitchProfile(display_name) => match self.service.as_mut() {
+                Some(service) => {
+                    // Find profile ID by display name
+                    let profile_id = service.tailscale.profiles.iter()
+                        .find(|p| p.display_name() == display_name)
+                        .map(|p| p.id.clone());
+                    
+                    if let Some(id) = profile_id {
+                        Action::Command(
+                            service
+                                .command(NetworkCommand::TailscaleSwitchProfile(id))
+                                .map(Message::Event),
+                        )
+                    } else {
+                        Action::None
+                    }
+                }
+                _ => Action::None,
+            },
+            Message::TailscaleSetExitNode(node_id) => match self.service.as_mut() {
+                Some(service) => Action::Command(
+                    service
+                        .command(NetworkCommand::TailscaleSetExitNode(node_id))
+                        .map(Message::Event),
+                ),
+                _ => Action::None,
+            },
+            Message::TailscaleSetAllowLan(allow) => match self.service.as_mut() {
+                Some(service) => Action::Command(
+                    service
+                        .command(NetworkCommand::TailscaleSetAllowLan(allow))
+                        .map(Message::Event),
+                ),
+                _ => Action::None,
+            },
+            Message::TailscaleToggleCountry(country) => {
+                if self.expanded_countries.contains(&country) {
+                    self.expanded_countries.retain(|c| c != &country);
+                } else {
+                    self.expanded_countries.push(country);
+                }
+                Action::None
+            }
+            Message::SwitchVpnTab(tab) => {
+                self.vpn_tab = tab;
                 Action::None
             }
         }
@@ -282,20 +408,27 @@ impl NetworkSettings {
 
     pub fn vpn_indicator<'a>(&'a self, _: &AshellTheme) -> Option<Element<'a, Message>> {
         self.service.as_ref().and_then(|service| {
-            service
+            // Check NM VPNs
+            let nm_vpn_active = service
                 .active_connections
                 .iter()
-                .find(|c| matches!(c, ActiveConnectionInfo::Vpn { .. }))
-                .map(|a| {
-                    let icon_type = a.get_icon();
+                .any(|c| matches!(c, ActiveConnectionInfo::Vpn { .. }));
 
-                    container(icon(icon_type))
+            // Check Tailscale
+            let tailscale_active = service.tailscale.is_running;
+
+            if nm_vpn_active || tailscale_active {
+                Some(
+                    container(icon(StaticIcon::Vpn))
                         .style(|theme: &Theme| container::Style {
-                            text_color: Some(theme.extended_palette().danger.weak.color),
+                            text_color: Some(theme.palette().success),
                             ..Default::default()
                         })
-                        .into()
-                })
+                        .into(),
+                )
+            } else {
+                None
+            }
         })
     }
 
@@ -351,64 +484,82 @@ impl NetworkSettings {
         sub_menu: Option<SubMenu>,
     ) -> Option<(Element<'a, Message>, Option<Element<'a, Message>>)> {
         self.service.as_ref().and_then(|service| {
-            service
+            // Check if we have NM VPNs or Tailscale
+            let has_nm_vpns = service
                 .known_connections
                 .iter()
-                .any(|c| matches!(c, KnownConnection::Vpn { .. }))
-                .then(|| {
-                    let mut known_vpn = service.known_connections.iter().filter_map(|c| match c {
-                        KnownConnection::Vpn(c) => Some(c),
-                        _ => None,
-                    });
-                    let actives = service
-                        .active_connections
-                        .iter()
-                        .filter_map(|c| match c {
-                            ActiveConnectionInfo::Vpn { name, .. } => {
-                                known_vpn.find(|v| v.name == *name)
-                            }
-                            _ => None,
-                        })
-                        .collect::<Vec<_>>();
+                .any(|c| matches!(c, KnownConnection::Vpn { .. }));
+            let has_tailscale = service.tailscale.available;
 
-                    let subtitle = if actives.len() > 1 {
-                        Some(format!("{} VPNs Connected", actives.len()))
-                    } else {
-                        actives.first().map(|c| c.name.clone())
-                    };
+            if !has_nm_vpns && !has_tailscale {
+                return None;
+            }
 
-                    (
-                        quick_setting_button(
-                            theme,
-                            StaticIcon::Vpn,
-                            "VPN".to_string(),
-                            subtitle,
-                            !actives.is_empty(),
-                            if !actives.is_empty()
-                                && let Some(first) = actives.first()
-                            {
-                                Message::ToggleVpn((*first).clone())
-                            } else {
-                                Message::ToggleVPNMenu
-                            },
-                            if !actives.is_empty() {
-                                Some((SubMenu::Vpn, sub_menu, Message::ToggleVPNMenu))
-                            } else {
-                                None
-                            },
-                        ),
-                        sub_menu
-                            .filter(|menu_type| *menu_type == SubMenu::Vpn)
-                            .map(|_| {
-                                Self::vpn_menu(
-                                    service,
-                                    id,
-                                    theme,
-                                    self.config.vpn_more_cmd.is_some(),
-                                )
-                            }),
-                    )
+            let mut known_vpn = service.known_connections.iter().filter_map(|c| match c {
+                KnownConnection::Vpn(c) => Some(c),
+                _ => None,
+            });
+            let nm_actives: Vec<_> = service
+                .active_connections
+                .iter()
+                .filter_map(|c| match c {
+                    ActiveConnectionInfo::Vpn { name, .. } => {
+                        known_vpn.find(|v| v.name == *name)
+                    }
+                    _ => None,
                 })
+                .collect();
+
+            // Determine subtitle based on active VPNs
+            let subtitle = if service.tailscale.is_running {
+                let profile_name = service.tailscale.current_profile
+                    .as_ref()
+                    .map(|p| p.display_name())
+                    .unwrap_or_else(|| "Connected".to_string());
+                Some(format!("Tailscale - {}", profile_name))
+            } else if nm_actives.len() > 1 {
+                Some(format!("{} VPNs Connected", nm_actives.len()))
+            } else {
+                nm_actives.first().map(|c| c.name.clone())
+            };
+
+            let any_active = !nm_actives.is_empty() || service.tailscale.is_running;
+
+            Some((
+                quick_setting_button(
+                    theme,
+                    StaticIcon::Vpn,
+                    "VPN".to_string(),
+                    subtitle,
+                    any_active,
+                    if any_active && !nm_actives.is_empty() {
+                        if let Some(first) = nm_actives.first() {
+                            Message::ToggleVpn((*first).clone())
+                        } else {
+                            Message::ToggleVPNMenu
+                        }
+                    } else if any_active && service.tailscale.is_running {
+                        Message::TailscaleDisconnect
+                    } else {
+                        // Smart toggle: try to reconnect to last active VPN
+                        match &self.last_active_vpn {
+                            Some(LastActiveVpn::Tailscale) => Message::TailscaleConnect,
+                            Some(LastActiveVpn::System(vpn)) => Message::ToggleVpn(vpn.clone()),
+                            None => Message::ToggleVPNMenu,
+                        }
+                    },
+                    Some((SubMenu::Vpn, sub_menu, Message::ToggleVPNMenu)),
+                ),
+                sub_menu
+                    .filter(|menu_type| *menu_type == SubMenu::Vpn)
+                    .map(|_| {
+                        self.vpn_menu(
+                            service,
+                            id,
+                            theme,
+                        )
+                    }),
+            ))
         })
     }
 
@@ -540,50 +691,426 @@ impl NetworkSettings {
     }
 
     fn vpn_menu<'a>(
+        &'a self,
         service: &'a NetworkService,
         id: Id,
         theme: &'a AshellTheme,
-        show_more_button: bool,
     ) -> Element<'a, Message> {
-        let main = Column::with_children(
-            service.known_connections
-                .iter()
-                .filter_map(|c| match c {
-                    KnownConnection::Vpn(vpn) => Some(vpn),
-                    _ => None,
-                })
-                .map(|vpn| {
-                    let is_active = service.active_connections.iter().any(
-                        |c| matches!(c, ActiveConnectionInfo::Vpn { name, .. } if name == &vpn.name),
+        let mut content = Column::new().spacing(theme.space.sm);
+
+        // Check what's available
+        let nm_vpns: Vec<_> = service.known_connections
+            .iter()
+            .filter_map(|c| match c {
+                KnownConnection::Vpn(vpn) => Some(vpn),
+                _ => None,
+            })
+            .collect();
+        let has_nm_vpns = !nm_vpns.is_empty();
+        let has_tailscale = service.tailscale.available;
+
+        // Check which VPN is currently active
+        let nm_vpn_active = service.active_connections.iter()
+            .any(|c| matches!(c, ActiveConnectionInfo::Vpn { .. }));
+        let tailscale_running = service.tailscale.is_running;
+
+        // Auto-select tab based on active VPN
+        let effective_tab = if tailscale_running {
+            VpnTab::Tailscale
+        } else if nm_vpn_active {
+            VpnTab::System
+        } else {
+            self.vpn_tab.clone()
+        };
+
+        // If both are available, show tabs
+        if has_nm_vpns && has_tailscale {
+            let system_active = effective_tab == VpnTab::System;
+            let tailscale_active = effective_tab == VpnTab::Tailscale;
+
+            // Pill slider tabs - always NetworkManager first
+            let tabs = container(
+                row![
+                    button(
+                        text("NetworkManager")
+                            .size(theme.font_size.sm)
+                            .align_x(iced::alignment::Horizontal::Center)
+                    )
+                    .width(Length::Fill)
+                    .padding([theme.space.xs, theme.space.sm])
+                    .style(theme.pill_slider_tab_style(system_active))
+                    .on_press(Message::SwitchVpnTab(VpnTab::System)),
+                    button(
+                        text("Tailscale")
+                            .size(theme.font_size.sm)
+                            .align_x(iced::alignment::Horizontal::Center)
+                    )
+                    .width(Length::Fill)
+                    .padding([theme.space.xs, theme.space.sm])
+                    .style(theme.pill_slider_tab_style(tailscale_active))
+                    .on_press(Message::SwitchVpnTab(VpnTab::Tailscale)),
+                ]
+                .spacing(theme.space.xxs)
+            )
+            .padding(theme.space.xxs)
+            .style(move |theme: &Theme| iced::widget::container::Style {
+                background: Some(theme.extended_palette().background.weak.color.into()),
+                border: Border::default().rounded(32),
+                ..Default::default()
+            });
+
+            content = content.push(tabs);
+            content = content.push(horizontal_rule(1));
+
+            // Show content based on selected tab
+            match effective_tab {
+                VpnTab::System => {
+                    content = content.push(self.system_vpns_section(service, &nm_vpns, tailscale_running, theme));
+                }
+                VpnTab::Tailscale => {
+                    content = content.push(self.tailscale_section(service, nm_vpn_active, theme));
+                }
+            }
+        } else if has_nm_vpns {
+            // Only system VPNs
+            content = content.push(self.system_vpns_section(service, &nm_vpns, false, theme));
+        } else if has_tailscale {
+            // Only Tailscale
+            content = content.push(self.tailscale_section(service, false, theme));
+        }
+
+        // More button - tab specific
+        match effective_tab {
+            VpnTab::System if self.config.vpn_more_cmd.is_some() => {
+                content = content
+                    .push(horizontal_rule(1))
+                    .push(
+                        button(text("More").size(theme.font_size.sm))
+                            .on_press(Message::VpnMore(id))
+                            .padding([theme.space.xxs, theme.space.sm])
+                            .width(Length::Fill)
+                            .style(theme.ghost_button_style())
+                    );
+            }
+            VpnTab::Tailscale if has_tailscale => {
+                content = content
+                    .push(horizontal_rule(1))
+                    .push(
+                        button(text("More").size(theme.font_size.sm))
+                            .on_press(Message::TailscaleMore(id))
+                            .padding([theme.space.xxs, theme.space.sm])
+                            .width(Length::Fill)
+                            .style(theme.ghost_button_style())
+                    );
+            }
+            _ => {}
+        }
+
+        scrollable(content).height(Length::Shrink).into()
+    }
+
+    fn system_vpns_section<'a>(
+        &'a self,
+        service: &'a NetworkService,
+        nm_vpns: &[&'a Vpn],
+        other_vpn_active: bool,
+        theme: &'a AshellTheme,
+    ) -> Element<'a, Message> {
+        let mut section = Column::new().spacing(theme.space.xs);
+
+        // Show warning if other VPN is active
+        if other_vpn_active {
+            section = section.push(
+                text("Disconnect Tailscale to enable NetworkManager VPN")
+                    .size(theme.font_size.sm)
+                    .font(iced::Font {
+                        style: iced::font::Style::Italic,
+                        ..Default::default()
+                    })
+                    .style(|t: &Theme| text::Style {
+                        color: Some(t.extended_palette().danger.weak.color),
+                    })
+            );
+        }
+
+        for vpn in nm_vpns {
+            let is_active = service.active_connections.iter().any(
+                |c| matches!(c, ActiveConnectionInfo::Vpn { name, .. } if name == &vpn.name),
+            );
+
+            let mut vpn_toggler = toggler(is_active)
+                .width(Length::Shrink);
+            
+            // Only allow toggling if other VPN is not active
+            if !other_vpn_active || is_active {
+                vpn_toggler = vpn_toggler.on_toggle(|_| Message::ToggleVpn((*vpn).clone()));
+            }
+
+            section = section.push(
+                row!(
+                    text(vpn.name.to_string()).width(Length::Fill).size(theme.font_size.sm),
+                    vpn_toggler,
+                )
+                .align_y(Alignment::Center)
+            );
+        }
+
+        section.into()
+    }
+
+    fn tailscale_section<'a>(
+        &'a self,
+        service: &'a NetworkService,
+        other_vpn_active: bool,
+        theme: &'a AshellTheme,
+    ) -> Element<'a, Message> {
+        let ts = &service.tailscale;
+        let mut section = Column::new().spacing(theme.space.xs);
+
+        // Show warning if other VPN is active
+        if other_vpn_active && !ts.is_running {
+            section = section.push(
+                text("Disconnect System VPN to enable Tailscale")
+                    .size(theme.font_size.sm)
+                    .font(iced::Font {
+                        style: iced::font::Style::Italic,
+                        ..Default::default()
+                    })
+                    .style(|t: &Theme| text::Style {
+                        color: Some(t.extended_palette().danger.weak.color),
+                    })
+            );
+        }
+
+        // Profile selector (if multiple profiles)
+        if ts.profiles.len() > 1 {
+            let profile_names: Vec<String> = ts.profiles.iter()
+                .map(|p| p.display_name())
+                .collect();
+            
+            let current_profile = ts.current_profile.as_ref().map(|p| p.display_name());
+
+            section = section.push(
+                row![
+                    text("Profile:").width(Length::Shrink).size(theme.font_size.sm),
+                    iced::widget::pick_list(
+                        profile_names,
+                        current_profile,
+                        |name| {
+                            // Find the profile ID by display name
+                            Message::TailscaleSwitchProfile(name)
+                        }
+                    )
+                    .text_size(theme.font_size.sm)
+                    .width(Length::Fill),
+                ]
+                .spacing(theme.space.xs)
+                .align_y(Alignment::Center)
+            );
+        }
+
+        // Connection toggle
+        let mut connection_toggler = toggler(ts.is_running)
+            .width(Length::Shrink);
+        
+        // Only allow connecting if other VPN is not active (but always allow disconnecting)
+        if !other_vpn_active || ts.is_running {
+            connection_toggler = connection_toggler.on_toggle(|enabled| {
+                if enabled {
+                    Message::TailscaleConnect
+                } else {
+                    Message::TailscaleDisconnect
+                }
+            });
+        }
+
+        section = section.push(
+            row![
+                text(if ts.is_running { "Connected" } else { "Disconnected" })
+                    .width(Length::Fill)
+                    .size(theme.font_size.sm),
+                connection_toggler,
+            ]
+            .align_y(Alignment::Center)
+        );
+
+        // Exit nodes section (only if connected and has exit nodes)
+        if ts.is_running && !ts.exit_nodes.is_empty() {
+            section = section.push(horizontal_rule(1));
+            section = section.push(
+                text("Exit Nodes").size(theme.font_size.sm)
+                    .style(|t: &Theme| text::Style {
+                        color: Some(t.extended_palette().secondary.base.text),
+                    })
+            );
+
+            // Current exit node status
+            let current_exit = ts.exit_nodes.iter()
+                .find(|n| ts.current_exit_node_id.as_ref() == Some(&n.id));
+
+            let status_row = if let Some(node) = current_exit {
+                row![
+                    text("●").size(theme.font_size.sm).style(|t: &Theme| text::Style {
+                        color: Some(t.palette().success),
+                    }),
+                    text(node.display_name()).size(theme.font_size.sm),
+                    horizontal_space(),
+                    button(text("Clear").size(theme.font_size.sm))
+                        .padding([theme.space.xxs, theme.space.xs])
+                        .style(theme.ghost_button_style())
+                        .on_press(Message::TailscaleSetExitNode(None)),
+                ]
+                .spacing(theme.space.xs)
+                .align_y(Alignment::Center)
+            } else {
+                row![
+                    text("○").size(theme.font_size.sm),
+                    text("No exit node").size(theme.font_size.sm),
+                ]
+                .spacing(theme.space.xs)
+                .align_y(Alignment::Center)
+            };
+
+            section = section.push(status_row);
+
+            // Group exit nodes by country
+            let by_country = self.group_exit_nodes_by_country(&ts.exit_nodes);
+            let mut countries: Vec<_> = by_country.keys().collect();
+            countries.sort();
+
+            let mut exit_list = Column::new().spacing(1);
+
+            // None option
+            let no_exit_selected = ts.current_exit_node_id.is_none();
+            let none_btn = button(
+                row![
+                    text(if no_exit_selected { "●" } else { "○" }).size(theme.font_size.sm),
+                    text("None (Direct)").size(theme.font_size.sm),
+                ]
+                .spacing(theme.space.xs)
+                .align_y(Alignment::Center),
+            )
+            .width(Length::Fill)
+            .padding([theme.space.xxs, theme.space.xs])
+            .style(move |t, s| {
+                if no_exit_selected {
+                    theme.settings_button_style()(t, s)
+                } else {
+                    theme.ghost_button_style()(t, s)
+                }
+            })
+            .on_press_maybe(if no_exit_selected {
+                None
+            } else {
+                Some(Message::TailscaleSetExitNode(None))
+            });
+
+            exit_list = exit_list.push(none_btn);
+
+            // Countries with nodes
+            for country in countries {
+                if let Some(nodes) = by_country.get(country) {
+                    let is_expanded = self.expanded_countries.contains(country);
+                    let has_selected = nodes.iter().any(|n| 
+                        ts.current_exit_node_id.as_ref() == Some(&n.id)
                     );
 
-                    row!(
-                        text(vpn.name.to_string()).width(Length::Fill),
-                        toggler(is_active)
-                            .on_toggle(|_| { Message::ToggleVpn(vpn.clone()) })
-                            .width(Length::Shrink),
+                    // Country row
+                    let country_row = button(
+                        row![
+                            text(if is_expanded { "▾" } else { "▸" }).size(theme.font_size.sm),
+                            text(country.clone()).size(theme.font_size.sm),
+                            text(format!("({})", nodes.len()))
+                                .size(theme.font_size.sm)
+                                .style(|t: &Theme| text::Style {
+                                    color: Some(t.extended_palette().secondary.base.text),
+                                }),
+                            horizontal_space(),
+                            if has_selected {
+                                text("●").size(theme.font_size.sm)
+                            } else {
+                                text("").size(theme.font_size.sm)
+                            },
+                        ]
+                        .spacing(theme.space.xxs)
+                        .align_y(Alignment::Center),
                     )
-                    .into()
-                })
-                .collect::<Vec<Element<'a, Message>>>(),
-        )
-        .spacing(theme.space.xs);
-
-        if show_more_button {
-            column!(
-                main,
-                horizontal_rule(1),
-                button("More")
-                    .on_press(Message::VpnMore(id))
-                    .padding([theme.space.xxs, theme.space.sm])
                     .width(Length::Fill)
-                    .style(theme.ghost_button_style())
-            )
-            .spacing(theme.space.sm)
-            .into()
-        } else {
-            main.into()
+                    .padding([theme.space.xxs, theme.space.xs])
+                    .style(move |t, s| {
+                        if has_selected && !is_expanded {
+                            theme.settings_button_style()(t, s)
+                        } else {
+                            theme.ghost_button_style()(t, s)
+                        }
+                    })
+                    .on_press(Message::TailscaleToggleCountry(country.clone()));
+
+                    exit_list = exit_list.push(country_row);
+
+                    // Expanded nodes
+                    if is_expanded {
+                        for node in nodes.iter().take(15) {
+                            let is_current = ts.current_exit_node_id.as_ref() == Some(&node.id);
+
+                            let node_btn = button(
+                                row![
+                                    text(if is_current { "●" } else { "○" }).size(theme.font_size.sm),
+                                    text(node.display_name()).size(theme.font_size.sm),
+                                ]
+                                .spacing(theme.space.xs)
+                                .align_y(Alignment::Center),
+                            )
+                            .width(Length::Fill)
+                            .padding([theme.space.xxs, theme.space.md])
+                            .style(move |t, s| {
+                                if is_current {
+                                    theme.settings_button_style()(t, s)
+                                } else {
+                                    theme.ghost_button_style()(t, s)
+                                }
+                            })
+                            .on_press_maybe(if is_current {
+                                None
+                            } else {
+                                Some(Message::TailscaleSetExitNode(Some(node.id.clone())))
+                            });
+
+                            exit_list = exit_list.push(node_btn);
+                        }
+                    }
+                }
+            }
+
+            section = section.push(
+                scrollable(exit_list)
+                    .height(Length::Fixed(150.0))
+            );
+
+            // Allow LAN toggle (only when using exit node)
+            if ts.current_exit_node_id.is_some() {
+                section = section.push(
+                    row![
+                        text("Allow LAN Access").width(Length::Fill).size(theme.font_size.sm),
+                        toggler(ts.allow_lan)
+                            .on_toggle(Message::TailscaleSetAllowLan)
+                            .width(Length::Shrink),
+                    ]
+                    .align_y(Alignment::Center)
+                );
+            }
         }
+
+        section.into()
+    }
+
+    fn group_exit_nodes_by_country<'a>(&self, nodes: &'a [ExitNode]) -> HashMap<String, Vec<&'a ExitNode>> {
+        let mut by_country: HashMap<String, Vec<&ExitNode>> = HashMap::new();
+        for node in nodes.iter().filter(|n| n.online) {
+            let country = node.country();
+            by_country.entry(country).or_default().push(node);
+        }
+        by_country
     }
 
     pub fn subscription(&self) -> Subscription<Message> {

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -44,6 +44,9 @@ impl super::NetworkBackend for NetworkDbus<'_> {
             .await?;
         debug!("Known connections: {known_connections:?}");
 
+        // Fetch initial Tailscale state
+        let tailscale = super::TailscaleBackend::get_state().await.unwrap_or_default();
+
         Ok(NetworkData {
             wifi_present,
             active_connections,
@@ -53,6 +56,7 @@ impl super::NetworkBackend for NetworkDbus<'_> {
             wireless_access_points,
             known_connections,
             scanning_nearby_wifi: false,
+            tailscale,
         })
     }
 

--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -103,6 +103,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
             wireless_access_points,
             known_connections,
             scanning_nearby_wifi: is_scanning,
+            tailscale: crate::services::network::TailscaleBackend::get_state().await.unwrap_or_default(),
         })
     }
 

--- a/src/services/network/tailscale.rs
+++ b/src/services/network/tailscale.rs
@@ -1,0 +1,492 @@
+//! Tailscale backend for the network service
+//!
+//! Provides Tailscale VPN integration via the LocalAPI over Unix socket.
+
+use http_body_util::{BodyExt, Empty};
+use hyper::body::Bytes;
+use hyper_util::{client::legacy::Client, rt::TokioExecutor};
+use hyperlocal::{UnixConnector, Uri};
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
+use std::{collections::HashMap, path::Path};
+
+/// Default path to the Tailscale daemon socket
+const TAILSCALE_SOCKET: &str = "/var/run/tailscale/tailscaled.sock";
+/// Required Host header for LocalAPI security
+const TAILSCALE_HOST: &str = "local-tailscaled.sock";
+
+/// Current Tailscale state for the network service
+#[derive(Debug, Clone, Default)]
+pub struct TailscaleState {
+    pub available: bool,
+    pub is_running: bool,
+    pub current_profile: Option<TailscaleProfile>,
+    pub profiles: Vec<TailscaleProfile>,
+    pub exit_nodes: Vec<ExitNode>,
+    pub current_exit_node_id: Option<String>,
+    pub allow_lan: bool,
+}
+
+/// A Tailscale profile (account/identity)
+#[derive(Debug, Clone)]
+pub struct TailscaleProfile {
+    pub id: String,
+    pub name: String,
+    pub is_current: bool,
+}
+
+impl TailscaleProfile {
+    /// Get display name (username only, without domain)
+    pub fn display_name(&self) -> String {
+        if let Some(at_pos) = self.name.find('@') {
+            self.name[..at_pos].to_string()
+        } else {
+            self.name.clone()
+        }
+    }
+}
+
+/// Location information for an exit node
+#[derive(Debug, Clone, Default)]
+pub struct ExitNodeLocation {
+    pub country: Option<String>,
+    #[allow(dead_code)]
+    pub country_code: Option<String>,
+    pub city: Option<String>,
+}
+
+/// A peer that can be used as an exit node
+#[derive(Debug, Clone)]
+pub struct ExitNode {
+    pub id: String,
+    pub name: String,
+    pub location: Option<ExitNodeLocation>,
+    pub online: bool,
+    #[allow(dead_code)]
+    pub is_mullvad: bool,
+}
+
+impl ExitNode {
+    /// Get country name for grouping
+    pub fn country(&self) -> String {
+        self.location
+            .as_ref()
+            .and_then(|l| l.country.clone())
+            .unwrap_or_else(|| "Your Network".to_string())
+    }
+
+    /// Get display name (city + name or just name)
+    pub fn display_name(&self) -> String {
+        if let Some(loc) = &self.location {
+            if let Some(city) = &loc.city {
+                return format!("{} ({})", city, self.name);
+            }
+        }
+        self.name.clone()
+    }
+}
+
+// ============================================================================
+// API Response Types (internal, for JSON deserialization)
+// ============================================================================
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+#[allow(dead_code)]
+struct ApiProfile {
+    #[serde(rename = "ID")]
+    id: String,
+    name: String,
+    #[serde(default)]
+    current_profile: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct ApiStatus {
+    #[serde(rename = "BackendState")]
+    backend_state: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct ApiLocation {
+    country: Option<String>,
+    country_code: Option<String>,
+    city: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct ApiExitNode {
+    #[serde(rename = "ID")]
+    id: String,
+    #[serde(rename = "DNSName")]
+    dns_name: String,
+    host_name: Option<String>,
+    location: Option<ApiLocation>,
+    online: bool,
+    #[serde(default)]
+    exit_node_option: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+#[serde(rename_all = "PascalCase")]
+#[allow(dead_code)]
+struct ApiPrefs {
+    #[serde(rename = "ExitNodeID")]
+    exit_node_id: Option<String>,
+    #[serde(rename = "ExitNodeAllowLANAccess", default)]
+    exit_node_allow_lan_access: bool,
+    #[serde(rename = "WantRunning", default)]
+    want_running: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+#[serde(rename_all = "PascalCase")]
+struct ApiPrefsUpdate {
+    #[serde(rename = "ExitNodeIDSet", skip_serializing_if = "Option::is_none")]
+    exit_node_id_set: Option<bool>,
+    #[serde(rename = "ExitNodeID", skip_serializing_if = "Option::is_none")]
+    exit_node_id: Option<String>,
+    #[serde(
+        rename = "ExitNodeAllowLANAccessSet",
+        skip_serializing_if = "Option::is_none"
+    )]
+    exit_node_allow_lan_access_set: Option<bool>,
+    #[serde(
+        rename = "ExitNodeAllowLANAccess",
+        skip_serializing_if = "Option::is_none"
+    )]
+    exit_node_allow_lan_access: Option<bool>,
+    #[serde(rename = "WantRunningSet", skip_serializing_if = "Option::is_none")]
+    want_running_set: Option<bool>,
+    #[serde(rename = "WantRunning", skip_serializing_if = "Option::is_none")]
+    want_running: Option<bool>,
+}
+
+#[derive(Deserialize)]
+struct StatusWithPeers {
+    #[serde(rename = "Peer", default)]
+    peer: HashMap<String, ApiExitNode>,
+}
+
+// ============================================================================
+// Tailscale Backend
+// ============================================================================
+
+/// Backend for communicating with Tailscale LocalAPI
+pub struct TailscaleBackend;
+
+impl TailscaleBackend {
+    /// Check if the Tailscale socket exists and is accessible
+    pub fn is_available() -> bool {
+        Path::new(TAILSCALE_SOCKET).exists()
+    }
+
+    /// Get the complete Tailscale state
+    pub async fn get_state() -> Option<TailscaleState> {
+        if !Self::is_available() {
+            return None;
+        }
+
+        let status = match Self::get_status().await {
+            Ok(s) => s,
+            Err(e) => {
+                warn!("Failed to get Tailscale status: {}", e);
+                return None;
+            }
+        };
+
+        let profiles = Self::get_profiles().await.unwrap_or_default();
+        let exit_nodes = Self::get_exit_nodes().await.unwrap_or_default();
+        let prefs = Self::get_prefs().await.unwrap_or_default();
+
+        Some(TailscaleState {
+            available: true,
+            is_running: status.backend_state == "Running",
+            current_profile: profiles.iter().find(|p| p.is_current).cloned(),
+            profiles,
+            exit_nodes,
+            current_exit_node_id: prefs
+                .exit_node_id
+                .filter(|id| !id.is_empty()),
+            allow_lan: prefs.exit_node_allow_lan_access,
+        })
+    }
+
+    /// Connect to Tailscale (tailscale up)
+    pub async fn connect() -> anyhow::Result<()> {
+        let update = ApiPrefsUpdate {
+            want_running_set: Some(true),
+            want_running: Some(true),
+            ..Default::default()
+        };
+        Self::set_prefs(&update).await?;
+        debug!("Tailscale connected");
+        Ok(())
+    }
+
+    /// Disconnect from Tailscale (tailscale down)
+    pub async fn disconnect() -> anyhow::Result<()> {
+        let update = ApiPrefsUpdate {
+            want_running_set: Some(true),
+            want_running: Some(false),
+            ..Default::default()
+        };
+        Self::set_prefs(&update).await?;
+        debug!("Tailscale disconnected");
+        Ok(())
+    }
+
+    /// Switch to a different profile
+    pub async fn switch_profile(profile_id: &str) -> anyhow::Result<()> {
+        let endpoint = format!("/localapi/v0/profiles/{}", profile_id);
+        Self::post(&endpoint).await?;
+        debug!("Tailscale switched to profile: {}", profile_id);
+        Ok(())
+    }
+
+    /// Set exit node (None to clear)
+    pub async fn set_exit_node(node_id: Option<&str>) -> anyhow::Result<()> {
+        let update = ApiPrefsUpdate {
+            exit_node_id_set: Some(true),
+            exit_node_id: Some(node_id.unwrap_or("").to_string()),
+            ..Default::default()
+        };
+        Self::set_prefs(&update).await?;
+        debug!("Tailscale exit node set to: {:?}", node_id);
+        Ok(())
+    }
+
+    /// Set allow LAN access
+    pub async fn set_allow_lan(allow: bool) -> anyhow::Result<()> {
+        let update = ApiPrefsUpdate {
+            exit_node_allow_lan_access_set: Some(true),
+            exit_node_allow_lan_access: Some(allow),
+            ..Default::default()
+        };
+        Self::set_prefs(&update).await?;
+        debug!("Tailscale allow LAN set to: {}", allow);
+        Ok(())
+    }
+
+    /// Watch for Tailscale state changes using the watch-ipn-bus streaming API.
+    /// Returns a channel receiver that yields state updates.
+    /// The stream will close if the daemon shuts down or connection is lost.
+    pub async fn watch_state(
+        sender: tokio::sync::mpsc::Sender<TailscaleState>,
+    ) -> anyhow::Result<()> {
+        use tokio::io::AsyncBufReadExt;
+        use tokio::io::BufReader;
+        
+        if !Self::is_available() {
+            anyhow::bail!("Tailscale socket not available");
+        }
+
+        // Connect to the Unix socket directly for streaming
+        let socket = tokio::net::UnixStream::connect(TAILSCALE_SOCKET).await?;
+        let (reader, mut writer) = tokio::io::split(socket);
+
+        // Send HTTP request manually for the streaming endpoint
+        let request = format!(
+            "GET /localapi/v0/watch-ipn-bus HTTP/1.1\r\n\
+             Host: {}\r\n\
+             Connection: keep-alive\r\n\
+             \r\n",
+            TAILSCALE_HOST
+        );
+        
+        use tokio::io::AsyncWriteExt;
+        writer.write_all(request.as_bytes()).await?;
+
+        let mut buf_reader = BufReader::new(reader);
+        
+        // Skip HTTP response headers
+        let mut header_line = String::new();
+        loop {
+            header_line.clear();
+            let bytes_read = buf_reader.read_line(&mut header_line).await?;
+            if bytes_read == 0 || header_line.trim().is_empty() {
+                break;
+            }
+        }
+
+        debug!("Tailscale watch-ipn-bus connected");
+
+        // Read newline-delimited JSON messages
+        let mut line = String::new();
+        loop {
+            line.clear();
+            let bytes_read = buf_reader.read_line(&mut line).await?;
+            
+            if bytes_read == 0 {
+                // Connection closed
+                debug!("Tailscale watch-ipn-bus connection closed");
+                break;
+            }
+
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+
+            // Each message indicates a state change, fetch new state
+            // (The watch-ipn-bus messages are complex, easier to just refresh)
+            if let Some(state) = Self::get_state().await {
+                if sender.send(state).await.is_err() {
+                    // Receiver dropped
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // ========================================================================
+    // Internal API helpers
+    // ========================================================================
+
+    async fn get_status() -> anyhow::Result<ApiStatus> {
+        let body = Self::get("/localapi/v0/status").await?;
+        let status: ApiStatus = serde_json::from_str(&body)?;
+        Ok(status)
+    }
+
+    async fn get_profiles() -> anyhow::Result<Vec<TailscaleProfile>> {
+        let body = Self::get("/localapi/v0/profiles/").await?;
+        let api_profiles: Vec<ApiProfile> = serde_json::from_str(&body)?;
+
+        // Get current profile to mark it
+        let current_id = Self::get_current_profile_id().await.ok();
+
+        let profiles = api_profiles
+            .into_iter()
+            .map(|p| TailscaleProfile {
+                is_current: current_id.as_ref() == Some(&p.id),
+                id: p.id,
+                name: p.name,
+            })
+            .collect();
+
+        Ok(profiles)
+    }
+
+    async fn get_current_profile_id() -> anyhow::Result<String> {
+        let body = Self::get("/localapi/v0/profiles/current").await?;
+        let profile: ApiProfile = serde_json::from_str(&body)?;
+        Ok(profile.id)
+    }
+
+    async fn get_exit_nodes() -> anyhow::Result<Vec<ExitNode>> {
+        let body = Self::get("/localapi/v0/status").await?;
+        let status: StatusWithPeers = serde_json::from_str(&body)?;
+
+        let exit_nodes = status
+            .peer
+            .into_values()
+            .filter(|p| p.exit_node_option)
+            .map(|p| ExitNode {
+                id: p.id,
+                name: p.host_name.unwrap_or_else(|| p.dns_name.clone()),
+                is_mullvad: p.dns_name.contains(".mullvad.ts.net"),
+                online: p.online,
+                location: p.location.map(|l| ExitNodeLocation {
+                    country: l.country,
+                    country_code: l.country_code,
+                    city: l.city,
+                }),
+            })
+            .collect();
+
+        Ok(exit_nodes)
+    }
+
+    async fn get_prefs() -> anyhow::Result<ApiPrefs> {
+        let body = Self::get("/localapi/v0/prefs").await?;
+        let prefs: ApiPrefs = serde_json::from_str(&body)?;
+        Ok(prefs)
+    }
+
+    async fn set_prefs(update: &ApiPrefsUpdate) -> anyhow::Result<ApiPrefs> {
+        let body = Self::patch("/localapi/v0/prefs", update).await?;
+        let prefs: ApiPrefs = serde_json::from_str(&body)?;
+        Ok(prefs)
+    }
+
+    // ========================================================================
+    // HTTP client helpers
+    // ========================================================================
+
+    fn create_client() -> Client<UnixConnector, Empty<Bytes>> {
+        Client::builder(TokioExecutor::new()).build(UnixConnector)
+    }
+
+    async fn get(endpoint: &str) -> anyhow::Result<String> {
+        let client = Self::create_client();
+        let uri: hyper::Uri = Uri::new(TAILSCALE_SOCKET, endpoint).into();
+
+        let request = hyper::Request::builder()
+            .method("GET")
+            .uri(uri)
+            .header("Host", TAILSCALE_HOST)
+            .body(Empty::<Bytes>::new())?;
+
+        let response = client.request(request).await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("LocalAPI returned status: {}", response.status());
+        }
+
+        let body = response.into_body().collect().await?.to_bytes();
+        Ok(String::from_utf8_lossy(&body).to_string())
+    }
+
+    async fn post(endpoint: &str) -> anyhow::Result<String> {
+        let client = Self::create_client();
+        let uri: hyper::Uri = Uri::new(TAILSCALE_SOCKET, endpoint).into();
+
+        let request = hyper::Request::builder()
+            .method("POST")
+            .uri(uri)
+            .header("Host", TAILSCALE_HOST)
+            .body(Empty::<Bytes>::new())?;
+
+        let response = client.request(request).await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("LocalAPI returned status: {}", response.status());
+        }
+
+        let body = response.into_body().collect().await?.to_bytes();
+        Ok(String::from_utf8_lossy(&body).to_string())
+    }
+
+    async fn patch<T: Serialize>(endpoint: &str, body: &T) -> anyhow::Result<String> {
+        use http_body_util::Full;
+        use hyper_util::client::legacy::Client as LegacyClient;
+
+        let json_body = serde_json::to_string(body)?;
+        let uri: hyper::Uri = Uri::new(TAILSCALE_SOCKET, endpoint).into();
+
+        let client: LegacyClient<UnixConnector, Full<Bytes>> =
+            LegacyClient::builder(TokioExecutor::new()).build(UnixConnector);
+
+        let request = hyper::Request::builder()
+            .method("PATCH")
+            .uri(uri)
+            .header("Host", TAILSCALE_HOST)
+            .header("Content-Type", "application/json")
+            .body(Full::new(Bytes::from(json_body)))?;
+
+        let response = client.request(request).await?;
+
+        if !response.status().is_success() {
+            anyhow::bail!("LocalAPI PATCH returned status: {}", response.status());
+        }
+
+        let body = response.into_body().collect().await?.to_bytes();
+        Ok(String::from_utf8_lossy(&body).to_string())
+    }
+}

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -411,6 +411,50 @@ impl AshellTheme {
         }
     }
 
+    /// Style for pill slider tabs (like iOS segmented control)
+    pub fn pill_slider_tab_style(
+        &self,
+        is_active: bool,
+    ) -> impl Fn(&Theme, Status) -> button::Style {
+        move |theme: &Theme, status: Status| {
+            let mut base = button::Style {
+                background: Some(
+                    if is_active {
+                        // Active tab gets a white/light pill background
+                        theme.extended_palette().background.base.color
+                    } else {
+                        // Inactive tabs are transparent
+                        Color::TRANSPARENT
+                    }
+                    .into(),
+                ),
+                border: Border {
+                    width: 0.0,
+                    radius: self.radius.xl.into(),
+                    color: Color::TRANSPARENT,
+                },
+                text_color: if is_active {
+                    theme.palette().text
+                } else {
+                    theme.extended_palette().secondary.weak.color
+                },
+                ..button::Style::default()
+            };
+            match status {
+                Status::Active => base,
+                Status::Hovered if !is_active => {
+                    base.background = Some(
+                        theme.extended_palette().background.weak.color
+                            .scale_alpha(0.3)
+                            .into()
+                    );
+                    base
+                }
+                _ => base,
+            }
+        }
+    }
+
     pub fn workspace_button_style(
         &self,
         is_empty: bool,


### PR DESCRIPTION
Hey folks,

I am not sure if you wanna take that code, just generated it with agentic coding.
For me it works quite nice, so I thought it might be a good start.
I designed the module to be similar to the Trayscale software.
It still has some rough edges. I am going to work a bit more the next weeks on it.

If there is not interest to integrate the code that's also fine, just let me know.
Also if you have early feedback I appreciate it.

- Add disconnect/connect toggle with loading states
- Add exit node selection with 'None (This device)' option
- Add profile switching with auto-connect
- Show status indicator in bar (green/red dot)
- Smaller togglers for compact UI