### PR TITLE
Fix/network settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,6 @@ dependencies = [
  "libpulse-binding",
  "linicon-theme",
  "log",
- "natord",
  "niri-ipc",
  "parking_lot 0.12.5",
  "pin-project-lite",
@@ -3347,12 +3346,6 @@ dependencies = [
  "thiserror 1.0.69",
  "unicode-xid",
 ]
-
-[[package]]
-name = "natord"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "ndk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ rust-version = "1.88"
 [profile.release]
 lto = "thin"
 strip = true
-opt-level = 3 
+opt-level = 3
 panic = "abort"
 
 # The profile that 'dist' will build with
@@ -20,23 +20,12 @@ inherits = "release"
 
 [package.metadata.nfpm]
 provides = ["ashell"]
-depends = [
-  "libxkbcommon",
-  "dbus",
-]
+depends = ["libxkbcommon", "dbus"]
 
 [package.metadata.nfpm.deb]
-depends = [
-  "libwayland-client0",
-  "libpipewire-0.3-0t64",
-  "libpulse0",
-]
+depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 [package.metadata.nfpm.rpm]
-depends = [
-  "libwayland-client",
-  "pipewire-libs",
-  "pulseaudio-libs",
-]
+depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
 iced = { git = "https://github.com/MalpenZibo/iced", rev = "237116726a405b326bf6f61f2b9105b38a938490", features = [
@@ -48,7 +37,7 @@ iced = { git = "https://github.com/MalpenZibo/iced", rev = "237116726a405b326bf6
   "wayland",
   "image",
   "svg",
-  "canvas"
+  "canvas",
 ] }
 chrono = { version = "0.4", default-features = false, features = ["clock"] }
 hyprland = "0.4.0-beta.2"
@@ -80,7 +69,6 @@ inotify = "0.11.0"
 pin-project-lite = "0.2.16"
 niri-ipc = "25.11.0"
 parking_lot = "0.12.5"
-natord = "1.0.9"
 
 [build-dependencies]
 allsorts = "0.15"

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -601,10 +601,8 @@ impl NetworkSettings {
             })
             .collect();
 
-        // Sort naturally using natord crate
-        vpns.sort_by(|a, b| natord::compare(&a.name, &b.name));
+        vpns.sort_by_key(|a| a.name.clone());
 
-        // Map the sorted list to UI elements
         let vpn_list = Column::with_children(
             vpns.into_iter()
                 .map(|vpn| {


### PR DESCRIPTION
**Optimize network settings performance with HashMap lookups**
Replace O(n) iterations with O(1) HashMap/HashSet lookups for VPN and WiFi network matching. 
Refactor WiFi access point filtering to use partition for cleaner separation of active/inactive networks. 
Replace unnecessary clone() calls with to_string() and as_str() for better performance.

**Refactor network icon styling and add signal strength clamping**
Extract connectivity color logic and icon creation into separate functions to reduce code duplication. 
Add signal strength clamping to prevent out-of-bounds array access when signal values exceed 100. 
Fix typo in variable name (strengh -> strength). 
Add Debug and Clone derives to IndicatorState enum.


**Improve network connectivity indicator color logic**
Make the network indicator less aggressive by showing normal color for active connections with failed connectivity checks, unless signal strength is very weak. 
Only show red when there's no connectivity at all.

After suspend I had a red wifi icon, i ran 
`❯ nmcli -f connectivity general status`
which gave me `LIMITED` 
but everything was fine, I had full internet speed and 2.4GHz and 5.8GHz were available.
So let's show a red WIFI sign when we have no connection or so.

I ran some isolated benchmarks. 
Due to the hashmap we have a bit of overhead, so 10 VPNs are a bit slower but the use case in 
#370 with 200 VPNs is significantly faster 


 **WiFi Menu Partition Optimization**
| Networks | Old (ms) | New (ms) | Improvement | Time |
|----------|----------|----------|-------------|-------------|
| 10 | 4.992 | 3.507 | 1.42x | -1.485ms |
| 25 | 3.208 | 1.781 | 1.80x | -1.427ms |
| 50 | 2.743 | 1.645 | 1.67x | -1.097ms |
| 100 | 2.660 | 1.557 | 1.71x | -1.102ms |
| 200 | 5.135 | 3.101 | 1.66x | -2.034ms |

**VPN Lookup Optimization**
| VPNs/Active | Old (ms) | New (ms) | Improvement | Time |
|-------------|----------|----------|-------------|-------------|
| 10/2 | 2.140 | 3.643| 0.59x | +1.502ms |
| 25/5 | 4.868 | 3.688 | 1.32x | -1.180ms |
| 50/10 | 8.009 | 3.671 | 2.18x | -4.338ms |
| 100/20 | 15.464 | 3.625 | 4.27x | -11.839ms |
| 200/40 | 57.641 | 7.519 | 7.67x | -50.121ms |
