### PR TITLE
Add SIGUSR1 signal handling for visibility toggle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,6 +335,7 @@ dependencies = [
  "iced",
  "inotify",
  "itertools 0.14.0",
+ "libc",
  "libpulse-binding",
  "linicon-theme",
  "log",
@@ -349,6 +350,8 @@ dependencies = [
  "serde_json",
  "serde_with",
  "shellexpand",
+ "signal-hook",
+ "signal-hook-tokio",
  "sysinfo",
  "tokio",
  "tokio-stream",
@@ -3178,9 +3181,9 @@ checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -4606,7 +4609,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5083,7 +5086,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5318,6 +5321,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "signal-hook"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5325,6 +5338,18 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signal-hook-tokio"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e513e435a8898a0002270f29d0a708b7879708fb5c4d00e46983ca2d2d378cf0"
+dependencies = [
+ "futures-core",
+ "libc",
+ "signal-hook",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,10 @@ iced = { git = "https://github.com/MalpenZibo/iced", rev = "daccb115c0827bd67fb1
   "svg",
   "canvas",
 ] }
-chrono = { version = "0.4", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4", default-features = false, features = [
+  "clock",
+  "serde",
+] }
 hyprland = "0.4.0-beta.2"
 serde = { version = "1.0", default-features = false, features = [] }
 sysinfo = "0.37"
@@ -61,17 +64,30 @@ linicon-theme = "1.2.0"
 once_cell = "1.18.0"
 serde_json = "1"
 regex = "1.12.2"
-serde_with = { version = "3.12", default-features = false, features = ["macros"] }
+serde_with = { version = "3.12", default-features = false, features = [
+  "macros",
+] }
 tokio-stream = { version = "0.1", default-features = false }
 uuid = { version = "1", default-features = false, features = ["v4"] }
-clap = { version = "4.5", default-features = false, features = ["std", "derive"] }
+clap = { version = "4.5", default-features = false, features = [
+  "std",
+  "derive",
+] }
 shellexpand = { version = "3", features = ["path"] }
-inotify = { version = "0.11.0", default-features = false, features = ["stream"] }
+inotify = { version = "0.11.0", default-features = false, features = [
+  "stream",
+] }
 pin-project-lite = "0.2.16"
 niri-ipc = "25.11.0"
 parking_lot = "0.12.5"
-reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
+reqwest = { version = "0.13", default-features = false, features = [
+  "json",
+  "rustls",
+] }
 url = "2.5.7"
+signal-hook = "0.4.3"
+signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
+libc = "0.2.182"
 
 [build-dependencies]
 allsorts = "0.15"

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -18,13 +18,13 @@ use crate::{
 };
 
 #[derive(Debug, Clone)]
-struct ShellInfo {
-    id: Id,
-    position: Position,
-    layer: config::Layer,
-    style: AppearanceStyle,
-    menu: Menu,
-    scale_factor: f64,
+pub struct ShellInfo {
+    pub id: Id,
+    pub position: Position,
+    pub layer: config::Layer,
+    pub style: AppearanceStyle,
+    pub menu: Menu,
+    pub scale_factor: f64,
 }
 
 #[derive(Debug, Clone)]
@@ -36,6 +36,9 @@ pub enum HasOutput<'a> {
 }
 
 impl Outputs {
+    pub fn iter(&self) -> std::slice::Iter<'_, (String, Option<ShellInfo>, Option<WlOutput>)> {
+        self.0.iter()
+    }
     pub fn new<Message: 'static>(
         style: AppearanceStyle,
         position: Position,
@@ -71,7 +74,7 @@ impl Outputs {
             * scale_factor
     }
 
-    fn create_output_layers<Message: 'static>(
+    pub fn create_output_layers<Message: 'static>(
         style: AppearanceStyle,
         wl_output: Option<WlOutput>,
         position: Position,


### PR DESCRIPTION
Adds support for toggling ashell bar visibility using `killall -SIGUSR1 ashell`, similar to how Waybar handles it.
 
Usage:
```bash
killall -SIGUSR1 ashell
```

closes https://github.com/MalpenZibo/ashell/issues/416