### PR TITLE
add configurable Wayland layer support 

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -44,6 +44,7 @@ use wayland_client::protocol::wl_output::WlOutput;
 pub struct GeneralConfig {
     outputs: config::Outputs,
     pub modules: Modules,
+    pub layer: config::Layer,
     enable_esc_key: bool,
 }
 
@@ -101,6 +102,7 @@ impl App {
             let (outputs, task) = Outputs::new(
                 config.appearance.style,
                 config.position,
+                config.layer,
                 config.appearance.scale_factor,
             );
 
@@ -119,6 +121,7 @@ impl App {
                     general_config: GeneralConfig {
                         outputs: config.outputs,
                         modules: config.modules,
+                        layer: config.layer,
                         enable_esc_key: config.enable_esc_key,
                     },
                     outputs,
@@ -146,6 +149,7 @@ impl App {
         self.general_config = GeneralConfig {
             outputs: config.outputs,
             modules: config.modules,
+            layer: config.layer,
             enable_esc_key: config.enable_esc_key,
         };
         self.theme = AshellTheme::new(config.position, &config.appearance);
@@ -226,12 +230,14 @@ impl App {
                     || self.theme.bar_position != config.position
                     || self.theme.bar_style != config.appearance.style
                     || self.theme.scale_factor != config.appearance.scale_factor
+                    || self.general_config.layer != config.layer
                 {
                     warn!("Outputs changed, syncing");
                     tasks.push(self.outputs.sync(
                         config.appearance.style,
                         &config.outputs,
                         config.position,
+                        config.layer,
                         config.appearance.scale_factor,
                     ));
                 }
@@ -389,6 +395,7 @@ impl App {
                         self.theme.bar_style,
                         &self.general_config.outputs,
                         self.theme.bar_position,
+                        self.general_config.layer,
                         name,
                         wl_output,
                         self.theme.scale_factor,
@@ -399,6 +406,7 @@ impl App {
                     self.outputs.remove(
                         self.theme.bar_style,
                         self.theme.bar_position,
+                        self.general_config.layer,
                         wl_output,
                         self.theme.scale_factor,
                     )

--- a/src/config.rs
+++ b/src/config.rs
@@ -25,6 +25,7 @@ pub const DEFAULT_CONFIG_FILE_PATH: &str = "~/.config/ashell/config.toml";
 pub struct Config {
     pub log_level: String,
     pub position: Position,
+    pub layer: Layer,
     pub outputs: Outputs,
     pub modules: Modules,
     pub app_launcher_cmd: Option<String>,
@@ -48,6 +49,7 @@ impl Default for Config {
         Self {
             log_level: "warn".to_owned(),
             position: Position::default(),
+            layer: Layer::default(),
             outputs: Outputs::default(),
             modules: Modules::default(),
             app_launcher_cmd: None,
@@ -543,6 +545,13 @@ pub enum Position {
     #[default]
     Top,
     Bottom,
+}
+
+#[derive(Deserialize, Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Layer {
+    #[default]
+    Bottom,
+    Overlay,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -90,22 +90,30 @@ Render the status bar on a specific list of monitors:
 outputs = { Targets = ["DP-1", "eDP-1"] }
 ```
 
-## Position
+## Position & Layer
 
-You can set the position of the status bar to either `Top` or `Bottom`.
+Configure the bar position and Wayland layer.
 
-### Position Examples
+### Position Options
 
-Set the bar position to the top:
+- `"Top"` - Bar at top of screen (default)
+- `"Bottom"` - Bar at bottom of screen
+
+### Layer Options
+
+- `"Overlay"` - Above everything including fullscreen
+- `"Bottom"` - Above background, below windows (default)
+
+### Examples
 
 ```toml
 position = "Top"
+layer = "Overlay"
 ```
-
-Set the bar position to the bottom:
 
 ```toml
 position = "Bottom"
+layer = "Bottom"
 ```
 
 ## Close menu with esc


### PR DESCRIPTION
Add `layer` configuration option to control which Wayland layer the bar is rendered on. 

Supports 
`Bottom` (default), 
`Background`, 
`Top`, and 
`Overlay` layers. 

The layer setting is now threaded through the app initialization, config reloading, and output management.

A bit of cleanup, remove the `.clone()` because we are using the `Copy` Trait 

closes #356