### PR TITLE
Add keyboard layout change handler for Hyprland

### DIFF
--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -116,6 +116,8 @@ pub async fn run_listener(tx: &broadcast::Sender<ServiceEvent<CompositorService>
     add_refresh_handler!(add_window_moved_handler);
     add_refresh_handler!(add_active_window_changed_handler);
 
+    add_refresh_handler!(add_layout_changed_handler);
+
     // custom refresh handler that takes the changed value as the submap
     listener.add_sub_map_changed_handler({
         let tx = tx.clone();


### PR DESCRIPTION
I have a shortcut in Hyprland to change my keyboard layout and the bar would not change the string of the new layout until I would move the mouse to a window that is not directly under the KeyboardLayout string.

This one immediately changes the layout string.

closes https://github.com/MalpenZibo/ashell/issues/406