### PR TITLE
PATCH: fix: handle Wayland toplevel race condition in cosmic-client-toolkit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1257,7 +1257,6 @@ dependencies = [
 [[package]]
 name = "cosmic-client-toolkit"
 version = "0.1.0"
-source = "git+https://github.com/pop-os/cosmic-protocols?rev=d0e95be#d0e95be25e423cfe523b11111a3666ed7aaf0dc4"
 dependencies = [
  "bitflags 2.10.0",
  "cosmic-protocols",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.88"
 [profile.release]
 lto = "thin"
 strip = true
-opt-level = 3 
+opt-level = 3
 panic = "abort"
 
 # The profile that 'dist' will build with
@@ -20,23 +20,12 @@ inherits = "release"
 
 [package.metadata.nfpm]
 provides = ["ashell"]
-depends = [
-  "libxkbcommon",
-  "dbus",
-]
+depends = ["libxkbcommon", "dbus"]
 
 [package.metadata.nfpm.deb]
-depends = [
-  "libwayland-client0",
-  "libpipewire-0.3-0t64",
-  "libpulse0",
-]
+depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 [package.metadata.nfpm.rpm]
-depends = [
-  "libwayland-client",
-  "pipewire-libs",
-  "pulseaudio-libs",
-]
+depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
 iced = { git = "https://github.com/MalpenZibo/iced", rev = "237116726a405b326bf6f61f2b9105b38a938490", features = [
@@ -48,7 +37,7 @@ iced = { git = "https://github.com/MalpenZibo/iced", rev = "237116726a405b326bf6
   "wayland",
   "image",
   "svg",
-  "canvas"
+  "canvas",
 ] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hyprland = "0.4.0-beta.2"
@@ -92,3 +81,6 @@ buildflags = ["--release"]
 
 [package.metadata.rpm.targets]
 ashell = { path = "/usr/bin/ashell" }
+
+[patch."https://github.com/pop-os/cosmic-protocols"]
+cosmic-client-toolkit = { path = "patches/cosmic-client-toolkit" }

--- a/patches/cosmic-client-toolkit/Cargo.toml
+++ b/patches/cosmic-client-toolkit/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "cosmic-client-toolkit"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+cosmic-protocols = { git = "https://github.com/pop-os/cosmic-protocols", rev = "d0e95be", features = [
+    "client",
+] }
+sctk = { package = "smithay-client-toolkit", version = "0.20.0" }
+wayland-client = { version = "0.31.11" }
+libc = "0.2.175"
+wayland-protocols = { version = "0.32.9", features = ["client", "staging"] }
+bitflags = "2.9.3"

--- a/patches/cosmic-client-toolkit/src/lib.rs
+++ b/patches/cosmic-client-toolkit/src/lib.rs
@@ -1,0 +1,13 @@
+pub use cosmic_protocols;
+pub use sctk;
+pub use wayland_client;
+pub use wayland_protocols;
+
+pub mod screencopy;
+pub mod toplevel_info;
+pub mod toplevel_management;
+pub mod workspace;
+
+#[doc(hidden)]
+#[derive(Debug, Default)]
+pub struct GlobalData;

--- a/patches/cosmic-client-toolkit/src/screencopy/capture_source.rs
+++ b/patches/cosmic-client-toolkit/src/screencopy/capture_source.rs
@@ -1,0 +1,89 @@
+use std::{error::Error, fmt};
+use wayland_client::{Dispatch, QueueHandle, protocol::wl_output};
+use wayland_protocols::ext::{
+    foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    image_capture_source::v1::client::ext_image_capture_source_v1,
+    workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+};
+
+use super::Capturer;
+use crate::GlobalData;
+
+#[derive(Debug)]
+pub struct CaptureSourceError(CaptureSourceKind);
+
+impl fmt::Display for CaptureSourceError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), fmt::Error> {
+        write!(f, "capture kind '{:?}' unsupported by compositor", self.0)
+    }
+}
+
+impl Error for CaptureSourceError {}
+
+#[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
+pub enum CaptureSourceKind {
+    Output,
+    Toplevel,
+    Workspace,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+pub enum CaptureSource {
+    Output(wl_output::WlOutput),
+    Toplevel(ExtForeignToplevelHandleV1),
+    Workspace(ExtWorkspaceHandleV1),
+}
+
+impl CaptureSource {
+    pub fn kind(&self) -> CaptureSourceKind {
+        match self {
+            Self::Output(_) => CaptureSourceKind::Output,
+            Self::Toplevel(_) => CaptureSourceKind::Toplevel,
+            Self::Workspace(_) => CaptureSourceKind::Workspace,
+        }
+    }
+
+    pub(crate) fn create_source<D>(
+        &self,
+        capturer: &Capturer,
+        qh: &QueueHandle<D>,
+    ) -> Result<WlCaptureSource, CaptureSourceError>
+    where
+        D: 'static,
+        D: Dispatch<ext_image_capture_source_v1::ExtImageCaptureSourceV1, GlobalData>,
+    {
+        match self {
+            CaptureSource::Output(output) => {
+                if let Some(manager) = &capturer.0.output_source_manager {
+                    return Ok(WlCaptureSource(
+                        manager.create_source(output, qh, GlobalData),
+                    ));
+                }
+            }
+            CaptureSource::Toplevel(toplevel) => {
+                if let Some(manager) = &capturer.0.foreign_toplevel_source_manager {
+                    return Ok(WlCaptureSource(
+                        manager.create_source(toplevel, qh, GlobalData),
+                    ));
+                }
+            }
+            CaptureSource::Workspace(workspace) => {
+                if let Some(manager) = &capturer.0.workspace_source_manager {
+                    return Ok(WlCaptureSource(
+                        manager.create_source(workspace, qh, GlobalData),
+                    ));
+                }
+            }
+        }
+        Err(CaptureSourceError(self.kind()))
+    }
+}
+
+// TODO name?
+pub(crate) struct WlCaptureSource(pub ext_image_capture_source_v1::ExtImageCaptureSourceV1);
+
+impl Drop for WlCaptureSource {
+    fn drop(&mut self) {
+        self.0.destroy();
+    }
+}

--- a/patches/cosmic-client-toolkit/src/screencopy/dispatch.rs
+++ b/patches/cosmic-client-toolkit/src/screencopy/dispatch.rs
@@ -1,0 +1,366 @@
+use cosmic_protocols::image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1;
+use std::time::Duration;
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
+use wayland_protocols::ext::{
+    image_capture_source::v1::client::{
+        ext_foreign_toplevel_image_capture_source_manager_v1, ext_image_capture_source_v1,
+        ext_output_image_capture_source_manager_v1,
+    },
+    image_copy_capture::v1::client::{
+        ext_image_copy_capture_cursor_session_v1, ext_image_copy_capture_frame_v1,
+        ext_image_copy_capture_manager_v1, ext_image_copy_capture_session_v1,
+    },
+};
+
+use super::{
+    CaptureCursorSession, CaptureFrame, CaptureSession, Rect, ScreencopyCursorSessionDataExt,
+    ScreencopyFrameDataExt, ScreencopyHandler, ScreencopySessionDataExt, ScreencopyState,
+};
+use crate::GlobalData;
+
+impl<D> Dispatch<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, GlobalData, D>
+    for ScreencopyState
+where
+    D: Dispatch<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, GlobalData>
+        + ScreencopyHandler,
+{
+    fn event(
+        _: &mut D,
+        _: &ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1,
+        _: ext_image_copy_capture_manager_v1::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D, U> Dispatch<ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1, U, D>
+    for ScreencopyState
+where
+    D: Dispatch<ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1, U>
+        + ScreencopyHandler,
+    U: ScreencopySessionDataExt,
+{
+    fn event(
+        app_data: &mut D,
+        session: &ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1,
+        event: ext_image_copy_capture_session_v1::Event,
+        udata: &U,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        let formats = &udata.screencopy_session_data().formats;
+        match event {
+            ext_image_copy_capture_session_v1::Event::BufferSize { width, height } => {
+                formats.lock().unwrap().buffer_size = (width, height);
+            }
+            ext_image_copy_capture_session_v1::Event::ShmFormat { format } => {
+                if let WEnum::Value(value) = format {
+                    formats.lock().unwrap().shm_formats.push(value);
+                }
+            }
+            ext_image_copy_capture_session_v1::Event::DmabufDevice { device } => {
+                let device = libc::dev_t::from_ne_bytes(device.try_into().unwrap());
+                formats.lock().unwrap().dmabuf_device = Some(device);
+            }
+            ext_image_copy_capture_session_v1::Event::DmabufFormat { format, modifiers } => {
+                let modifiers = modifiers
+                    .chunks_exact(8)
+                    .map(|x| u64::from_ne_bytes(x.try_into().unwrap()))
+                    .collect();
+                formats
+                    .lock()
+                    .unwrap()
+                    .dmabuf_formats
+                    .push((format, modifiers));
+            }
+            ext_image_copy_capture_session_v1::Event::Done => {
+                if let Some(session) = udata
+                    .screencopy_session_data()
+                    .session
+                    .get()
+                    .unwrap()
+                    .upgrade()
+                    .map(CaptureSession)
+                {
+                    app_data.init_done(conn, qh, &session, &formats.lock().unwrap());
+                }
+            }
+            ext_image_copy_capture_session_v1::Event::Stopped => {
+                if let Some(session) = udata
+                    .screencopy_session_data()
+                    .session
+                    .get()
+                    .unwrap()
+                    .upgrade()
+                    .map(CaptureSession)
+                {
+                    app_data.stopped(conn, qh, &session);
+                }
+                session.destroy();
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D, U> Dispatch<ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1, U, D>
+    for ScreencopyState
+where
+    D: Dispatch<ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1, U> + ScreencopyHandler,
+    U: ScreencopyFrameDataExt,
+{
+    fn event(
+        app_data: &mut D,
+        screencopy_frame: &ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1,
+        event: ext_image_copy_capture_frame_v1::Event,
+        udata: &U,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        let frame = &udata.screencopy_frame_data().frame;
+        match event {
+            ext_image_copy_capture_frame_v1::Event::Transform { transform } => {
+                frame.lock().unwrap().transform = transform;
+            }
+            ext_image_copy_capture_frame_v1::Event::Damage {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                frame.lock().unwrap().damage.push(Rect {
+                    x,
+                    y,
+                    width,
+                    height,
+                });
+            }
+            ext_image_copy_capture_frame_v1::Event::PresentationTime {
+                tv_sec_hi,
+                tv_sec_lo,
+                tv_nsec,
+            } => {
+                let secs = (u64::from(tv_sec_hi) << 32) + u64::from(tv_sec_lo);
+                let duration = Duration::new(secs, tv_nsec);
+                frame.lock().unwrap().present_time = Some(duration);
+            }
+            ext_image_copy_capture_frame_v1::Event::Ready => {
+                let frame = frame.lock().unwrap().clone();
+                app_data.ready(
+                    conn,
+                    qh,
+                    &CaptureFrame {
+                        frame: screencopy_frame.clone(),
+                    },
+                    frame,
+                );
+                screencopy_frame.destroy();
+            }
+            ext_image_copy_capture_frame_v1::Event::Failed { reason } => {
+                app_data.failed(
+                    conn,
+                    qh,
+                    &CaptureFrame {
+                        frame: screencopy_frame.clone(),
+                    },
+                    reason,
+                );
+                screencopy_frame.destroy();
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D, U>
+    Dispatch<ext_image_copy_capture_cursor_session_v1::ExtImageCopyCaptureCursorSessionV1, U, D>
+    for ScreencopyState
+where
+    D: Dispatch<ext_image_copy_capture_cursor_session_v1::ExtImageCopyCaptureCursorSessionV1, U>
+        + ScreencopyHandler,
+    U: ScreencopyCursorSessionDataExt,
+{
+    fn event(
+        app_data: &mut D,
+        _screencopy_cursor_session: &ext_image_copy_capture_cursor_session_v1::ExtImageCopyCaptureCursorSessionV1,
+        event: ext_image_copy_capture_cursor_session_v1::Event,
+        udata: &U,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            ext_image_copy_capture_cursor_session_v1::Event::Enter => {
+                if let Some(session) = udata
+                    .screencopy_cursor_session_data()
+                    .session
+                    .get()
+                    .unwrap()
+                    .upgrade()
+                    .map(CaptureCursorSession)
+                {
+                    app_data.cursor_enter(conn, qh, &session);
+                }
+            }
+            ext_image_copy_capture_cursor_session_v1::Event::Leave => {
+                if let Some(session) = udata
+                    .screencopy_cursor_session_data()
+                    .session
+                    .get()
+                    .unwrap()
+                    .upgrade()
+                    .map(CaptureCursorSession)
+                {
+                    app_data.cursor_leave(conn, qh, &session);
+                }
+            }
+            ext_image_copy_capture_cursor_session_v1::Event::Position { x, y } => {
+                if let Some(session) = udata
+                    .screencopy_cursor_session_data()
+                    .session
+                    .get()
+                    .unwrap()
+                    .upgrade()
+                    .map(CaptureCursorSession)
+                {
+                    app_data.cursor_position(conn, qh, &session, x, y);
+                }
+            }
+            ext_image_copy_capture_cursor_session_v1::Event::Hotspot { x, y } => {
+                if let Some(session) = udata
+                    .screencopy_cursor_session_data()
+                    .session
+                    .get()
+                    .unwrap()
+                    .upgrade()
+                    .map(CaptureCursorSession)
+                {
+                    app_data.cursor_hotspot(conn, qh, &session, x, y);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<ext_image_capture_source_v1::ExtImageCaptureSourceV1, GlobalData, D>
+    for ScreencopyState
+where
+    D: Dispatch<ext_image_capture_source_v1::ExtImageCaptureSourceV1, GlobalData>
+        + ScreencopyHandler,
+{
+    fn event(
+        _app_data: &mut D,
+        _source: &ext_image_capture_source_v1::ExtImageCaptureSourceV1,
+        _event: ext_image_capture_source_v1::Event,
+        _udata: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D>
+    Dispatch<
+        ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1,
+        GlobalData,
+        D,
+    > for ScreencopyState
+where
+    D: Dispatch<
+            ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1,
+            GlobalData,
+        > + ScreencopyHandler,
+{
+    fn event(
+        _app_data: &mut D,
+        _source: &ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1,
+        _event: ext_output_image_capture_source_manager_v1::Event,
+        _udata: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D>
+    Dispatch<
+        ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1,
+        GlobalData,
+        D,
+    > for ScreencopyState
+where
+    D: Dispatch<
+            ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1,
+            GlobalData,
+        > + ScreencopyHandler,
+{
+    fn event(
+        _app_data: &mut D,
+        _source: &ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1,
+        _event: ext_foreign_toplevel_image_capture_source_manager_v1::Event,
+        _udata: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D>
+    Dispatch<
+        zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1,
+        GlobalData,
+        D,
+    > for ScreencopyState
+where
+    D: Dispatch<
+            zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1,
+            GlobalData,
+        > + ScreencopyHandler,
+{
+    fn event(
+        _app_data: &mut D,
+        _source: &zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1,
+        _event: zcosmic_workspace_image_capture_source_manager_v1::Event,
+        _udata: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_screencopy {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::image_capture_source::v1::client::ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::image_capture_source::v1::client::ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::image_capture_source::v1::client::ext_image_capture_source_v1::ExtImageCaptureSourceV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1: $crate::GlobalData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!(@<$( $lt $( : $clt $(+ $dlt )* )? ),* SessionData: ($crate::screencopy::ScreencopySessionDataExt)> $ty: [
+            $crate::wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1: SessionData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!(@<$( $lt $( : $clt $(+ $dlt )* )? ),* FrameData: ($crate::screencopy::ScreencopyFrameDataExt)> $ty: [
+            $crate::wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1: FrameData
+        ] => $crate::screencopy::ScreencopyState);
+        $crate::wayland_client::delegate_dispatch!(@<$( $lt $( : $clt $(+ $dlt )* )? ),* CursorSessionData: ($crate::screencopy::ScreencopyCursorSessionDataExt)> $ty: [
+            $crate::wayland_protocols::ext::image_copy_capture::v1::client::ext_image_copy_capture_cursor_session_v1::ExtImageCopyCaptureCursorSessionV1: CursorSessionData
+        ] => $crate::screencopy::ScreencopyState);
+    };
+}

--- a/patches/cosmic-client-toolkit/src/screencopy/mod.rs
+++ b/patches/cosmic-client-toolkit/src/screencopy/mod.rs
@@ -1,0 +1,422 @@
+use cosmic_protocols::image_capture_source::v1::client::zcosmic_workspace_image_capture_source_manager_v1;
+use std::{
+    sync::{Arc, Mutex, OnceLock, Weak},
+    time::Duration,
+};
+use wayland_client::{
+    Connection, Dispatch, Proxy, QueueHandle, WEnum,
+    globals::GlobalList,
+    protocol::{wl_buffer, wl_output::Transform, wl_pointer, wl_shm},
+};
+use wayland_protocols::ext::{
+    image_capture_source::v1::client::{
+        ext_foreign_toplevel_image_capture_source_manager_v1, ext_image_capture_source_v1,
+        ext_output_image_capture_source_manager_v1,
+    },
+    image_copy_capture::v1::client::{
+        ext_image_copy_capture_cursor_session_v1, ext_image_copy_capture_frame_v1,
+        ext_image_copy_capture_manager_v1, ext_image_copy_capture_session_v1,
+    },
+};
+
+pub use ext_image_copy_capture_frame_v1::FailureReason;
+pub use ext_image_copy_capture_manager_v1::Options as CaptureOptions;
+
+use crate::GlobalData;
+
+mod capture_source;
+pub use capture_source::{CaptureSource, CaptureSourceError, CaptureSourceKind};
+mod dispatch;
+
+#[derive(Clone, Debug)]
+pub struct Rect {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Clone, Debug)]
+pub struct Frame {
+    pub transform: WEnum<Transform>,
+    pub damage: Vec<Rect>,
+    // XXX monotonic? Is this used elsewhere in wayland?
+    pub present_time: Option<Duration>,
+}
+
+impl Default for Frame {
+    fn default() -> Self {
+        Self {
+            transform: WEnum::Value(Transform::Normal),
+            damage: Vec::new(),
+            present_time: None,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct Formats {
+    pub buffer_size: (u32, u32),
+    pub shm_formats: Vec<wl_shm::Format>,
+    pub dmabuf_device: Option<libc::dev_t>,
+    pub dmabuf_formats: Vec<(u32, Vec<u64>)>,
+}
+
+#[derive(Debug)]
+struct CapturerInner {
+    image_copy_capture_manager: Option<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1>,
+    output_source_manager: Option<ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1>,
+    foreign_toplevel_source_manager: Option<ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1>,
+    workspace_source_manager: Option<zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1>,
+}
+
+impl Drop for CapturerInner {
+    fn drop(&mut self) {
+        if let Some(manager) = &self.image_copy_capture_manager {
+            manager.destroy();
+        }
+        if let Some(manager) = &self.output_source_manager {
+            manager.destroy();
+        }
+        if let Some(manager) = &self.foreign_toplevel_source_manager {
+            manager.destroy();
+        }
+        if let Some(manager) = &self.workspace_source_manager {
+            manager.destroy();
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Capturer(Arc<CapturerInner>);
+
+impl Capturer {
+    // TODO check supported capture types
+
+    pub fn create_session<D, U>(
+        &self,
+        source: &CaptureSource,
+        options: CaptureOptions,
+        qh: &QueueHandle<D>,
+        udata: U,
+    ) -> Result<CaptureSession, CaptureSourceError>
+    where
+        D: 'static,
+        D: Dispatch<ext_image_capture_source_v1::ExtImageCaptureSourceV1, GlobalData>,
+        D: Dispatch<ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1, U>,
+        U: ScreencopySessionDataExt + Send + Sync + 'static,
+    {
+        let source = source.create_source(self, qh)?;
+        Ok(CaptureSession(Arc::new_cyclic(|weak_session| {
+            udata
+                .screencopy_session_data()
+                .session
+                .set(weak_session.clone())
+                .unwrap();
+            CaptureSessionInner {
+                session: self
+                    .0
+                    .image_copy_capture_manager
+                    .as_ref()
+                    .expect("ext capture source with no image capture copy manager")
+                    .create_session(&source.0, options, qh, udata),
+            }
+        })))
+    }
+
+    pub fn create_cursor_session<D, U>(
+        &self,
+        source: &CaptureSource,
+        pointer: &wl_pointer::WlPointer,
+        qh: &QueueHandle<D>,
+        udata: U,
+    ) -> Result<CaptureCursorSession, CaptureSourceError>
+    where
+        D: 'static,
+        D: Dispatch<ext_image_capture_source_v1::ExtImageCaptureSourceV1, GlobalData>,
+        D: Dispatch<
+                ext_image_copy_capture_cursor_session_v1::ExtImageCopyCaptureCursorSessionV1,
+                U,
+            >,
+        U: ScreencopyCursorSessionDataExt + Send + Sync + 'static,
+    {
+        let source = source.create_source(self, qh)?;
+        Ok(CaptureCursorSession(Arc::new_cyclic(|weak_session| {
+            udata
+                .screencopy_cursor_session_data()
+                .session
+                .set(weak_session.clone())
+                .unwrap();
+            CaptureCursorSessionInner {
+                session: self
+                    .0
+                    .image_copy_capture_manager
+                    .as_ref()
+                    .expect("ext capture source with no image capture copy manager")
+                    .create_pointer_cursor_session(&source.0, pointer, qh, udata),
+            }
+        })))
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct CaptureSessionInner {
+    session: ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1,
+}
+
+impl Drop for CaptureSessionInner {
+    fn drop(&mut self) {
+        self.session.destroy();
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CaptureSession(Arc<CaptureSessionInner>);
+
+impl CaptureSession {
+    pub fn capture<D, U>(
+        &self,
+        buffer: &wl_buffer::WlBuffer,
+        buffer_damage: &[Rect],
+        qh: &QueueHandle<D>,
+        udata: U,
+    ) -> CaptureFrame
+    where
+        D: 'static,
+        D: Dispatch<ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1, U>,
+        U: ScreencopyFrameDataExt + Send + Sync + 'static,
+    {
+        udata
+            .screencopy_frame_data()
+            .session
+            .set(Arc::downgrade(&self.0))
+            .unwrap();
+        let frame = self.0.session.create_frame(qh, udata);
+        frame.attach_buffer(buffer);
+        for Rect {
+            x,
+            y,
+            width,
+            height,
+        } in buffer_damage
+        {
+            frame.damage_buffer(*x, *y, *width, *height);
+        }
+        frame.capture();
+        CaptureFrame { frame }
+    }
+
+    pub fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
+        self.0.session.data()
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CaptureFrame {
+    frame: ext_image_copy_capture_frame_v1::ExtImageCopyCaptureFrameV1,
+}
+
+impl CaptureFrame {
+    pub fn session<U: ScreencopyFrameDataExt + Send + Sync + 'static>(
+        &self,
+    ) -> Option<CaptureSession> {
+        Some(CaptureSession(
+            self.data::<U>()?
+                .screencopy_frame_data()
+                .session
+                .get()
+                .unwrap()
+                .upgrade()?,
+        ))
+    }
+
+    pub fn data<U: Send + Sync + 'static>(&self) -> Option<&U> {
+        self.frame.data()
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Hash)]
+struct CaptureCursorSessionInner {
+    session: ext_image_copy_capture_cursor_session_v1::ExtImageCopyCaptureCursorSessionV1,
+}
+
+impl Drop for CaptureCursorSessionInner {
+    fn drop(&mut self) {
+        self.session.destroy();
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct CaptureCursorSession(Arc<CaptureCursorSessionInner>);
+
+impl CaptureCursorSession {
+    pub fn capture_session<D, U>(
+        &self,
+        qh: &QueueHandle<D>,
+        udata: U,
+    ) -> Result<CaptureSession, CaptureSourceError>
+    where
+        D: 'static,
+        D: Dispatch<ext_image_capture_source_v1::ExtImageCaptureSourceV1, GlobalData>,
+        D: Dispatch<ext_image_copy_capture_session_v1::ExtImageCopyCaptureSessionV1, U>,
+        U: ScreencopySessionDataExt + Send + Sync + 'static,
+    {
+        Ok(CaptureSession(Arc::new_cyclic(|weak_session| {
+            udata
+                .screencopy_session_data()
+                .session
+                .set(weak_session.clone())
+                .unwrap();
+            CaptureSessionInner {
+                session: self.0.session.get_capture_session(qh, udata),
+            }
+        })))
+    }
+}
+
+#[derive(Debug)]
+pub struct ScreencopyState {
+    capturer: Capturer,
+}
+
+impl ScreencopyState {
+    pub fn new<D>(globals: &GlobalList, qh: &QueueHandle<D>) -> Self
+    where
+        D: 'static,
+        D: Dispatch<ext_image_copy_capture_manager_v1::ExtImageCopyCaptureManagerV1, GlobalData>,
+        D: Dispatch<ext_output_image_capture_source_manager_v1::ExtOutputImageCaptureSourceManagerV1, GlobalData>,
+        D: Dispatch<ext_foreign_toplevel_image_capture_source_manager_v1::ExtForeignToplevelImageCaptureSourceManagerV1, GlobalData>,
+        D: Dispatch<zcosmic_workspace_image_capture_source_manager_v1::ZcosmicWorkspaceImageCaptureSourceManagerV1, GlobalData>,
+    {
+        let image_copy_capture_manager = globals.bind(qh, 1..=1, GlobalData).ok();
+        let output_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
+        let foreign_toplevel_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
+        let workspace_source_manager = globals.bind(qh, 1..=1, GlobalData).ok();
+
+        let capturer = Capturer(Arc::new(CapturerInner {
+            image_copy_capture_manager,
+            output_source_manager,
+            foreign_toplevel_source_manager,
+            workspace_source_manager,
+        }));
+
+        Self { capturer }
+    }
+
+    pub fn capturer(&self) -> &Capturer {
+        &self.capturer
+    }
+}
+
+pub trait ScreencopyHandler: Sized {
+    fn screencopy_state(&mut self) -> &mut ScreencopyState;
+
+    fn init_done(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        session: &CaptureSession,
+        formats: &Formats,
+    );
+
+    fn stopped(&mut self, conn: &Connection, qh: &QueueHandle<Self>, session: &CaptureSession);
+
+    fn ready(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        screencopy_frame: &CaptureFrame,
+        frame: Frame,
+    );
+
+    fn failed(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        screencopy_frame: &CaptureFrame,
+        reason: WEnum<FailureReason>,
+    );
+
+    fn cursor_enter(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _cursor_session: &CaptureCursorSession,
+    ) {
+    }
+
+    fn cursor_leave(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _cursor_session: &CaptureCursorSession,
+    ) {
+    }
+
+    fn cursor_position(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _cursor_session: &CaptureCursorSession,
+        _x: i32,
+        _y: i32,
+    ) {
+    }
+
+    fn cursor_hotspot(
+        &mut self,
+        _conn: &Connection,
+        _qh: &QueueHandle<Self>,
+        _cursor_session: &CaptureCursorSession,
+        _x: i32,
+        _y: i32,
+    ) {
+    }
+}
+
+pub trait ScreencopySessionDataExt {
+    fn screencopy_session_data(&self) -> &ScreencopySessionData;
+}
+
+#[derive(Default)]
+pub struct ScreencopySessionData {
+    formats: Mutex<Formats>,
+    session: OnceLock<Weak<CaptureSessionInner>>,
+}
+
+impl ScreencopySessionDataExt for ScreencopySessionData {
+    fn screencopy_session_data(&self) -> &ScreencopySessionData {
+        self
+    }
+}
+
+#[derive(Default)]
+pub struct ScreencopyFrameData {
+    frame: Mutex<Frame>,
+    session: OnceLock<Weak<CaptureSessionInner>>,
+}
+
+pub trait ScreencopyFrameDataExt {
+    fn screencopy_frame_data(&self) -> &ScreencopyFrameData;
+}
+
+impl ScreencopyFrameDataExt for ScreencopyFrameData {
+    fn screencopy_frame_data(&self) -> &ScreencopyFrameData {
+        self
+    }
+}
+
+#[derive(Default)]
+pub struct ScreencopyCursorSessionData {
+    session: OnceLock<Weak<CaptureCursorSessionInner>>,
+}
+
+pub trait ScreencopyCursorSessionDataExt {
+    fn screencopy_cursor_session_data(&self) -> &ScreencopyCursorSessionData;
+}
+
+impl ScreencopyCursorSessionDataExt for ScreencopyCursorSessionData {
+    fn screencopy_cursor_session_data(&self) -> &ScreencopyCursorSessionData {
+        self
+    }
+}

--- a/patches/cosmic-client-toolkit/src/toplevel_info.rs
+++ b/patches/cosmic-client-toolkit/src/toplevel_info.rs
@@ -1,0 +1,443 @@
+use std::{
+    collections::{HashMap, HashSet},
+    sync::OnceLock,
+};
+
+use cosmic_protocols::toplevel_info::v1::client::{
+    zcosmic_toplevel_handle_v1, zcosmic_toplevel_info_v1,
+};
+use sctk::registry::RegistryState;
+use wayland_client::{Connection, Dispatch, Proxy, QueueHandle, Weak, protocol::wl_output};
+use wayland_protocols::ext::{
+    foreign_toplevel_list::v1::client::{
+        ext_foreign_toplevel_handle_v1, ext_foreign_toplevel_list_v1,
+    },
+    workspace::v1::client::ext_workspace_handle_v1,
+};
+
+use crate::GlobalData;
+
+#[derive(Clone, Debug, Default)]
+pub struct ToplevelGeometry {
+    pub x: i32,
+    pub y: i32,
+    pub width: i32,
+    pub height: i32,
+}
+
+#[derive(Clone, Debug)]
+pub struct ToplevelInfo {
+    pub title: String,
+    pub app_id: String,
+    pub identifier: String,
+    /// Requires zcosmic_toplevel_info_v1 version 2
+    pub state: HashSet<zcosmic_toplevel_handle_v1::State>,
+    /// Requires zcosmic_toplevel_info_v1 version 2
+    pub output: HashSet<wl_output::WlOutput>,
+    /// Requires zcosmic_toplevel_info_v1 version 2
+    pub geometry: HashMap<wl_output::WlOutput, ToplevelGeometry>,
+    /// Requires zcosmic_toplevel_info_v1 version 3
+    pub workspace: HashSet<ext_workspace_handle_v1::ExtWorkspaceHandleV1>,
+    /// Requires zcosmic_toplevel_info_v1 version 2
+    pub cosmic_toplevel: Option<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1>,
+    pub foreign_toplevel: ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+}
+
+#[derive(Debug)]
+struct ToplevelData {
+    current_info: Option<ToplevelInfo>,
+    pending_info: ToplevelInfo,
+    has_cosmic_info: bool,
+}
+
+impl ToplevelData {
+    fn new(foreign_toplevel: ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1) -> Self {
+        let pending_info = ToplevelInfo {
+            title: String::new(),
+            app_id: String::new(),
+            identifier: String::new(),
+            state: HashSet::new(),
+            output: HashSet::new(),
+            geometry: HashMap::new(),
+            workspace: HashSet::new(),
+            cosmic_toplevel: None,
+            foreign_toplevel,
+        };
+        Self {
+            current_info: None,
+            pending_info,
+            has_cosmic_info: false,
+        }
+    }
+
+    fn cosmic_toplevel(&self) -> Option<&zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1> {
+        self.pending_info.cosmic_toplevel.as_ref()
+    }
+
+    fn foreign_toplevel(&self) -> &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1 {
+        &self.pending_info.foreign_toplevel
+    }
+}
+
+#[doc(hidden)]
+#[derive(Default)]
+pub struct ToplevelUserData {
+    cosmic_toplevel: OnceLock<Option<Weak<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1>>>,
+}
+
+/// Handler for `ext-foreign-toplevel-list-v1`, and optionally
+/// `cosmic-toplevel-info-unstable-v1` which extends it with additional information.
+#[derive(Debug)]
+pub struct ToplevelInfoState {
+    pub foreign_toplevel_list: ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+    pub cosmic_toplevel_info: Option<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1>,
+    toplevels: Vec<ToplevelData>,
+}
+
+impl ToplevelInfoState {
+    pub fn try_new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Option<Self>
+    where
+        D: Dispatch<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, GlobalData>
+            + Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, GlobalData>
+            + 'static,
+    {
+        let foreign_toplevel_list = registry
+            .bind_one::<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, _, _>(
+                qh,
+                1..=1,
+                GlobalData,
+            )
+            .ok()?;
+        let cosmic_toplevel_info = registry
+            .bind_one::<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, _, _>(
+                qh,
+                2..=3,
+                GlobalData,
+            )
+            .ok();
+
+        Some(Self {
+            foreign_toplevel_list,
+            cosmic_toplevel_info,
+            toplevels: Vec::new(),
+        })
+    }
+
+    pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
+    where
+        D: Dispatch<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, GlobalData>
+            + Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, GlobalData>
+            + 'static,
+    {
+        Self::try_new(registry, qh).unwrap()
+    }
+
+    pub fn info(
+        &self,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    ) -> Option<&ToplevelInfo> {
+        self.toplevels
+            .iter()
+            .find(|data| data.foreign_toplevel() == toplevel)?
+            .current_info
+            .as_ref()
+    }
+
+    pub fn toplevels(&self) -> impl Iterator<Item = &ToplevelInfo> {
+        self.toplevels
+            .iter()
+            .filter_map(|data| data.current_info.as_ref())
+    }
+}
+
+pub trait ToplevelInfoHandler: Sized {
+    fn toplevel_info_state(&mut self) -> &mut ToplevelInfoState;
+
+    fn new_toplevel(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    );
+
+    fn update_toplevel(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    );
+
+    fn toplevel_closed(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        toplevel: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+    );
+
+    fn info_done(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {}
+
+    fn finished(&mut self, _conn: &Connection, _qh: &QueueHandle<Self>) {}
+}
+
+impl<D> Dispatch<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, GlobalData, D>
+    for ToplevelInfoState
+where
+    D: Dispatch<zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, GlobalData>
+        + Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, GlobalData>
+        + ToplevelInfoHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        _proxy: &zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1,
+        event: zcosmic_toplevel_info_v1::Event,
+        _: &GlobalData,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            zcosmic_toplevel_info_v1::Event::Done => {
+                state.info_done(conn, qh);
+            }
+            // Not used in protocol version 2
+            zcosmic_toplevel_info_v1::Event::Toplevel { .. }
+            | zcosmic_toplevel_info_v1::Event::Finished => {}
+            _ => unreachable!(),
+        }
+    }
+
+    wayland_client::event_created_child!(D, zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1, [
+        zcosmic_toplevel_info_v1::EVT_TOPLEVEL_OPCODE => (zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, GlobalData)
+    ]);
+}
+
+impl<D> Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, GlobalData, D>
+    for ToplevelInfoState
+where
+    D: Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, GlobalData>
+        + ToplevelInfoHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        toplevel: &zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1,
+        event: zcosmic_toplevel_handle_v1::Event,
+        _: &GlobalData,
+        _conn: &Connection,
+        _qh: &QueueHandle<D>,
+    ) {
+        let data = if let Some(data) = state
+            .toplevel_info_state()
+            .toplevels
+            .iter_mut()
+            .find(|data| data.cosmic_toplevel() == Some(toplevel))
+        {
+            data
+        } else {
+            // Gracefully handle race condition where event arrives for dead toplevel
+            // Using eprintln! as log crate is not available in this context
+            eprintln!("Warning: Received event for dead cosmic toplevel handle:");
+            eprintln!("  - Handle: {:?}", toplevel);
+            eprintln!("  - Event: {:?}", event);
+            eprintln!(
+                "  - Total toplevels tracked: {}",
+                state.toplevel_info_state().toplevels.len()
+            );
+            return;
+        };
+        match event {
+            zcosmic_toplevel_handle_v1::Event::OutputEnter { output } => {
+                data.pending_info.output.insert(output);
+            }
+            zcosmic_toplevel_handle_v1::Event::OutputLeave { output } => {
+                data.pending_info.output.remove(&output);
+                data.pending_info.geometry.remove(&output);
+            }
+            // Ignore legacy workspace handle events
+            zcosmic_toplevel_handle_v1::Event::WorkspaceEnter { .. }
+            | zcosmic_toplevel_handle_v1::Event::WorkspaceLeave { .. } => {}
+            zcosmic_toplevel_handle_v1::Event::ExtWorkspaceEnter { workspace } => {
+                data.pending_info.workspace.insert(workspace);
+            }
+            zcosmic_toplevel_handle_v1::Event::ExtWorkspaceLeave { workspace } => {
+                data.pending_info.workspace.remove(&workspace);
+            }
+            zcosmic_toplevel_handle_v1::Event::State { state } => {
+                data.has_cosmic_info = true;
+                data.pending_info.state.clear();
+                for value in state.chunks_exact(4) {
+                    if let Ok(state) = zcosmic_toplevel_handle_v1::State::try_from(
+                        u32::from_ne_bytes(value[0..4].try_into().unwrap()),
+                    ) {
+                        data.pending_info.state.insert(state);
+                    }
+                }
+            }
+            zcosmic_toplevel_handle_v1::Event::Geometry {
+                output,
+                x,
+                y,
+                width,
+                height,
+            } => {
+                data.pending_info.geometry.insert(
+                    output,
+                    ToplevelGeometry {
+                        x,
+                        y,
+                        width,
+                        height,
+                    },
+                );
+            }
+            // Not used in protocol version 2
+            zcosmic_toplevel_handle_v1::Event::AppId { .. }
+            | zcosmic_toplevel_handle_v1::Event::Title { .. }
+            | zcosmic_toplevel_handle_v1::Event::Done { .. }
+            | zcosmic_toplevel_handle_v1::Event::Closed { .. } => {}
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, GlobalData, D>
+    for ToplevelInfoState
+where
+    D: Dispatch<ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, GlobalData>
+        + Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ToplevelUserData>
+        + Dispatch<zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1, GlobalData>
+        + ToplevelInfoHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        proxy: &ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1,
+        event: ext_foreign_toplevel_list_v1::Event,
+        _: &GlobalData,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            ext_foreign_toplevel_list_v1::Event::Toplevel { toplevel } => {
+                let info_state = state.toplevel_info_state();
+                let mut toplevel_data = ToplevelData::new(toplevel.clone());
+                let cosmic_toplevel =
+                    info_state
+                        .cosmic_toplevel_info
+                        .as_ref()
+                        .map(|cosmic_toplevel_info| {
+                            cosmic_toplevel_info.get_cosmic_toplevel(&toplevel, qh, GlobalData)
+                        });
+                toplevel
+                    .data::<ToplevelUserData>()
+                    .unwrap()
+                    .cosmic_toplevel
+                    .set(cosmic_toplevel.as_ref().map(|t| t.downgrade()))
+                    .unwrap();
+                toplevel_data.pending_info.cosmic_toplevel = cosmic_toplevel;
+                info_state.toplevels.push(toplevel_data);
+            }
+            ext_foreign_toplevel_list_v1::Event::Finished => {
+                state.finished(conn, qh);
+                proxy.destroy();
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    wayland_client::event_created_child!(D, ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1, [
+        ext_foreign_toplevel_list_v1::EVT_TOPLEVEL_OPCODE => (ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, Default::default())
+    ]);
+}
+
+impl<D> Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ToplevelUserData, D>
+    for ToplevelInfoState
+where
+    D: Dispatch<ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1, ToplevelUserData>
+        + ToplevelInfoHandler,
+{
+    fn event(
+        state: &mut D,
+        handle: &ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1,
+        event: ext_foreign_toplevel_handle_v1::Event,
+        _data: &ToplevelUserData,
+        conn: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        let data = if let Some(data) = state
+            .toplevel_info_state()
+            .toplevels
+            .iter_mut()
+            .find(|data| data.foreign_toplevel() == handle)
+        {
+            data
+        } else {
+            // Gracefully handle race condition where event arrives for dead toplevel
+            // Using eprintln! as log crate is not available in this context
+            eprintln!("Warning: Received event for dead toplevel handle:");
+            eprintln!("  - Handle: {:?}", handle);
+            eprintln!("  - Event: {:?}", event);
+            eprintln!(
+                "  - Total toplevels tracked: {}",
+                state.toplevel_info_state().toplevels.len()
+            );
+            return;
+        };
+        match event {
+            ext_foreign_toplevel_handle_v1::Event::Closed => {
+                state.toplevel_closed(conn, qh, handle);
+
+                let toplevels = &mut state.toplevel_info_state().toplevels;
+                if let Some(idx) = toplevels
+                    .iter()
+                    .position(|data| data.foreign_toplevel() == handle)
+                {
+                    toplevels.remove(idx);
+                }
+            }
+            ext_foreign_toplevel_handle_v1::Event::Done => {
+                if data.cosmic_toplevel().is_some() && !data.has_cosmic_info {
+                    // Don't call `new_toplevel` if we have the `ext_foreign_toplevel_handle_v1`,
+                    // but don't have any `zcosmic_toplevel_handle_v1` events yet.
+                    return;
+                }
+
+                let is_new = data.current_info.is_none();
+                data.current_info = Some(data.pending_info.clone());
+                if is_new {
+                    state.new_toplevel(conn, qh, handle);
+                } else {
+                    state.update_toplevel(conn, qh, handle);
+                }
+            }
+            ext_foreign_toplevel_handle_v1::Event::Title { title } => {
+                data.pending_info.title = title;
+            }
+            ext_foreign_toplevel_handle_v1::Event::AppId { app_id } => {
+                data.pending_info.app_id = app_id;
+            }
+            ext_foreign_toplevel_handle_v1::Event::Identifier { identifier } => {
+                data.pending_info.identifier = identifier;
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_toplevel_info {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_info_v1::ZcosmicToplevelInfoV1: $crate::GlobalData
+        ] => $crate::toplevel_info::ToplevelInfoState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::toplevel_info::v1::client::zcosmic_toplevel_handle_v1::ZcosmicToplevelHandleV1: $crate::GlobalData
+        ] => $crate::toplevel_info::ToplevelInfoState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_list_v1::ExtForeignToplevelListV1: $crate::GlobalData
+        ] => $crate::toplevel_info::ToplevelInfoState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::foreign_toplevel_list::v1::client::ext_foreign_toplevel_handle_v1::ExtForeignToplevelHandleV1: $crate::toplevel_info::ToplevelUserData
+        ] => $crate::toplevel_info::ToplevelInfoState);
+    };
+}

--- a/patches/cosmic-client-toolkit/src/toplevel_management.rs
+++ b/patches/cosmic-client-toolkit/src/toplevel_management.rs
@@ -1,0 +1,84 @@
+use cosmic_protocols::toplevel_management::v1::client::zcosmic_toplevel_manager_v1;
+use sctk::registry::RegistryState;
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum};
+
+use crate::GlobalData;
+
+pub struct ToplevelManagerState {
+    pub manager: zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1,
+}
+
+impl ToplevelManagerState {
+    pub fn try_new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Option<Self>
+    where
+        D: Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, GlobalData> + 'static,
+    {
+        let manager = registry
+            .bind_one::<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, _, _>(
+                qh,
+                1..=4,
+                GlobalData,
+            )
+            .ok()?;
+
+        Some(Self { manager })
+    }
+
+    pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
+    where
+        D: Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, GlobalData> + 'static,
+    {
+        Self::try_new(registry, qh).unwrap()
+    }
+}
+
+impl<D> Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, GlobalData, D>
+    for ToplevelManagerState
+where
+    D: Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, GlobalData>
+        + Dispatch<zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1, GlobalData>
+        + ToplevelManagerHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        _proxy: &zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1,
+        event: <zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1 as wayland_client::Proxy>::Event,
+        _data: &GlobalData,
+        conn: &wayland_client::Connection,
+        qhandle: &QueueHandle<D>,
+    ) {
+        match event {
+            zcosmic_toplevel_manager_v1::Event::Capabilities { capabilities } => {
+                let capabilities = capabilities
+                    .chunks(4)
+                    .map(|chunk| WEnum::from(u32::from_ne_bytes(chunk.try_into().unwrap())))
+                    .collect();
+                state.capabilities(conn, qhandle, capabilities)
+            }
+            _ => unimplemented!(),
+        }
+    }
+}
+
+pub trait ToplevelManagerHandler: Sized {
+    fn toplevel_manager_state(&mut self) -> &mut ToplevelManagerState;
+
+    fn capabilities(
+        &mut self,
+        conn: &Connection,
+        qh: &QueueHandle<Self>,
+        capabilities: Vec<
+            WEnum<zcosmic_toplevel_manager_v1::ZcosmicToplelevelManagementCapabilitiesV1>,
+        >,
+    );
+}
+
+#[macro_export]
+macro_rules! delegate_toplevel_manager {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::toplevel_management::v1::client::zcosmic_toplevel_manager_v1::ZcosmicToplevelManagerV1: $crate::GlobalData
+        ] => $crate::toplevel_management::ToplevelManagerState);
+    };
+}

--- a/patches/cosmic-client-toolkit/src/workspace.rs
+++ b/patches/cosmic-client-toolkit/src/workspace.rs
@@ -1,0 +1,441 @@
+use cosmic_protocols::workspace::v2::client::{
+    zcosmic_workspace_handle_v2, zcosmic_workspace_manager_v2,
+};
+use sctk::registry::{GlobalProxy, RegistryState};
+use std::collections::HashSet;
+use wayland_client::{Connection, Dispatch, QueueHandle, WEnum, protocol::wl_output};
+use wayland_protocols::ext::workspace::v1::client::{
+    ext_workspace_group_handle_v1, ext_workspace_handle_v1, ext_workspace_manager_v1,
+};
+
+use crate::GlobalData;
+
+#[derive(Clone, Debug)]
+pub struct WorkspaceGroup {
+    pub handle: ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    pub capabilities: ext_workspace_group_handle_v1::GroupCapabilities,
+    pub outputs: Vec<wl_output::WlOutput>,
+    pub workspaces: HashSet<ext_workspace_handle_v1::ExtWorkspaceHandleV1>,
+}
+
+#[derive(Debug)]
+struct WorkspaceGroupData {
+    handle: ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    current: Option<WorkspaceGroup>,
+    pending: Option<WorkspaceGroup>,
+}
+
+impl WorkspaceGroupData {
+    fn pending(&mut self) -> &mut WorkspaceGroup {
+        if self.pending.is_none() {
+            self.pending = Some(self.current.clone().unwrap_or(WorkspaceGroup {
+                handle: self.handle.clone(),
+                capabilities: ext_workspace_group_handle_v1::GroupCapabilities::empty(),
+                outputs: Vec::new(),
+                workspaces: HashSet::new(),
+            }));
+        }
+        self.pending.as_mut().unwrap()
+    }
+
+    fn commit_pending(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            self.current = Some(pending);
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct Workspace {
+    pub handle: ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    pub cosmic_handle: Option<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2>,
+    pub name: String,
+    pub coordinates: Vec<u32>,
+    pub state: ext_workspace_handle_v1::State,
+    pub cosmic_state: zcosmic_workspace_handle_v2::State,
+    pub capabilities: ext_workspace_handle_v1::WorkspaceCapabilities,
+    pub cosmic_capabilities: zcosmic_workspace_handle_v2::WorkspaceCapabilities,
+    pub tiling: Option<WEnum<zcosmic_workspace_handle_v2::TilingState>>,
+    pub id: Option<String>,
+}
+
+#[derive(Debug)]
+struct WorkspaceData {
+    handle: ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    cosmic_handle: Option<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2>,
+    current: Option<Workspace>,
+    pending: Option<Workspace>,
+    has_cosmic_info: bool,
+}
+
+impl WorkspaceData {
+    fn pending(&mut self) -> &mut Workspace {
+        if self.pending.is_none() {
+            self.pending = Some(self.current.clone().unwrap_or(Workspace {
+                handle: self.handle.clone(),
+                cosmic_handle: self.cosmic_handle.clone(),
+                name: String::new(),
+                coordinates: Vec::new(),
+                state: ext_workspace_handle_v1::State::empty(),
+                cosmic_state: zcosmic_workspace_handle_v2::State::empty(),
+                capabilities: ext_workspace_handle_v1::WorkspaceCapabilities::empty(),
+                cosmic_capabilities: zcosmic_workspace_handle_v2::WorkspaceCapabilities::empty(),
+                tiling: None,
+                id: None,
+            }));
+        }
+        self.pending.as_mut().unwrap()
+    }
+
+    fn commit_pending(&mut self) {
+        if let Some(pending) = self.pending.take() {
+            self.current = Some(pending);
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct WorkspaceState {
+    workspace_groups: Vec<WorkspaceGroupData>,
+    workspaces: Vec<WorkspaceData>,
+    manager: GlobalProxy<ext_workspace_manager_v1::ExtWorkspaceManagerV1>,
+    cosmic_manager: GlobalProxy<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2>,
+}
+
+impl WorkspaceState {
+    pub fn new<D>(registry: &RegistryState, qh: &QueueHandle<D>) -> Self
+    where
+        D: Dispatch<ext_workspace_manager_v1::ExtWorkspaceManagerV1, GlobalData>
+            + Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, GlobalData>
+            + 'static,
+    {
+        Self {
+            workspace_groups: Vec::new(),
+            workspaces: Vec::new(),
+            manager: GlobalProxy::from(registry.bind_one(qh, 1..=1, GlobalData)),
+            cosmic_manager: GlobalProxy::from(registry.bind_one(qh, 1..=2, GlobalData)),
+        }
+    }
+
+    pub fn workspace_manager(
+        &self,
+    ) -> &GlobalProxy<ext_workspace_manager_v1::ExtWorkspaceManagerV1> {
+        &self.manager
+    }
+
+    pub fn workspace_groups(&self) -> impl Iterator<Item = &WorkspaceGroup> {
+        self.workspace_groups
+            .iter()
+            .filter_map(|data| data.current.as_ref())
+    }
+
+    pub fn workspace_group_info(
+        &self,
+        handle: &ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+    ) -> Option<&WorkspaceGroup> {
+        self.workspace_groups
+            .iter()
+            .find(|g| g.handle == *handle)?
+            .current
+            .as_ref()
+    }
+
+    pub fn workspaces(&self) -> impl Iterator<Item = &Workspace> {
+        self.workspaces
+            .iter()
+            .filter_map(|data| data.current.as_ref())
+    }
+
+    pub fn workspace_info(
+        &self,
+        handle: &ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+    ) -> Option<&Workspace> {
+        self.workspaces
+            .iter()
+            .find(|g| g.handle == *handle)?
+            .current
+            .as_ref()
+    }
+}
+
+pub trait WorkspaceHandler {
+    fn workspace_state(&mut self) -> &mut WorkspaceState;
+
+    // TODO: Added/remove/update methods? How to do that with groups and workspaces?
+    fn done(&mut self);
+}
+
+impl<D> Dispatch<ext_workspace_manager_v1::ExtWorkspaceManagerV1, GlobalData, D> for WorkspaceState
+where
+    D: Dispatch<ext_workspace_manager_v1::ExtWorkspaceManagerV1, GlobalData>
+        + Dispatch<ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData>
+        + Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData>
+        + Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, GlobalData>
+        + WorkspaceHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        _: &ext_workspace_manager_v1::ExtWorkspaceManagerV1,
+        event: ext_workspace_manager_v1::Event,
+        _: &GlobalData,
+        _: &Connection,
+        qh: &QueueHandle<D>,
+    ) {
+        match event {
+            ext_workspace_manager_v1::Event::WorkspaceGroup { workspace_group } => {
+                state
+                    .workspace_state()
+                    .workspace_groups
+                    .push(WorkspaceGroupData {
+                        handle: workspace_group,
+                        current: None,
+                        pending: None,
+                    });
+            }
+            ext_workspace_manager_v1::Event::Workspace { workspace } => {
+                let cosmic_handle =
+                    state
+                        .workspace_state()
+                        .cosmic_manager
+                        .get()
+                        .ok()
+                        .map(|cosmic_manager| {
+                            cosmic_manager.get_cosmic_workspace(&workspace, qh, GlobalData)
+                        });
+                state.workspace_state().workspaces.push(WorkspaceData {
+                    handle: workspace,
+                    cosmic_handle,
+                    current: None,
+                    pending: None,
+                    has_cosmic_info: false,
+                });
+            }
+            ext_workspace_manager_v1::Event::Done => {
+                // If any workspace doesn't have cosmic info yet, we should wait for the
+                // server to send, it instead of providing incomplete data.
+                // Ignore this `done`, and wait for the one sent after the cosmic info.
+                if state.workspace_state().cosmic_manager.get().is_ok()
+                    && state
+                        .workspace_state()
+                        .workspaces
+                        .iter()
+                        .any(|w| !w.has_cosmic_info)
+                {
+                    return;
+                }
+                for data in &mut state.workspace_state().workspace_groups {
+                    data.commit_pending();
+                }
+                for data in &mut state.workspace_state().workspaces {
+                    data.commit_pending();
+                }
+                state.done();
+            }
+            ext_workspace_manager_v1::Event::Finished => {}
+            _ => unreachable!(),
+        }
+    }
+
+    wayland_client::event_created_child!(D, ext_workspace_manager_v1::ExtWorkspaceManagerV1, [
+        ext_workspace_manager_v1::EVT_WORKSPACE_GROUP_OPCODE => (ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData),
+        ext_workspace_manager_v1::EVT_WORKSPACE_OPCODE => (ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData)
+    ]);
+}
+
+impl<D> Dispatch<ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData, D>
+    for WorkspaceState
+where
+    D: Dispatch<ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1, GlobalData>
+        + Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData>
+        + WorkspaceHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        handle: &ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1,
+        event: ext_workspace_group_handle_v1::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        let group = &mut state
+            .workspace_state()
+            .workspace_groups
+            .iter_mut()
+            .find(|group| &group.handle == handle)
+            .unwrap();
+        match event {
+            ext_workspace_group_handle_v1::Event::Capabilities { capabilities } => {
+                group.pending().capabilities = bitflags_retained(capabilities);
+            }
+            ext_workspace_group_handle_v1::Event::OutputEnter { output } => {
+                group.pending().outputs.push(output);
+            }
+            ext_workspace_group_handle_v1::Event::OutputLeave { output } => {
+                let pending = group.pending();
+                if let Some(idx) = pending.outputs.iter().position(|x| x == &output) {
+                    pending.outputs.remove(idx);
+                }
+            }
+            ext_workspace_group_handle_v1::Event::WorkspaceEnter { workspace } => {
+                group.pending().workspaces.insert(workspace);
+            }
+            ext_workspace_group_handle_v1::Event::WorkspaceLeave { workspace } => {
+                group.pending().workspaces.remove(&workspace);
+            }
+            ext_workspace_group_handle_v1::Event::Removed => {
+                if let Some(idx) = state
+                    .workspace_state()
+                    .workspace_groups
+                    .iter()
+                    .position(|group| &group.handle == handle)
+                {
+                    state.workspace_state().workspace_groups.remove(idx);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData, D> for WorkspaceState
+where
+    D: Dispatch<ext_workspace_handle_v1::ExtWorkspaceHandleV1, GlobalData> + WorkspaceHandler,
+{
+    fn event(
+        state: &mut D,
+        handle: &ext_workspace_handle_v1::ExtWorkspaceHandleV1,
+        event: ext_workspace_handle_v1::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        let workspace = state
+            .workspace_state()
+            .workspaces
+            .iter_mut()
+            .find(|w| &w.handle == handle)
+            .unwrap();
+        match event {
+            ext_workspace_handle_v1::Event::Name { name } => {
+                workspace.pending().name = name;
+            }
+            ext_workspace_handle_v1::Event::Coordinates { coordinates } => {
+                workspace.pending().coordinates = coordinates
+                    .chunks(4)
+                    .map(|chunk| u32::from_ne_bytes(chunk.try_into().unwrap()))
+                    .collect();
+            }
+            ext_workspace_handle_v1::Event::State { state } => {
+                workspace.pending().state = bitflags_retained(state);
+            }
+            ext_workspace_handle_v1::Event::Capabilities { capabilities } => {
+                workspace.pending().capabilities = bitflags_retained(capabilities);
+            }
+            ext_workspace_handle_v1::Event::Id { id } => {
+                workspace.pending().id = Some(id);
+            }
+            ext_workspace_handle_v1::Event::Removed => {
+                // Protocol guarantees it will already have been removed from group,
+                // so no need to do that here.
+
+                if let Some(idx) = state
+                    .workspace_state()
+                    .workspaces
+                    .iter()
+                    .position(|w| &w.handle == handle)
+                {
+                    state.workspace_state().workspaces.remove(idx);
+                }
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl<D> Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, GlobalData, D>
+    for WorkspaceState
+where
+    D: Dispatch<zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2, GlobalData>
+        + WorkspaceHandler
+        + 'static,
+{
+    fn event(
+        _: &mut D,
+        _: &zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2,
+        _: zcosmic_workspace_manager_v2::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        unreachable!()
+    }
+}
+
+impl<D> Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, GlobalData, D>
+    for WorkspaceState
+where
+    D: Dispatch<zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2, GlobalData>
+        + WorkspaceHandler
+        + 'static,
+{
+    fn event(
+        state: &mut D,
+        handle: &zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2,
+        event: zcosmic_workspace_handle_v2::Event,
+        _: &GlobalData,
+        _: &Connection,
+        _: &QueueHandle<D>,
+    ) {
+        let workspace = state
+            .workspace_state()
+            .workspaces
+            .iter_mut()
+            .find(|w| w.cosmic_handle.as_ref() == Some(&handle))
+            .unwrap();
+        match event {
+            zcosmic_workspace_handle_v2::Event::Capabilities { capabilities } => {
+                workspace.pending().cosmic_capabilities = bitflags_retained(capabilities);
+                workspace.has_cosmic_info = true;
+            }
+            zcosmic_workspace_handle_v2::Event::TilingState { state } => {
+                workspace.pending().tiling = Some(state);
+            }
+            zcosmic_workspace_handle_v2::Event::State { state } => {
+                workspace.pending().cosmic_state = bitflags_retained(state);
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+// Convert bitflags `WEnum` to bitflag type, retaining unrecognized bits
+fn bitflags_retained<T: bitflags::Flags<Bits = u32>>(flags: WEnum<T>) -> T {
+    match flags {
+        WEnum::Value(value) => value,
+        WEnum::Unknown(value) => T::from_bits_retain(value),
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_workspace {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty: ty) => {
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::workspace::v1::client::ext_workspace_manager_v1::ExtWorkspaceManagerV1: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::workspace::v1::client::ext_workspace_group_handle_v1::ExtWorkspaceGroupHandleV1: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::wayland_protocols::ext::workspace::v1::client::ext_workspace_handle_v1::ExtWorkspaceHandleV1: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_manager_v2::ZcosmicWorkspaceManagerV2: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+        $crate::wayland_client::delegate_dispatch!($(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+            $crate::cosmic_protocols::workspace::v2::client::zcosmic_workspace_handle_v2::ZcosmicWorkspaceHandleV2: $crate::GlobalData
+        ] => $crate::workspace::WorkspaceState);
+    };
+}


### PR DESCRIPTION
**JUST A TEST VERSION FOR NOW**

The application crashes with a thread 'main' panicked at 'Received event for dead toplevel' error. This occurs due to a race condition in the Wayland event loop within the cosmic-client-toolkit dependency.

 In Wayland, the event order is not always guaranteed across different handles. When a window is closed, the `ext_foreign_toplevel_handle_v1::Event::Closed` event removes the toplevel data from the internal state. 
 However, other events (like `Title`, `AppId`, or `OutputEnter`) for that same handle might already be in the event queue. 
When these delayed events are processed, the toolkit attempts to find the handle in its toplevels vector, fails, and calls `.expect()`, resulting in a crash.

Measures:
- Patch cosmic-client-toolkit to prevent panics when events arrive for destroyed toplevels
- Replace .expect() with graceful error handling and detailed stderr logging
- Add local patch configuration to Cargo.toml

Let's find some affected folks that can build and test that version and if it works, 
let's patch the forked version of you @MalpenZibo 

unfortunately the cargo patch needs all these files 
but the only change is in 
patches/cosmic-client-toolkit/src/toplevel_info.rs:229-247
patches/cosmic-client-toolkit/src/toplevel_info.rs:367-385


fixes #343 
https://github.com/MalpenZibo/ashell/issues/305
https://github.com/MalpenZibo/ashell/issues/178