### PR TITLE
Cleanup code docs

### DIFF
--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -975,15 +975,15 @@ trait WiredDevice {
     #[zbus(property)]
     fn carrier(&self) -> zbus::Result<bool>;
 
-    /// HwAddress property
+    /// `HwAddress` property
     #[zbus(property)]
     fn hw_address(&self) -> zbus::Result<String>;
 
-    /// PermHwAddress property
+    /// `PermHwAddress` property
     #[zbus(property)]
     fn perm_hw_address(&self) -> zbus::Result<String>;
 
-    /// S390Subchannels property
+    /// `S390Subchannels` property
     #[zbus(property)]
     fn s390subchannels(&self) -> zbus::Result<Vec<String>>;
 
@@ -998,7 +998,7 @@ trait WiredDevice {
     interface = "org.freedesktop.NetworkManager.Device.Wireless"
 )]
 pub trait WirelessDevice {
-    /// GetAccessPoints method
+    /// `GetAccessPoints` method
     fn get_access_points(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
 
     #[zbus(property)]

--- a/src/services/network/iwd_dbus/access_point.rs
+++ b/src/services/network/iwd_dbus/access_point.rs
@@ -13,18 +13,18 @@
 use zbus::proxy;
 #[proxy(interface = "net.connman.iwd.AccessPoint", assume_defaults = true)]
 pub trait AccessPoint {
-    /// GetOrderedNetworks method
+    /// `GetOrderedNetworks` method
     fn get_ordered_networks(
         &self,
     ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;
 
-    /// Scan method
+    /// `Scan` method
     fn scan(&self) -> zbus::Result<()>;
 
     /// Start method
     fn start(&self, ssid: &str, psk: &str) -> zbus::Result<()>;
 
-    /// StartProfile method
+    /// `StartProfile` method
     fn start_profile(&self, ssid: &str) -> zbus::Result<()>;
 
     /// Stop method
@@ -34,7 +34,7 @@ pub trait AccessPoint {
     #[zbus(property)]
     fn frequency(&self) -> zbus::Result<u32>;
 
-    /// GroupCipher property
+    /// `GroupCipher` property
     #[zbus(property)]
     fn group_cipher(&self) -> zbus::Result<String>;
 
@@ -42,7 +42,7 @@ pub trait AccessPoint {
     #[zbus(property)]
     fn name(&self) -> zbus::Result<String>;
 
-    /// PairwiseCiphers property
+    /// `PairwiseCiphers` property
     #[zbus(property)]
     fn pairwise_ciphers(&self) -> zbus::Result<Vec<String>>;
 

--- a/src/services/network/iwd_dbus/adapter.rs
+++ b/src/services/network/iwd_dbus/adapter.rs
@@ -34,7 +34,7 @@ pub trait Adapter {
     #[zbus(property)]
     fn set_powered(&self, value: bool) -> zbus::Result<()>;
 
-    /// SupportedModes property
+    /// `SupportedModes` property
     #[zbus(property)]
     fn supported_modes(&self) -> zbus::Result<Vec<String>>;
 

--- a/src/services/network/iwd_dbus/agent_manager.rs
+++ b/src/services/network/iwd_dbus/agent_manager.rs
@@ -20,19 +20,19 @@
 use zbus::proxy;
 #[proxy(interface = "net.connman.iwd.AgentManager", assume_defaults = true)]
 pub trait AgentManager {
-    /// RegisterAgent method
+    /// `RegisterAgent` method
     fn register_agent(&self, path: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
 
-    /// RegisterNetworkConfigurationAgent method
+    /// `RegisterNetworkConfigurationAgent` method
     fn register_network_configuration_agent(
         &self,
         path: &zbus::zvariant::ObjectPath<'_>,
     ) -> zbus::Result<()>;
 
-    /// UnregisterAgent method
+    /// `UnregisterAgent` method
     fn unregister_agent(&self, path: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
 
-    /// UnregisterNetworkConfigurationAgent method
+    /// `UnregisterNetworkConfigurationAgent` method
     fn unregister_network_configuration_agent(
         &self,
         path: &zbus::zvariant::ObjectPath<'_>,

--- a/src/services/network/iwd_dbus/daemon.rs
+++ b/src/services/network/iwd_dbus/daemon.rs
@@ -20,7 +20,7 @@
 use zbus::proxy;
 #[proxy(interface = "net.connman.iwd.Daemon", assume_defaults = true)]
 pub trait Daemon {
-    /// GetInfo method
+    /// `GetInfo` method
     fn get_info(
         &self,
     ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;

--- a/src/services/network/iwd_dbus/device_provisioning.rs
+++ b/src/services/network/iwd_dbus/device_provisioning.rs
@@ -23,13 +23,13 @@ use zbus::proxy;
     assume_defaults = true
 )]
 pub trait DeviceProvisioning {
-    /// ConfigureEnrollee method
+    /// `ConfigureEnrollee` method
     fn configure_enrollee(&self, uri: &str) -> zbus::Result<()>;
 
-    /// StartConfigurator method
+    /// `StartConfigurator` method
     fn start_configurator(&self) -> zbus::Result<String>;
 
-    /// StartEnrollee method
+    /// `StartEnrollee` method
     fn start_enrollee(&self) -> zbus::Result<String>;
 
     /// Stop method

--- a/src/services/network/iwd_dbus/known_network.rs
+++ b/src/services/network/iwd_dbus/known_network.rs
@@ -23,7 +23,7 @@ pub trait KnownNetwork {
     /// Forget method
     fn forget(&self) -> zbus::Result<()>;
 
-    /// AutoConnect property
+    /// `AutoConnect` property
     #[zbus(property)]
     fn auto_connect(&self) -> zbus::Result<bool>;
     #[zbus(property)]
@@ -33,7 +33,7 @@ pub trait KnownNetwork {
     #[zbus(property)]
     fn hidden(&self) -> zbus::Result<bool>;
 
-    /// LastConnectedTime property
+    /// `LastConnectedTime` property
     #[zbus(property)]
     fn last_connected_time(&self) -> zbus::Result<String>;
 

--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -43,7 +43,7 @@ use known_network::KnownNetworkProxy;
 use network::NetworkProxy;
 use station::StationProxy;
 
-/// Wrapper around the IWD D-Bus ObjectManager
+/// Wrapper around the IWD D-Bus `ObjectManager`.
 pub struct IwdDbus<'a> {
     _inner: ObjectManagerProxy<'a>,
 }
@@ -106,7 +106,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
         })
     }
 
-    /// List known (provisioned) SSIDs
+    /// List known (provisioned) SSIDs.
     async fn known_connections(&self) -> anyhow::Result<Vec<KnownConnection>> {
         let nets = self.reachable_networks().await?;
         let mut networks = Vec::new();
@@ -298,7 +298,7 @@ impl PWAgent {
 
 #[allow(dead_code, unused_variables)]
 impl IwdDbus<'_> {
-    /// Connect to the system bus and the IWD service
+    /// Connect to the system bus and the IWD service.
     pub async fn new(conn: &zbus::Connection) -> anyhow::Result<Self> {
         let manager = ObjectManagerProxy::builder(conn)
             .destination("net.connman.iwd")?
@@ -592,7 +592,7 @@ impl IwdDbus<'_> {
         Ok(events)
     }
 
-    /// Get the state of all station interfaces
+    /// Get the state of all station interfaces.
     pub async fn connectivity(&self) -> anyhow::Result<Vec<String>> {
         let mut states = Vec::new();
         for s in self.stations().await? {
@@ -602,7 +602,7 @@ impl IwdDbus<'_> {
         Ok(states)
     }
 
-    /// Return true if any device in station mode is present
+    /// Return true if any device in station mode is present.
     pub async fn wifi_device_present(&self) -> anyhow::Result<bool> {
         let devices = self.wireless_devices().await?;
 
@@ -614,7 +614,7 @@ impl IwdDbus<'_> {
         Ok(false)
     }
 
-    /// List all networks currently connected (Connected = true)
+    /// List all networks currently connected (Connected = true).
     pub async fn active_connections(&'_ self) -> anyhow::Result<Vec<(NetworkProxy<'_>, i16)>> {
         let mut networks = Vec::new();
         for (net, strength) in self.reachable_networks().await? {
@@ -625,7 +625,7 @@ impl IwdDbus<'_> {
         Ok(networks)
     }
 
-    /// Detailed info on active connections
+    /// Detailed info on active connections.
     pub async fn active_connections_info(&self) -> anyhow::Result<Vec<ActiveConnectionInfo>> {
         // INFO: probably way cleaner with a custom dbus object - SignalLevelAgent
 
@@ -642,7 +642,7 @@ impl IwdDbus<'_> {
         Ok(info)
     }
 
-    /// List all wireless (station-mode) devices
+    /// List all wireless (station-mode) devices.
     pub async fn wireless_devices(&'_ self) -> anyhow::Result<Vec<DeviceProxy<'_>>> {
         let devices = self.devices().await?;
         let mut devs = Vec::new();
@@ -654,7 +654,7 @@ impl IwdDbus<'_> {
         Ok(devs)
     }
 
-    /// Scan and list available access points
+    /// Scan and list available access points.
     pub async fn wireless_access_points(&self) -> anyhow::Result<Vec<AccessPoint>> {
         let mut aps = Vec::new();
         {

--- a/src/services/network/iwd_dbus/network.rs
+++ b/src/services/network/iwd_dbus/network.rs
@@ -31,11 +31,11 @@ pub trait Network {
     #[zbus(property)]
     fn device(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
 
-    /// ExtendedServiceSet property
+    /// `ExtendedServiceSet` property
     #[zbus(property)]
     fn extended_service_set(&self) -> zbus::Result<Vec<zbus::zvariant::OwnedObjectPath>>;
 
-    /// KnownNetwork property
+    /// `KnownNetwork` property
     #[zbus(property)]
     fn known_network(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
 

--- a/src/services/network/iwd_dbus/service_manager.rs
+++ b/src/services/network/iwd_dbus/service_manager.rs
@@ -23,12 +23,12 @@ use zbus::proxy;
     assume_defaults = true
 )]
 pub trait ServiceManager {
-    /// RegisterDisplayService method
+    /// `RegisterDisplayService` method
     fn register_display_service(
         &self,
         properties: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
     ) -> zbus::Result<()>;
 
-    /// UnregisterDisplayService method
+    /// `UnregisterDisplayService` method
     fn unregister_display_service(&self) -> zbus::Result<()>;
 }

--- a/src/services/network/iwd_dbus/shared_code_device_provisioning.rs
+++ b/src/services/network/iwd_dbus/shared_code_device_provisioning.rs
@@ -23,16 +23,16 @@ use zbus::proxy;
     assume_defaults = true
 )]
 pub trait SharedCodeDeviceProvisioning {
-    /// ConfigureEnrollee method
+    /// `ConfigureEnrollee` method
     fn configure_enrollee(
         &self,
         args: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,
     ) -> zbus::Result<()>;
 
-    /// StartConfigurator method
+    /// `StartConfigurator` method
     fn start_configurator(&self, path: &zbus::zvariant::ObjectPath<'_>) -> zbus::Result<()>;
 
-    /// StartEnrollee method
+    /// `StartEnrollee` method
     fn start_enrollee(
         &self,
         args: std::collections::HashMap<&str, &zbus::zvariant::Value<'_>>,

--- a/src/services/network/iwd_dbus/simple_configuration.rs
+++ b/src/services/network/iwd_dbus/simple_configuration.rs
@@ -26,12 +26,12 @@ pub trait SimpleConfiguration {
     /// Cancel method
     fn cancel(&self) -> zbus::Result<()>;
 
-    /// GeneratePin method
+    /// `GeneratePin` method
     fn generate_pin(&self) -> zbus::Result<String>;
 
-    /// PushButton method
+    /// `PushButton` method
     fn push_button(&self) -> zbus::Result<()>;
 
-    /// StartPin method
+    /// `StartPin` method
     fn start_pin(&self, pin: &str) -> zbus::Result<()>;
 }

--- a/src/services/network/iwd_dbus/station.rs
+++ b/src/services/network/iwd_dbus/station.rs
@@ -20,19 +20,19 @@
 use zbus::proxy;
 #[proxy(interface = "net.connman.iwd.Station", assume_defaults = true)]
 pub trait Station {
-    /// ConnectHiddenNetwork method
+    /// `ConnectHiddenNetwork` method
     fn connect_hidden_network(&self, name: &str) -> zbus::Result<()>;
 
     /// Disconnect method
     fn disconnect(&self) -> zbus::Result<()>;
 
-    /// GetHiddenAccessPoints method
+    /// `GetHiddenAccessPoints` method
     fn get_hidden_access_points(&self) -> zbus::Result<Vec<(String, i16, String)>>;
 
-    /// GetOrderedNetworks method
+    /// `GetOrderedNetworks` method
     fn get_ordered_networks(&self) -> zbus::Result<Vec<(zbus::zvariant::OwnedObjectPath, i16)>>;
 
-    /// RegisterSignalLevelAgent method
+    /// `RegisterSignalLevelAgent` method
     fn register_signal_level_agent(
         &self,
         path: &zbus::zvariant::ObjectPath<'_>,
@@ -42,7 +42,7 @@ pub trait Station {
     /// Scan method
     fn scan(&self) -> zbus::Result<()>;
 
-    /// UnregisterSignalLevelAgent method
+    /// `UnregisterSignalLevelAgent` method
     fn unregister_signal_level_agent(
         &self,
         path: &zbus::zvariant::ObjectPath<'_>,
@@ -54,11 +54,11 @@ pub trait Station {
     #[zbus(property)]
     fn set_affinities(&self, value: &[&zbus::zvariant::ObjectPath<'_>]) -> zbus::Result<()>;
 
-    /// ConnectedAccessPoint property
+    /// `ConnectedAccessPoint` property
     #[zbus(property)]
     fn connected_access_point(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
 
-    /// ConnectedNetwork property
+    /// `ConnectedNetwork` property
     #[zbus(property)]
     fn connected_network(&self) -> zbus::Result<zbus::zvariant::OwnedObjectPath>;
 

--- a/src/services/network/iwd_dbus/station_diagnostic.rs
+++ b/src/services/network/iwd_dbus/station_diagnostic.rs
@@ -23,7 +23,7 @@ use zbus::proxy;
     assume_defaults = true
 )]
 pub trait StationDiagnostic {
-    /// GetDiagnostics method
+    /// `GetDiagnostics` method
     fn get_diagnostics(
         &self,
     ) -> zbus::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>>;

--- a/src/services/network/mod.rs
+++ b/src/services/network/mod.rs
@@ -18,7 +18,7 @@ pub mod dbus;
 pub mod iwd_dbus;
 
 /// Trait defining the interface for a network backend.
-/// This allows abstracting the specific D-Bus implementation (like IWD or NetworkManager).
+/// This allows abstracting the specific D-Bus implementation (like IWD or `NetworkManager`).
 pub trait NetworkBackend: Send + Sync {
     /// Initializes the backend and fetches the initial network data.
     async fn initialize_data(&self) -> anyhow::Result<NetworkData>;

--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -115,7 +115,7 @@ pub enum UpDeviceKind {
 }
 
 impl UpDeviceKind {
-    /// Convert from u32 to UpDeviceKind
+    /// Convert from u32 to `UpDeviceKind`.
     pub fn from_u32(value: u32) -> Option<Self> {
         match value {
             0 => Some(Self::Unknown),
@@ -140,12 +140,12 @@ impl UpDeviceKind {
         }
     }
 
-    /// Convert to u32
+    /// Convert to u32.
     pub fn to_u32(self) -> u32 {
         self as u32
     }
 
-    /// Check if this device type is a peripheral input device
+    /// Check if this device type is a peripheral input device.
     pub fn is_peripheral(&self) -> bool {
         matches!(
             self,
@@ -153,12 +153,12 @@ impl UpDeviceKind {
         )
     }
 
-    /// Check if this device type is a system power source
+    /// Check if this device type is a system power source.
     pub fn is_power_source(&self) -> bool {
         matches!(self, Self::Battery)
     }
 
-    /// Get a human-readable description
+    /// Get a human-readable description.
     pub fn description(&self) -> &'static str {
         match self {
             Self::Unknown => "Unknown",


### PR DESCRIPTION
Wrap property and method names in backticks for better documentation formatting. 
Also improve documentation sentence formatting with proper punctuation.