### PR TITLE
[Status: 1/2] Add format options for audio, network, and bluetooth indicators

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -268,10 +268,12 @@ pub enum SettingsIndicator {
 }
 
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]
-pub enum BatteryFormat {
+pub enum SettingsFormat {
     Icon,
+    #[serde(alias = "Value")]
     Percentage,
     #[default]
+    #[serde(alias = "IconAndValue")]
     IconAndPercentage,
     Time,
     IconAndTime,
@@ -293,9 +295,13 @@ pub struct SettingsModuleConfig {
     pub hibernate_cmd: String,
     pub reboot_cmd: String,
     pub logout_cmd: String,
-    pub battery_format: BatteryFormat,
+    pub battery_format: SettingsFormat,
     pub peripheral_indicators: PeripheralIndicators,
-    pub peripheral_battery_format: BatteryFormat,
+    pub peripheral_battery_format: SettingsFormat,
+    pub audio_indicator_format: SettingsFormat,
+    pub microphone_indicator_format: SettingsFormat,
+    pub network_indicator_format: SettingsFormat,
+    pub bluetooth_indicator_format: SettingsFormat,
     pub audio_sinks_more_cmd: Option<String>,
     pub audio_sources_more_cmd: Option<String>,
     pub wifi_more_cmd: Option<String>,
@@ -317,9 +323,13 @@ impl Default for SettingsModuleConfig {
             hibernate_cmd: "systemctl hibernate".to_string(),
             reboot_cmd: "systemctl reboot".to_string(),
             logout_cmd: "loginctl kill-user $(whoami)".to_string(),
-            battery_format: Default::default(),
+            battery_format: SettingsFormat::IconAndPercentage,
             peripheral_indicators: Default::default(),
-            peripheral_battery_format: BatteryFormat::Icon,
+            peripheral_battery_format: SettingsFormat::Icon,
+            audio_indicator_format: SettingsFormat::Icon,
+            microphone_indicator_format: SettingsFormat::Icon,
+            network_indicator_format: SettingsFormat::Icon,
+            bluetooth_indicator_format: SettingsFormat::Icon,
             audio_sinks_more_cmd: Default::default(),
             audio_sources_more_cmd: Default::default(),
             wifi_more_cmd: Default::default(),

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -103,15 +103,19 @@ impl Settings {
             audio: AudioSettings::new(AudioSettingsConfig::new(
                 config.audio_sinks_more_cmd,
                 config.audio_sources_more_cmd,
+                config.audio_indicator_format,
+                config.microphone_indicator_format,
             )),
             brightness: BrightnessSettings::new(),
             network: NetworkSettings::new(NetworkSettingsConfig::new(
                 config.wifi_more_cmd,
                 config.vpn_more_cmd,
                 config.remove_airplane_btn,
+                config.network_indicator_format,
             )),
             bluetooth: BluetoothSettings::new(BluetoothSettingsConfig::new(
                 config.bluetooth_more_cmd,
+                config.bluetooth_indicator_format,
             )),
             idle_inhibitor: if config.remove_idle_btn {
                 None
@@ -388,16 +392,22 @@ impl Settings {
                     .update(audio::Message::ConfigReloaded(AudioSettingsConfig::new(
                         config.audio_sinks_more_cmd,
                         config.audio_sources_more_cmd,
+                        config.audio_indicator_format,
+                        config.microphone_indicator_format,
                     )));
                 self.network.update(network::Message::ConfigReloaded(
                     NetworkSettingsConfig::new(
                         config.wifi_more_cmd,
                         config.vpn_more_cmd,
                         config.remove_airplane_btn,
+                        config.network_indicator_format,
                     ),
                 ));
                 self.bluetooth.update(bluetooth::Message::ConfigReloaded(
-                    BluetoothSettingsConfig::new(config.bluetooth_more_cmd),
+                    BluetoothSettingsConfig::new(
+                        config.bluetooth_more_cmd,
+                        config.bluetooth_indicator_format,
+                    ),
                 ));
                 if config.remove_idle_btn {
                     self.idle_inhibitor = None;
@@ -628,8 +638,10 @@ impl Settings {
                     }
                 }
                 SettingsIndicator::Audio => {
-                    if let Some(element) =
-                        self.audio.sink_indicator().map(|e| e.map(Message::Audio))
+                    if let Some(element) = self
+                        .audio
+                        .sink_indicator(theme)
+                        .map(|e| e.map(Message::Audio))
                     {
                         row = row.push(element);
                     }
@@ -662,8 +674,10 @@ impl Settings {
                     }
                 }
                 SettingsIndicator::Microphone => {
-                    if let Some(element) =
-                        self.audio.source_indicator().map(|e| e.map(Message::Audio))
+                    if let Some(element) = self
+                        .audio
+                        .source_indicator(theme)
+                        .map(|e| e.map(Message::Audio))
                     {
                         row = row.push(element);
                     }

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -2,7 +2,7 @@ use std::convert;
 
 use crate::{
     components::icons::{StaticIcon, icon},
-    config::{BatteryFormat, PeripheralIndicators},
+    config::{PeripheralIndicators, SettingsFormat},
     modules::settings::quick_setting_button,
     services::{
         ReadOnlyService, Service, ServiceEvent,
@@ -68,9 +68,9 @@ pub struct PowerSettingsConfig {
     pub reboot_cmd: String,
     pub shutdown_cmd: String,
     pub logout_cmd: String,
-    pub battery_format: BatteryFormat,
+    pub battery_format: SettingsFormat,
     pub peripheral_indicators: PeripheralIndicators,
-    pub peripheral_battery_format: BatteryFormat,
+    pub peripheral_battery_format: SettingsFormat,
 }
 
 impl PowerSettingsConfig {
@@ -81,9 +81,9 @@ impl PowerSettingsConfig {
         reboot_cmd: String,
         shutdown_cmd: String,
         logout_cmd: String,
-        battery_format: BatteryFormat,
+        battery_format: SettingsFormat,
         peripheral_indicators: PeripheralIndicators,
-        peripheral_battery_format: BatteryFormat,
+        peripheral_battery_format: SettingsFormat,
     ) -> Self {
         Self {
             suspend_cmd,
@@ -247,29 +247,29 @@ impl PowerSettings {
 
                                 Some(
                                     container(match self.config.peripheral_battery_format {
-                                        BatteryFormat::Icon => {
+                                        SettingsFormat::Icon => {
                                             convert::Into::<Element<'a, Message>>::into(icon(
                                                 p.get_icon_state(),
                                             ))
                                         }
-                                        BatteryFormat::Percentage => row!(
+                                        SettingsFormat::Percentage => row!(
                                             icon(p.kind.get_icon()),
                                             text(format!("{}%", p.data.capacity))
                                         )
                                         .spacing(ashell_theme.space.xxs)
                                         .align_y(Alignment::Center)
                                         .into(),
-                                        BatteryFormat::IconAndPercentage => row!(
+                                        SettingsFormat::IconAndPercentage => row!(
                                             icon(p.get_icon_state()),
                                             text(format!("{}%", p.data.capacity))
                                         )
                                         .spacing(ashell_theme.space.xxs)
                                         .align_y(Alignment::Center)
                                         .into(),
-                                        BatteryFormat::Time => {
+                                        SettingsFormat::Time => {
                                             text(format_time_for_battery(&p.data)).into()
                                         }
-                                        BatteryFormat::IconAndTime => row!(
+                                        SettingsFormat::IconAndTime => row!(
                                             icon(p.get_icon_state()),
                                             text(format_time_for_battery(&p.data))
                                         )
@@ -314,19 +314,19 @@ impl PowerSettings {
                 let state = battery.get_indicator_state();
 
                 container(match self.config.battery_format {
-                    BatteryFormat::Icon => icon(battery.get_icon()).into(),
-                    BatteryFormat::Percentage => convert::Into::<Element<'a, Message>>::into(text(
-                        format!("{}%", battery.capacity),
-                    )),
-                    BatteryFormat::IconAndPercentage => row!(
+                    SettingsFormat::Icon => icon(battery.get_icon()).into(),
+                    SettingsFormat::Percentage => convert::Into::<Element<'a, Message>>::into(
+                        text(format!("{}%", battery.capacity)),
+                    ),
+                    SettingsFormat::IconAndPercentage => row!(
                         icon(battery.get_icon()),
                         text(format!("{}%", battery.capacity))
                     )
                     .spacing(ashell_theme.space.xxs)
                     .align_y(Alignment::Center)
                     .into(),
-                    BatteryFormat::Time => text(format_time_for_battery(&battery)).into(),
-                    BatteryFormat::IconAndTime => row!(
+                    SettingsFormat::Time => text(format_time_for_battery(&battery)).into(),
+                    SettingsFormat::IconAndTime => row!(
                         icon(battery.get_icon()),
                         text(format_time_for_battery(&battery))
                     )

--- a/src/services/bluetooth/dbus.rs
+++ b/src/services/bluetooth/dbus.rs
@@ -203,7 +203,7 @@ pub trait Adapter {
 }
 
 #[proxy(default_service = "org.bluez", interface = "org.bluez.Device1")]
-trait Device {
+pub trait Device {
     #[zbus(property)]
     fn alias(&self) -> zbus::Result<String>;
 

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -63,6 +63,18 @@ With the `remove_airplane_btn` option you can remove the airplane mode button.
 
 With the `remove_idle_btn` option you can remove the idle inhibitor button.
 
+## Indicator Format Options
+
+With the format options you can customize how different indicators are displayed in the status bar.
+
+All format options support the same values:
+
+- `Icon` - Show only the icon
+- `Percentage` (or `Value`) - Show only the numeric value (percentage, count, or strength)
+- `IconAndPercentage` (or `IconAndValue`) - Show both the icon and the numeric value (default)
+
+### Battery Format
+
 With the `battery_format` option you can customize the battery indicator format.
 
 The possible values are:
@@ -73,10 +85,10 @@ The possible values are:
 - `Time` - Show smart time display (time to full when charging, time to empty when discharging, "100%" when full)
 - `IconAndTime` - Show battery icon with smart time display
 
-In the same way it's possible to customize the peripheral battery indicator format.
-The possible values are the same as above, but you need to use
-the `peripheral_battery_format` option.
-The default value is `Icon`.
+```toml
+[settings]
+battery_format = "IconAndPercentage"
+```
 
 ### Battery Time Display Behavior
 
@@ -101,6 +113,13 @@ peripheral_battery_format = "IconAndTime"
 # Full: "100%" or "🔋 100%"
 ```
 
+### Peripheral Battery Format
+
+In the same way it's possible to customize the peripheral battery indicator format.
+The possible values are the same as above, but you need to use
+the `peripheral_battery_format` option.
+The default value is `Icon`.
+
 With the `peripheral_indicators` you can decide which peripheral battery indicators
 are shown in the status bar.
 
@@ -119,6 +138,56 @@ The possible values are:
 battery_format = "IconAndPercentage"
 peripheral_battery_format = "Icon"
 peripheral_indicators = { Specific = ["Gamepad", "Keyboard"] }
+audio_indicator_format = "Icon"
+microphone_indicator_format = "Icon"
+network_indicator_format = "Icon"
+bluetooth_indicator_format = "Icon"
+```
+
+### Audio Format
+
+With the `audio_indicator_format` option you can customize the audio volume indicator format.
+
+The default value is `Icon`.
+
+```toml
+[settings]
+audio_indicator_format = "IconAndPercentage"
+```
+
+### Microphone Format
+
+With the `microphone_indicator_format` option you can customize the microphone volume indicator format.
+
+The default value is `Icon`.
+
+```toml
+[settings]
+microphone_indicator_format = "IconAndPercentage"
+```
+
+### Network Format
+
+With the `network_indicator_format` option you can customize the network connection indicator format.
+For WiFi connections, this shows the signal strength as a percentage.
+
+The default value is `Icon`.
+
+```toml
+[settings]
+network_indicator_format = "IconAndPercentage"
+```
+
+### Bluetooth Format
+
+With the `bluetooth_indicator_format` option you can customize the bluetooth indicator format.
+When devices are connected, this shows the number of connected devices.
+
+The default value is `Icon`.
+
+```toml
+[settings]
+bluetooth_indicator_format = "IconAndValue"
 ```
 
 ## Status Bar Indicators
@@ -138,14 +207,14 @@ Available indicators are:
 - `Battery` - Shows the battery level and charging status
 - `PeripheralBattery` - Shows the peripheral battery status
 
-```toml
+````toml
 [settings]
 # Customize which indicators to show and their order
 indicators = ["Battery", "Bluetooth", "Network", "Audio", "Microphone"]
 
 # Default indicators (shown in this order):
 indicators = ["IdleInhibitor", "PowerProfile", "Audio", "Microphone", "Bluetooth", "Network", "Vpn", "Battery"]
-```
+
 
 ## Custom Buttons
 
@@ -211,7 +280,7 @@ name = "Terminal"
 icon = ""
 command = "alacritty"
 tooltip = "Open Terminal"
-```
+````
 
 ## Example
 


### PR DESCRIPTION
- Rename `BatteryFormat` enum to `SettingsFormat` for broader use
- Add serde aliases for backward compatibility (Value, IconAndValue)
- Add format configuration for audio, network, and bluetooth indicators
- Implement format rendering (Icon, Percentage, IconAndPercentage) for:
  - Audio volume indicator with scroll support
  - Network connectivity with signal strength
  - Bluetooth number of connected devices
  
  
<img width="311" height="31" alt="image" src="https://github.com/user-attachments/assets/750fcf5b-e7de-4bc2-9d96-15c39bfea5c7" />
