### PR TITLE
Add git commit hash to version output

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ use std::error::Error;
 use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
+use std::process::Command;
 use std::str;
 
 use allsorts::binary::read::ReadScope;
@@ -17,6 +18,20 @@ use allsorts::unicode::VariationSelector;
 use allsorts::{subset, tag};
 
 pub fn main() -> Result<(), Box<dyn Error>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output();
+
+    match output {
+        Ok(output) if output.status.success() => {
+            let git_hash = String::from_utf8(output.stdout)?;
+            println!("cargo:rustc-env=GIT_HASH={}", git_hash.trim());
+        }
+        _ => {
+            println!("cargo:rustc-env=GIT_HASH=unknown");
+        }
+    }
+
     let source = "src/components/icons.rs";
     let input = "assets/SymbolsNerdFont-Regular.ttf";
     let input_mono = "assets/SymbolsNerdFontMono-Regular.ttf";

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,10 @@ const CUSTOM_FONT: &[u8] = include_bytes!("../assets/AshellCustomIcon-Regular.ot
 const HEIGHT: f64 = 34.;
 
 #[derive(Parser, Debug)]
-#[command(version, about, long_about = None)]
+#[command(
+    version = concat!(env!("CARGO_PKG_VERSION"), " (", env!("GIT_HASH"), ")"),
+    about = env!("CARGO_PKG_DESCRIPTION")
+)]
 struct Args {
     #[arg(short, long, value_parser = clap::value_parser!(PathBuf))]
     config_path: Option<PathBuf>,


### PR DESCRIPTION
adds the git hash of the build to the version string.
This is to better distinguish  between `ashell` and `ashell-git` package.

```
❯ ./target/debug/ashell -V
ashell 0.7.0 (6f10fe9)
```
