### PR TITLE
Fix WiFi Network Detection When No Networks Available at Startup

### DIFF
--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -293,11 +293,13 @@ impl NetworkDbus<'_> {
             })
             .boxed();
 
-        // Set up access point change listeners on wireless devices
-        let mut ac_changes = Vec::with_capacity(devices.len());
-        for device_path in devices.iter() {
-            let dp = WirelessDeviceProxy::builder(conn)
-                .path(device_path.clone())?
+        // When devices list change I need to update the wireless device state changes
+        let wireless_ac = nm.wireless_access_points().await?;
+
+        let mut device_state_changes = Vec::with_capacity(wireless_ac.len());
+        for ac in wireless_ac.iter() {
+            let dp = DeviceProxy::builder(conn)
+                .path(ac.device_path.clone())?
                 .build()
                 .await?;
 
@@ -323,11 +325,11 @@ impl NetworkDbus<'_> {
             );
         }
 
-        // When devices list change I need to update the access points changes
-        let mut ac_changes = Vec::with_capacity(wireless_ac.len());
-        for ac in wireless_ac.iter() {
+        // Set up access point change listeners on wireless devices
+        let mut ac_changes = Vec::with_capacity(devices.len());
+        for device_path in devices.iter() {
             let dp = WirelessDeviceProxy::builder(conn)
-                .path(ac.device_path.clone())?
+                .path(device_path.clone())?
                 .build()
                 .await?;
 


### PR DESCRIPTION
**Problem:** The nearby WiFi list wasn't updating when networks became available after startup if none were present initially. Event listeners for access point changes were only created for access points existing at initialization, resulting in an empty listener list when starting with no nearby networks.

**Solution:** Attach access point change listeners to wireless devices instead of individual access points. This ensures listeners are active even when the network list is initially empty, allowing new networks to be properly detected and displayed.

**Changes:** Modified `subscribe_events()` in `src/services/network/dbus.rs` to iterate over wireless devices rather than access points when setting up the `ac_changes` event listeners.