### PR TITLE
refactor: simplify code and improve readability

### DIFF
--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -107,12 +107,13 @@ impl Custom {
         // Wrap the icon in a container to apply padding
         let padded_icon_container = container(icon_element).padding([0, 1]);
 
-        let mut show_alert = false;
-        if let Some(re) = &self.config.alert
+        let show_alert = if let Some(re) = &self.config.alert
             && re.is_match(&self.data.alt)
         {
-            show_alert = true;
-        }
+            true
+        } else {
+            false
+        };
 
         let icon_with_alert = if show_alert {
             let alert_canvas = canvas(AlertIndicator)

--- a/src/position_button.rs
+++ b/src/position_button.rs
@@ -381,7 +381,7 @@ where
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
-            layout.children().next().unwrap(),
+            layout.children().next()?,
             renderer,
             translation,
         )

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -714,9 +714,7 @@ impl NetworkSettingsDbus<'_> {
                 .await?;
 
             let s = connection.get_settings().await?;
-            let id = s
-                .get("connection")
-                .unwrap()
+            let id = s["connection"]
                 .get("id")
                 .map(|v| match v.deref() {
                     Value::Str(v) => v.to_string(),

--- a/src/services/network/mod.rs
+++ b/src/services/network/mod.rs
@@ -441,11 +441,10 @@ impl NetworkService {
                         match nm.subscribe_events().await {
                             Ok(mut events) => {
                                 while let Some(event) = events.next().await {
-                                    let mut exit_loop = false;
-                                    // TODO: why do we do this?
-                                    if let NetworkEvent::WirelessDevice { .. } = event {
-                                        exit_loop = true;
-                                    }
+                                    let exit_loop =
+                                        matches!(event, NetworkEvent::WirelessDevice { .. });
+                                    // Send the event to UI before exiting - UI needs the WirelessDevice data
+                                    // (wifi_present and access_points) to populate the network menu
                                     let _ = output.send(ServiceEvent::Update(event)).await;
 
                                     if exit_loop {

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -77,11 +77,9 @@ pub struct StatusNotifierItem {
 
 impl StatusNotifierItem {
     pub async fn new(conn: &zbus::Connection, name: String) -> anyhow::Result<Self> {
-        let (dest, path) = if let Some(idx) = name.find('/') {
-            (&name[..idx], &name[idx..])
-        } else {
-            (name.as_ref(), "/StatusNotifierItem")
-        };
+        let (dest, path) = name
+            .split_once('/')
+            .unwrap_or((name.as_ref(), "/StatusNotifierItem"));
 
         let item_proxy = StatusNotifierItemProxy::builder(conn)
             .destination(dest.to_owned())?


### PR DESCRIPTION
- Use `std::fs::read_to_string` instead of manual file reading in config.rs
- Replace mutable flag with direct boolean expression in custom_module.rs
- Use `?` operator instead of `unwrap()` in position_button.rs overlay
- Replace `get().unwrap()` with direct indexing in network dbus.rs
- Use `matches!` macro for pattern matching in network service
- Add clarifying comment about WirelessDevice event handling
- Use `split_once()` instead of manual string splitting