### PR TITLE
fix(tray): skip invalid tray items instead of failing entire service

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -407,6 +407,7 @@ impl App {
                 self.theme.bar_style,
                 &self.general_config.outputs,
                 self.theme.bar_position,
+                self.general_config.layer,
                 self.theme.scale_factor,
             ),
         }

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -771,32 +771,14 @@ fn quick_setting_button<'a, Msg: Clone + 'static, I: Icon>(
     with_submenu: Option<(SubMenu, Option<SubMenu>, Msg)>,
 ) -> Element<'a, Msg> {
     let main_content = row!(
-        container(icon(icon_type).size(theme.font_size.lg)).style(|theme: &Theme| {
-            container::Style {
-                text_color: Some(theme.palette().text),
-                ..Default::default()
-            }
-        }),
+        icon(icon_type).size(theme.font_size.lg),
         container(
             Column::new()
-                .push(
-                    container(text(title).size(theme.font_size.sm)).style(|theme: &Theme| {
-                        container::Style {
-                            text_color: Some(theme.palette().text),
-                            ..Default::default()
-                        }
-                    })
-                )
+                .push(text(title).size(theme.font_size.sm))
                 .push_maybe(subtitle.map(|s| {
-                    container(
-                        text(s)
-                            .wrapping(text::Wrapping::None)
-                            .size(theme.font_size.xs),
-                    )
-                    .style(|theme: &Theme| container::Style {
-                        text_color: Some(theme.palette().text),
-                        ..Default::default()
-                    })
+                    text(s)
+                        .wrapping(text::Wrapping::None)
+                        .size(theme.font_size.xs)
                 }))
                 .spacing(theme.space.xxs)
         )
@@ -822,7 +804,6 @@ fn quick_setting_button<'a, Msg: Clone + 'static, I: Icon>(
                 .on_press(msg)
                 .size(IconButtonSize::Small)
                 .style(theme.quick_settings_submenu_button_style(active))
-                .color(theme.get_theme().palette().text)
             }))
             .spacing(theme.space.xxs)
             .align_y(Alignment::Center)

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -391,17 +391,9 @@ impl Workspaces {
 
                             Some(
                                 button(
-                                    container(
-                                        container(text(w.name.as_str()).size(theme.font_size.xs))
-                                            .style(|theme: &iced::Theme| {
-                                                iced::widget::container::Style {
-                                                    text_color: Some(theme.palette().text),
-                                                    ..Default::default()
-                                                }
-                                            }),
-                                    )
-                                    .align_x(alignment::Horizontal::Center)
-                                    .align_y(alignment::Vertical::Center),
+                                    container(text(w.name.as_str()).size(theme.font_size.xs))
+                                        .align_x(alignment::Horizontal::Center)
+                                        .align_y(alignment::Vertical::Center),
                                 )
                                 .style(theme.workspace_button_style(empty, color))
                                 .padding(if w.id < 0 {

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -177,8 +177,12 @@ impl TrayService {
 
         let mut status_items = Vec::with_capacity(items.len());
         for item in items {
-            let item = StatusNotifierItem::new(conn, item).await?;
-            status_items.push(item);
+            match StatusNotifierItem::new(conn, item.clone()).await {
+                Ok(item) => status_items.push(item),
+                Err(err) => {
+                    error!("Failed to initialize tray item '{item}': {err}");
+                }
+            }
         }
 
         Ok(TrayData(status_items))

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -112,10 +112,7 @@ impl AshellTheme {
                 "local".to_string(),
                 Palette {
                     background: appearance.background_color.get_base(),
-                    text: appearance
-                        .text_color
-                        .get_text()
-                        .unwrap_or(appearance.text_color.get_base()),
+                    text: appearance.text_color.get_base(),
                     primary: appearance.primary_color.get_base(),
                     success: appearance.success_color.get_base(),
                     danger: appearance.danger_color.get_base(),


### PR DESCRIPTION
The tray service fails to initialize when any registered StatusNotifierItem has an invalid object path.
This causes the entire tray service to fail, preventing all tray icons from appearing.

for now invalid items are logged with their service name and error details and
the tray service initializes successfully even with some problematic items

related https://github.com/MalpenZibo/ashell/issues/427