### PR TITLE
add scroll support for brightness slider and fix UI sync issues

### DIFF
--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -8,7 +8,8 @@ use crate::{
 };
 use iced::{
     Alignment, Element, Length, Subscription, Task,
-    widget::{container, row, slider},
+    futures::stream,
+    widget::{MouseArea, container, row, slider},
 };
 
 #[derive(Debug, Clone)]
@@ -16,6 +17,7 @@ pub enum Message {
     Event(ServiceEvent<BrightnessService>),
     Change(u32),
     MenuOpened,
+    ResetUserAdjusting,
 }
 
 pub enum Action {
@@ -25,36 +27,62 @@ pub enum Action {
 
 pub struct BrightnessSettings {
     service: Option<BrightnessService>,
+    ui_percentage: u32,
+    is_user_adjusting: bool,
+    reset_timer_active: bool,
 }
 
 impl BrightnessSettings {
     pub fn new() -> Self {
-        Self { service: None }
+        Self {
+            service: None,
+            ui_percentage: 50,
+            is_user_adjusting: false,
+            reset_timer_active: false,
+        }
     }
 
     pub fn update(&mut self, message: Message) -> Action {
         match message {
             Message::Event(event) => match event {
                 ServiceEvent::Init(service) => {
+                    self.ui_percentage = service.current * 100 / service.max;
                     self.service = Some(service);
                     Action::None
                 }
                 ServiceEvent::Update(data) => {
                     if let Some(service) = self.service.as_mut() {
                         service.update(data);
+                        // Only update UI if the difference is significant and user isn't actively adjusting
+                        if !self.is_user_adjusting {
+                            let new_percentage = service.current * 100 / service.max;
+                            if (new_percentage as i32 - self.ui_percentage as i32).abs() > 2 {
+                                self.ui_percentage = new_percentage;
+                            }
+                        }
                     }
                     Action::None
                 }
                 _ => Action::None,
             },
-            Message::Change(value) => match self.service.as_mut() {
-                Some(service) => Action::Command(
-                    service
-                        .command(BrightnessCommand::Set(value))
-                        .map(Message::Event),
-                ),
-                _ => Action::None,
-            },
+            Message::Change(value) => {
+                self.is_user_adjusting = true;
+                self.reset_timer_active = true;
+                self.ui_percentage = value * 100
+                    / if let Some(service) = &self.service {
+                        service.max
+                    } else {
+                        100
+                    };
+                match self.service.as_mut() {
+                    Some(service) => Action::Command(
+                        service
+                            .command(BrightnessCommand::Set(value))
+                            .map(Message::Event),
+                    ),
+                    _ => Action::None,
+                }
+            }
             Message::MenuOpened => {
                 if let Some(service) = self.service.as_mut() {
                     Action::Command(
@@ -66,21 +94,44 @@ impl BrightnessSettings {
                     Action::None
                 }
             }
+            Message::ResetUserAdjusting => {
+                self.is_user_adjusting = false;
+                self.reset_timer_active = false;
+                Action::None
+            }
         }
     }
 
     pub fn slider(&'_ self, theme: &AshellTheme) -> Option<Element<'_, Message>> {
         self.service.as_ref().map(|service| {
+            let max = service.max;
+            let current_percentage = self.ui_percentage;
             row!(
                 container(icon_mono(StaticIcon::Brightness))
                     .center_x(32.)
                     .center_y(32.)
                     .clip(true),
-                slider(0..=100, service.current * 100 / service.max, |v| {
-                    Message::Change(v * service.max / 100)
-                })
-                .step(1_u32)
-                .width(Length::Fill),
+                MouseArea::new(
+                    slider(0..=100, current_percentage, move |v| {
+                        Message::Change(v * max / 100)
+                    })
+                    .step(1_u32)
+                    .width(Length::Fill),
+                )
+                .on_scroll(move |delta| {
+                    let delta = match delta {
+                        iced::mouse::ScrollDelta::Lines { y, .. } => y,
+                        iced::mouse::ScrollDelta::Pixels { y, .. } => y,
+                    };
+                    // brightness is always changed by one less than expected
+                    let new_percentage = if delta > 0.0 {
+                        (current_percentage + 5 + 1).min(100)
+                    } else {
+                        current_percentage.saturating_sub(5 + 1)
+                    };
+                    let new_brightness_value = new_percentage * max / 100;
+                    Message::Change(new_brightness_value)
+                }),
             )
             .align_y(Alignment::Center)
             .spacing(theme.space.xs)
@@ -89,6 +140,19 @@ impl BrightnessSettings {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        BrightnessService::subscribe().map(Message::Event)
+        Subscription::batch([
+            BrightnessService::subscribe().map(Message::Event),
+            if self.reset_timer_active {
+                Subscription::run_with_id(
+                    0,
+                    stream::once(async {
+                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        Message::ResetUserAdjusting
+                    }),
+                )
+            } else {
+                Subscription::none()
+            },
+        ])
     }
 }


### PR DESCRIPTION
The brightness slider currently suffers from stuttering and jumping caused by conflicting updates between the UI and hardware, often stemming from rounding discrepancies, external brightness changes, and interference from hardware feedback loops. 

To resolve this and prevent UI flicker, the system will now track user interaction via an `is_user_adjusting` flag and a dedicated `ui_percentage` field that remains independent of hardware values during active input. 

While the user is interacting, including using new mouse wheel support for ±5% increments(related to #308), hardware updates will be ignored and a 500ms debounced reset timer will be used to safely re-enable hardware synchronization only after the interaction ends. 

This separation of UI state from hardware feedback ensures smooth slider behavior and eliminates the unexpected jumping caused by conflicting update cycles.


PS: I wish I could made it simpler. I spent some time trying to iron out the UI and HW value rounding differences but the slider still jumped around while dragging. 
This is the smoothest and visually most pleasing version that I could come up with.
