### PR TITLE
Fix the reported SystemBattery percentage.

### DIFF
--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -47,17 +47,15 @@ impl SystemBattery {
     }
 
     pub async fn percentage(&self) -> f64 {
-        let mut percentage = 0.0;
-        let mut count = 0;
+        let mut energy = 0.0;
+        let mut energy_full = 0.0;
 
         for device in &self.0 {
-            if let Ok(p) = device.percentage().await {
-                percentage += p;
-                count += 1;
-            }
+            energy += device.energy().await.unwrap_or(0.0);
+            energy_full += device.energy_full().await.unwrap_or(0.0);
         }
 
-        percentage / count as f64
+        energy / energy_full * 100.0
     }
 
     pub async fn time_to_empty(&self) -> i64 {
@@ -320,6 +318,12 @@ pub trait Device {
 
     #[zbus(property)]
     fn percentage(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy(&self) -> zbus::Result<f64>;
+
+    #[zbus(property)]
+    fn energy_full(&self) -> zbus::Result<f64>;
 
     #[zbus(property)]
     fn state(&self) -> zbus::Result<u32>;


### PR DESCRIPTION
When there are multiple batteries in the system, the percentage calculation overvalues the contribution of the smaller battery.i

This can lead to very strange results in extreme cases. For example, the Thinkpad T480 reports two batteries, but the second one is not real, with zero Energy and zero EnergyFull. With the current percentage calculation, the reported value ends up being half of the actual value.

To derive the SystemBattery percentage accurately, it should be based on the ratio of total Energy to total FullEnergy.