### PR TITLE
deprecate AppLauncher and Clipboard modules

### DIFF
--- a/src/modules/app_launcher.rs
+++ b/src/modules/app_launcher.rs
@@ -9,6 +9,7 @@ pub enum Message {
     Launch,
 }
 
+#[deprecated]
 #[derive(Debug, Clone)]
 pub struct AppLauncher {
     command: String,

--- a/src/modules/clipboard.rs
+++ b/src/modules/clipboard.rs
@@ -9,6 +9,7 @@ pub enum Message {
     Launch,
 }
 
+#[deprecated]
 #[derive(Debug, Clone)]
 pub struct Clipboard {
     command: String,


### PR DESCRIPTION
The docs say Clipboard and AppLauncher are deprecated. 
So I marked them as deprecated in code.