### PR TITLE
Fix text color not applied to workspace numbers, Wi-Fi widget, and power widget

### DIFF
--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -771,14 +771,32 @@ fn quick_setting_button<'a, Msg: Clone + 'static, I: Icon>(
     with_submenu: Option<(SubMenu, Option<SubMenu>, Msg)>,
 ) -> Element<'a, Msg> {
     let main_content = row!(
-        icon(icon_type).size(theme.font_size.lg),
+        container(icon(icon_type).size(theme.font_size.lg)).style(|theme: &Theme| {
+            container::Style {
+                text_color: Some(theme.palette().text),
+                ..Default::default()
+            }
+        }),
         container(
             Column::new()
-                .push(text(title).size(theme.font_size.sm))
+                .push(
+                    container(text(title).size(theme.font_size.sm)).style(|theme: &Theme| {
+                        container::Style {
+                            text_color: Some(theme.palette().text),
+                            ..Default::default()
+                        }
+                    })
+                )
                 .push_maybe(subtitle.map(|s| {
-                    text(s)
-                        .wrapping(text::Wrapping::None)
-                        .size(theme.font_size.xs)
+                    container(
+                        text(s)
+                            .wrapping(text::Wrapping::None)
+                            .size(theme.font_size.xs),
+                    )
+                    .style(|theme: &Theme| container::Style {
+                        text_color: Some(theme.palette().text),
+                        ..Default::default()
+                    })
                 }))
                 .spacing(theme.space.xxs)
         )
@@ -804,6 +822,7 @@ fn quick_setting_button<'a, Msg: Clone + 'static, I: Icon>(
                 .on_press(msg)
                 .size(IconButtonSize::Small)
                 .style(theme.quick_settings_submenu_button_style(active))
+                .color(theme.get_theme().palette().text)
             }))
             .spacing(theme.space.xxs)
             .align_y(Alignment::Center)

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -379,9 +379,17 @@ impl Workspaces {
 
                             Some(
                                 button(
-                                    container(text(w.name.as_str()).size(theme.font_size.xs))
-                                        .align_x(alignment::Horizontal::Center)
-                                        .align_y(alignment::Vertical::Center),
+                                    container(
+                                        container(text(w.name.as_str()).size(theme.font_size.xs))
+                                            .style(|theme: &iced::Theme| {
+                                                iced::widget::container::Style {
+                                                    text_color: Some(theme.palette().text),
+                                                    ..Default::default()
+                                                }
+                                            }),
+                                    )
+                                    .align_x(alignment::Horizontal::Center)
+                                    .align_y(alignment::Vertical::Center),
                                 )
                                 .style(theme.workspace_button_style(empty, color))
                                 .padding(if w.id < 0 {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -112,7 +112,10 @@ impl AshellTheme {
                 "local".to_string(),
                 Palette {
                     background: appearance.background_color.get_base(),
-                    text: appearance.text_color.get_base(),
+                    text: appearance
+                        .text_color
+                        .get_text()
+                        .unwrap_or(appearance.text_color.get_base()),
                     primary: appearance.primary_color.get_base(),
                     success: appearance.success_color.get_base(),
                     danger: appearance.danger_color.get_base(),


### PR DESCRIPTION
Changed theme construction to prioritize text_color.text field and added explicit text color styling to affected components.
closes #365 

src/theme.rs (line 115): Use get_text().unwrap_or(get_base()) for theme text color
src/modules/settings/mod.rs: Add explicit text color styling to quick setting buttons and chevron icons
src/modules/workspaces.rs (line 382): Add explicit text color styling to workspace number text