### PR TITLE
Suggest installation path as /usr/local/bin

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -106,5 +106,5 @@ Then, from the root of the repository, run:
 cargo build --release
 
 # To install it system-wide
-sudo cp target/release/ashell /usr/bin
+sudo cp target/release/ashell /usr/local/bin/ashell
 ```


### PR DESCRIPTION
By convention, `/usr/local` is preferred over `/usr` for files not managed by a package manager. See also [man hier(7)](https://man.archlinux.org/man/hier.7)