### PR TITLE
feat: Add support for optional disk name in indicator configuration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -189,16 +189,25 @@ impl Default for SystemInfoDisk {
     }
 }
 
-#[derive(Deserialize, Clone, Debug)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+pub struct SystemInfoDiskIndicatorConfig {
+    #[serde(rename = "Disk")]
+    pub path: String,
+    #[serde(rename = "Name")]
+    pub name: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
 pub enum SystemInfoIndicator {
     Cpu,
     Memory,
     MemorySwap,
     Temperature,
-    Disk(String),
     IpAddress,
     DownloadSpeed,
     UploadSpeed,
+    #[serde(untagged)]
+    Disk(SystemInfoDiskIndicatorConfig),
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -385,9 +385,9 @@ impl SystemInfo {
                     None,
                 )
             }),
-            SystemInfoIndicator::Disk(mount) => {
+            SystemInfoIndicator::Disk(config) => {
                 self.data.disks.iter().find_map(|(disk_mount, disk)| {
-                    if disk_mount == mount {
+                    if disk_mount == &config.path {
                         Some(Self::indicator_info_element(
                             theme,
                             StaticIcon::Drive,
@@ -397,7 +397,7 @@ impl SystemInfo {
                                 self.config.disk.warn_threshold,
                                 self.config.disk.alert_threshold,
                             )),
-                            Some(disk_mount),
+                            Some(config.name.as_deref().unwrap_or(disk_mount)),
                         ))
                     } else {
                         None

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -47,8 +47,8 @@ To enable this indicator, add `MemorySwap` to the `indicators` configuration.
 
 The Disk indicator displays the disk space usage for a specific path.
 
-To enable this indicator, add `{ Disk = "path" }` to the `indicators` configuration,
-where `path` is the path to the disk you want to monitor.
+To enable this indicator, add `{ Disk = "path" }` or `{ Disk = "path", Name = "label" }` to the `indicators` configuration,
+where `path` is the path to the disk you want to monitor and `label` is an optional name to display for the disk.
 
 #### Example
 
@@ -57,6 +57,13 @@ To monitor the home directory disk space, you can add the following to your conf
 ```toml
 [system_info]
 indicators = [ { Disk = "/home" } ]
+```
+
+Or if you want to display the directory disk space with an optional name, for example `bob` instead of its full path:
+
+```toml
+[system_info]
+indicators = [ { Disk = "/my/long/path/to/mount/called/bob", Name = "bob" } ]
 ```
 
 ### IpAddress


### PR DESCRIPTION
Implemented issue: #400 

Possiblity to add custom labels, while being backwards compatible.

Now I can have it show:
<img width="314" height="28" alt="image" src="https://github.com/user-attachments/assets/34e20233-e489-499b-8219-d95a6c5daddd" />

instead of:
<img width="776" height="27" alt="image" src="https://github.com/user-attachments/assets/7bfed167-514f-48d6-8fda-5381d02841ee" />

using configuration:
```diff
[system_info]
indicators = [
    { Disk = "/" },
-   { Disk = "/home/kazie/media/abyss" },
+   { Disk = "/home/kazie/media/abyss", Name="🕳" },
-   { Disk = "/home/kazie/media/space" },
+   { Disk = "/home/kazie/media/space", Name="👾" },
-   { Disk = "/home/kazie/media/fennec" },
+   { Disk = "/home/kazie/media/fennec", Name="🦊" },
    "DownloadSpeed", "Temperature" ,"Cpu", "Memory"
]
```