### PR TITLE
replace map().unwrap_or* with map_or_else and add inline attributes

### DIFF
--- a/src/centerbox.rs
+++ b/src/centerbox.rs
@@ -305,6 +305,7 @@ where
     Theme: 'a,
     Renderer: iced::advanced::Renderer + 'a,
 {
+    #[inline]
     fn from(row: Centerbox<'a, Message, Theme, Renderer>) -> Self {
         Self::new(row)
     }

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -357,6 +357,7 @@ impl<'a, I: Icon, Message> IconButton<'a, I, Message> {
 impl<'a, I: Icon, Message: 'static + Clone> From<IconButton<'a, I, Message>>
     for Element<'a, Message>
 {
+    #[inline]
     fn from(value: IconButton<'a, I, Message>) -> Self {
         let (container_size, font_size) = match value.size {
             IconButtonSize::Small => (24., value.theme.font_size.xs),

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,9 +85,10 @@ async fn main() -> iced::Result {
 
     logger.set_new_spec(get_log_spec(&config.log_level));
 
-    let font = match config.appearance.font_name {
-        Some(ref font_name) => Font::with_name(Box::leak(font_name.clone().into_boxed_str())),
-        None => Font::DEFAULT,
+    let font = if let Some(font_name) = &config.appearance.font_name {
+        Font::with_name(Box::leak(font_name.clone().into_boxed_str()))
+    } else {
+        Font::DEFAULT
     };
 
     iced::daemon(App::title, App::update, App::view)

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -277,8 +277,7 @@ impl Workspaces {
                                 .name
                                 .split(":")
                                 .last()
-                                .map(|s| s.to_string())
-                                .unwrap_or(special.name.clone()),
+                                .map_or_else(|| special.name.clone(), |s| s.to_string()),
                         ))
                         .map(Message::ServiceEvent);
                 }

--- a/src/position_button.rs
+++ b/src/position_button.rs
@@ -403,6 +403,7 @@ where
     Theme: Catalog + 'a,
     Renderer: iced::core::Renderer + 'a,
 {
+    #[inline]
     fn from(button: PositionButton<'a, Message, Theme, Renderer>) -> Self {
         Self::new(button)
     }

--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -832,11 +832,11 @@ impl From<&SinkInfo<'_>> for Device {
             name: value
                 .name
                 .as_ref()
-                .map_or(String::default(), |n| n.to_string()),
+                .map_or_else(String::default, |n| n.to_string()),
             description: value
                 .proplist
                 .get_str("device.description")
-                .map_or(String::default(), |d| d.to_string()),
+                .map_or_else(String::default, |d| d.to_string()),
             volume: value.volume,
             is_mute: value.mute,
             in_use: value.state == SinkState::Running,
@@ -849,7 +849,7 @@ impl From<&SinkInfo<'_>> for Device {
                             name: port
                                 .name
                                 .as_ref()
-                                .map_or(String::default(), |n| n.to_string()),
+                                .map_or_else(String::default, |n| n.to_string()),
                             description: port.description.as_ref().unwrap().to_string(),
                             device_type: match port.r#type {
                                 DevicePortType::Headphones => DeviceType::Headphones,
@@ -876,11 +876,11 @@ impl From<&SourceInfo<'_>> for Device {
             name: value
                 .name
                 .as_ref()
-                .map_or(String::default(), |n| n.to_string()),
+                .map_or_else(String::default, |n| n.to_string()),
             description: value
                 .proplist
                 .get_str("device.description")
-                .map_or(String::default(), |d| d.to_string()),
+                .map_or_else(String::default, |d| d.to_string()),
             volume: value.volume,
             is_mute: value.mute,
             in_use: value.state == SourceState::Running,
@@ -893,7 +893,7 @@ impl From<&SourceInfo<'_>> for Device {
                             name: port
                                 .name
                                 .as_ref()
-                                .map_or(String::default(), |n| n.to_string()),
+                                .map_or_else(String::default, |n| n.to_string()),
                             description: port.description.as_ref().unwrap().to_string(),
                             device_type: match port.r#type {
                                 DevicePortType::Headphones => DeviceType::Headphones,

--- a/src/services/compositor/niri.rs
+++ b/src/services/compositor/niri.rs
@@ -195,8 +195,7 @@ fn map_state(niri: &EventStreamState) -> CompositorState {
                     outputs
                         .iter()
                         .position(|o| *o == wo)
-                        .map(|i| i as i32)
-                        .unwrap_or(-1) as i128
+                        .map_or(-1, |i| i as i32) as i128
                 }),
                 windows: 0,
                 is_special: false,
@@ -224,8 +223,7 @@ fn map_state(niri: &EventStreamState) -> CompositorState {
             id: outputs
                 .iter()
                 .position(|o| *o == name)
-                .map(|i| i as i128)
-                .unwrap_or(-1),
+                .map_or(-1, |i| i as i128),
             name: name.clone(),
             active_workspace_id: *active_ws_id,
             special_workspace_id: -1,
@@ -250,17 +248,15 @@ fn map_state(niri: &EventStreamState) -> CompositorState {
             address: w.id.to_string(),
         });
 
-    let keyboard_layout = niri
-        .keyboard_layouts
-        .keyboard_layouts
-        .as_ref()
-        .map(|k| {
+    let keyboard_layout = niri.keyboard_layouts.keyboard_layouts.as_ref().map_or_else(
+        || "Unknown".to_string(),
+        |k| {
             k.names
                 .get(k.current_idx as usize)
                 .cloned()
                 .unwrap_or_else(|| "Unknown".to_string())
-        })
-        .unwrap_or_else(|| "Unknown".to_string());
+        },
+    );
 
     CompositorState {
         workspaces,

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -626,8 +626,7 @@ impl NetworkDbus<'_> {
                 let state: DeviceState = device
                     .cached_state()
                     .unwrap_or_default()
-                    .map(DeviceState::from)
-                    .unwrap_or_else(|| DeviceState::Unknown);
+                    .map_or_else(|| DeviceState::Unknown, DeviceState::from);
 
                 // Sort by strength and remove duplicates
                 let mut aps = HashMap::<String, AccessPoint>::new();
@@ -835,6 +834,7 @@ impl From<Vec<ConnectivityState>> for ConnectivityState {
 }
 
 impl From<ConnectivityState> for u32 {
+    #[inline]
     fn from(val: ConnectivityState) -> Self {
         match val {
             ConnectivityState::None => 1,

--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -190,6 +190,7 @@ impl std::fmt::Display for UpDeviceKind {
 }
 
 impl From<UpDeviceKind> for u32 {
+    #[inline]
     fn from(kind: UpDeviceKind) -> Self {
         kind.to_u32()
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -417,27 +417,32 @@ impl AshellTheme {
         colors: Option<Option<AppearanceColor>>,
     ) -> impl Fn(&Theme, Status) -> button::Style {
         move |theme: &Theme, status: Status| {
-            let (bg_color, fg_color) = colors
-                .map(|c| {
-                    c.map_or(
-                        (
-                            theme.extended_palette().primary.base.color,
-                            theme.extended_palette().primary.base.text,
-                        ),
+            let (bg_color, fg_color) = colors.map_or_else(
+                || {
+                    (
+                        theme.extended_palette().background.weak.color,
+                        theme.palette().text,
+                    )
+                },
+                |c| {
+                    c.map_or_else(
+                        || {
+                            (
+                                theme.extended_palette().primary.base.color,
+                                theme.extended_palette().primary.base.text,
+                            )
+                        },
                         |c| {
                             let color = palette::Primary::generate(
                                 c.get_base(),
                                 theme.palette().background,
-                                c.get_text().unwrap_or(theme.palette().text),
+                                c.get_text().unwrap_or_else(|| theme.palette().text),
                             );
                             (color.base.color, color.base.text)
                         },
                     )
-                })
-                .unwrap_or((
-                    theme.extended_palette().background.weak.color,
-                    theme.palette().text,
-                ));
+                },
+            );
             let mut base = button::Style {
                 background: Some(Background::Color(if is_empty {
                     theme.extended_palette().background.weak.color
@@ -459,27 +464,32 @@ impl AshellTheme {
             match status {
                 Status::Active => base,
                 Status::Hovered => {
-                    let (bg_color, fg_color) = colors
-                        .map(|c| {
-                            c.map_or(
-                                (
-                                    theme.extended_palette().primary.strong.color,
-                                    theme.extended_palette().primary.strong.text,
-                                ),
+                    let (bg_color, fg_color) = colors.map_or_else(
+                        || {
+                            (
+                                theme.extended_palette().background.strong.color,
+                                theme.palette().text,
+                            )
+                        },
+                        |c| {
+                            c.map_or_else(
+                                || {
+                                    (
+                                        theme.extended_palette().primary.strong.color,
+                                        theme.extended_palette().primary.strong.text,
+                                    )
+                                },
                                 |c| {
                                     let color = palette::Primary::generate(
                                         c.get_base(),
                                         theme.palette().background,
-                                        c.get_text().unwrap_or(theme.palette().text),
+                                        c.get_text().unwrap_or_else(|| theme.palette().text),
                                     );
                                     (color.strong.color, color.strong.text)
                                 },
                             )
-                        })
-                        .unwrap_or((
-                            theme.extended_palette().background.strong.color,
-                            theme.palette().text,
-                        ));
+                        },
+                    );
 
                     base.background = Some(Background::Color(if is_empty {
                         theme.extended_palette().background.strong.color


### PR DESCRIPTION
Replace chained map().unwrap_or() and map().unwrap_or_else() calls with the more idiomatic map_or_else() throughout the codebase. 
Add #[inline] attributes to simple From trait implementations for potential performance improvements.