### PR TITLE
Refactor WindowTitle module to simplify view rendering

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -260,14 +260,12 @@ impl App {
                     .map(Message::Workspaces),
                 None,
             )),
-            ModuleName::WindowTitle => self.window_title.get_value().map(|title| {
-                (
-                    self.window_title
-                        .view(&self.theme, title)
-                        .map(Message::WindowTitle),
-                    None,
-                )
-            }),
+            ModuleName::WindowTitle => Some((
+                self.window_title
+                    .view(&self.theme)
+                    .map(Message::WindowTitle),
+                None,
+            )),
             ModuleName::SystemInfo => Some((
                 self.system_info.view(&self.theme).map(Message::SystemInfo),
                 Some(OnModulePress::ToggleMenu(MenuType::SystemInfo)),

--- a/src/modules/window_title.rs
+++ b/src/modules/window_title.rs
@@ -69,11 +69,8 @@ impl WindowTitle {
         }
     }
 
-    pub fn get_value(&self) -> Option<String> {
-        self.value.clone()
-    }
-
-    pub fn view(&'_ self, theme: &AshellTheme, title: String) -> Element<'_, Message> {
+    pub fn view(&'_ self, theme: &AshellTheme) -> Element<'_, Message> {
+        let title = self.value.as_deref().unwrap_or("...");
         container(
             text(title)
                 .size(theme.font_size.sm)


### PR DESCRIPTION
Remove `get_value()` method and handle title display directly in `view()` method. 
The view now uses the internal value with a fallback to "..." when no title is available, 
eliminating the need for external value extraction.