### PR TITLE
Update window_title module documentation 

### DIFF
--- a/website/docs/configuration/modules/window_title.md
+++ b/website/docs/configuration/modules/window_title.md
@@ -4,22 +4,47 @@ sidebar_position: 5
 
 # Window Title
 
-Displays the title of the currently focused window.
+Displays the title of the currently focused window in your status bar.
 
-Using the `mode` field, you can configure what information to show:
+## What It Shows
 
-- `Title`: the window title, which is the default
-- `Class`: the window class
+Using the `mode` field, you can choose what information to display:
 
-You can also configure the maximum title length, after which the title will be  
-truncated, using the `truncate_title_after_length` field.
+- `Title`: The window's title text (default)
+- `Class`: The application name or class
 
-The default value is 150 characters.
+## Title Length Control
 
-## Example
+The `truncate_title_after_length` field limits how long the displayed title can be:
+
+- **Set to a number** (e.g., 75): Cuts off long titles at that length
+- **Set to 0**: Shows the full title without any limit
+- **Default**: 150 characters
+
+When titles are too long, they're shortened to show the beginning and end with "..." in between, so you can still see both the app name and part of the title.
+
+## Examples
+
+**Show window titles, but cut them off at 75 characters:**
 
 ```toml
 [window_title]
 mode = "Title"
 truncate_title_after_length = 75
+```
+
+**Show application names instead of titles:**
+
+```toml
+[window_title]
+mode = "Class"
+truncate_title_after_length = 50
+```
+
+**Show full titles without any length limit:**
+
+```toml
+[window_title]
+mode = "Title"
+truncate_title_after_length = 0
 ```


### PR DESCRIPTION
Enhance the window_title documentation with clearer explanations of the mode options, 
better description of truncation behavior including the 0 value for unlimited length, 
and add multiple practical configuration examples.