### PR TITLE
Fix VPN list when there are too many VPNs

### DIFF
--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -546,7 +546,8 @@ impl NetworkSettings {
         show_more_button: bool,
     ) -> Element<'a, Message> {
         // Collect and sort the VPNs
-        let mut vpns: Vec<_> = service.known_connections
+        let mut vpns: Vec<_> = service
+            .known_connections
             .iter()
             .filter_map(|c| match c {
                 KnownConnection::Vpn(vpn) => Some(vpn),
@@ -583,8 +584,7 @@ impl NetworkSettings {
             theme.space.xs,
         ]);
 
-        let main = container(
-            scrollable(vpn_list))
+        let main = container(scrollable(vpn_list))
             .height(Length::Shrink)
             .max_height(300);
 


### PR DESCRIPTION
When there are too many VPNs, the list doesn't render anything (I have about 200):
<img width="355" height="1408" alt="image" src="https://github.com/user-attachments/assets/df71eae9-02e6-4125-ad25-f06aa19c2676" />

With this fix, it makes it into a scroll-able list and renders the VPNs. Sorted alphabetically
<img width="352" height="894" alt="image" src="https://github.com/user-attachments/assets/3a8ac126-3a0d-402e-b936-adae7f1db9e2" />

