### PR TITLE
Ignore batteries with zero EnergyFull

### DIFF
--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -51,6 +51,11 @@ impl SystemBattery {
         let mut count = 0;
 
         for device in &self.0 {
+            let e = device.energy_full().await.unwrap_or(0.0);
+            if e == 0.0 {
+                continue;
+            }
+
             if let Ok(p) = device.percentage().await {
                 percentage += p;
                 count += 1;
@@ -320,6 +325,9 @@ pub trait Device {
 
     #[zbus(property)]
     fn percentage(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy_full(&self) -> zbus::Result<f64>;
 
     #[zbus(property)]
     fn state(&self) -> zbus::Result<u32>;


### PR DESCRIPTION
My ThinkPad  T480 reports two batteries, but the second one is not real. It has zero EnegryFull:

Device: /org/freedesktop/UPower/devices/battery_BAT0
  native-path:          BAT0
  vendor:               SMP
  model:                01AV421
  serial:               3469
  power supply:         yes
  updated:              Fri 19 Dec 2025 12:27:05 AM GMT (13 seconds ago)
  has history:          yes
  has statistics:       yes
  battery
    present:             yes
    rechargeable:        yes
    state:               charging
    warning-level:       none
    energy:              18.43 Wh
    energy-empty:        0 Wh
    energy-full:         20.95 Wh
    energy-full-design:  24 Wh
    voltage-min-design:  11.46 V
    capacity-level:      Normal
    energy-rate:         9.486 W
    voltage:             12.802 V
    charge-cycles:       456
    time to full:        15.9 minutes
    percentage:          88%
    capacity:            87.2917%
    technology:          lithium-polymer
    charge-start-threshold:        75%
    charge-end-threshold:          80%
    charge-threshold-supported:    yes
    icon-name:          'battery-full-charging-symbolic'
  History (charge):
    1766103995	88.000	charging
  History (rate):
    1766104025	9.486	charging
    1766103995	9.780	charging
    1766103965	10.038	charging
    1766103935	10.326	charging

Device: /org/freedesktop/UPower/devices/battery_BAT1
  native-path:          BAT1
  power supply:         yes
  updated:              Fri 19 Dec 2025 12:26:55 AM GMT (23 seconds ago)
  has history:          yes
  has statistics:       yes
  battery
    present:             yes
    rechargeable:        yes
    state:               pending-charge
    warning-level:       none
    energy:              0 Wh
    energy-empty:        0 Wh
    energy-full:         0 Wh
    energy-full-design:  0 Wh
    energy-rate:         0 W
    charge-cycles:       N/A
    percentage:          0%
    charge-start-threshold:        75%
    charge-end-threshold:          80%
    charge-threshold-supported:    yes
    icon-name:          'battery-caution-charging-symbolic'

As result ashell reports half of actual battery charge.

Fix it by ignoring bogus battery. 