### PR TITLE
Add Time and IconAndTime battery format options

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -264,6 +264,8 @@ pub enum BatteryFormat {
     Percentage,
     #[default]
     IconAndPercentage,
+    Time,
+    IconAndTime,
 }
 
 #[derive(Deserialize, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -20,6 +20,28 @@ use iced::{
     widget::{Column, Row, button, column, container, horizontal_rule, row, text},
 };
 
+fn format_time_for_battery(battery: &BatteryData) -> String {
+    match battery.status {
+        BatteryStatus::Charging(duration) => {
+            if battery.capacity >= 100 || duration.is_zero() {
+                "100%".to_string()
+            } else {
+                format_duration(&duration)
+            }
+        }
+        BatteryStatus::Discharging(duration) => {
+            if battery.capacity >= 100 {
+                "100%".to_string()
+            } else if duration.is_zero() {
+                "Calculating...".to_string()
+            } else {
+                format_duration(&duration)
+            }
+        }
+        BatteryStatus::Full => "100%".to_string(),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(ServiceEvent<UPowerService>),
@@ -244,6 +266,16 @@ impl PowerSettings {
                                         .spacing(ashell_theme.space.xxs)
                                         .align_y(Alignment::Center)
                                         .into(),
+                                        BatteryFormat::Time => {
+                                            text(format_time_for_battery(&p.data)).into()
+                                        }
+                                        BatteryFormat::IconAndTime => row!(
+                                            icon(p.get_icon_state()),
+                                            text(format_time_for_battery(&p.data))
+                                        )
+                                        .spacing(ashell_theme.space.xxs)
+                                        .align_y(Alignment::Center)
+                                        .into(),
                                     })
                                     .style(
                                         move |theme: &Theme| container::Style {
@@ -289,6 +321,14 @@ impl PowerSettings {
                     BatteryFormat::IconAndPercentage => row!(
                         icon(battery.get_icon()),
                         text(format!("{}%", battery.capacity))
+                    )
+                    .spacing(ashell_theme.space.xxs)
+                    .align_y(Alignment::Center)
+                    .into(),
+                    BatteryFormat::Time => text(format_time_for_battery(&battery)).into(),
+                    BatteryFormat::IconAndTime => row!(
+                        icon(battery.get_icon()),
+                        text(format_time_for_battery(&battery))
                     )
                     .spacing(ashell_theme.space.xxs)
                     .align_y(Alignment::Center)

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -69,11 +69,36 @@ The possible values are:
 - `Icon` - Show only the battery icon
 - `Percentage` - Show only the battery percentage
 - `IconAndPercentage` - Show both the battery icon and percentage (default)
+- `Time` - Show smart time display (time to full when charging, time to empty when discharging, "100%" when full)
+- `IconAndTime` - Show battery icon with smart time display
 
 In the same way it's possible to customize the peripheral battery indicator format.
 The possible values are the same as above, but you need to use
 the `peripheral_battery_format` option.
 The default value is `Icon`.
+
+### Battery Time Display Behavior
+
+The `Time` and `IconAndTime` formats provide intelligent time display:
+
+- **When charging**: Shows time until full (e.g., "45m", "2h 15m")
+- **When discharging**: Shows time until empty (e.g., "1h 30m", "3h 45m")
+- **When at 100%**: Shows "100%"
+- **When calculating**: Shows "Calculating..." for system battery, empty for peripherals
+
+```toml
+[settings]
+# Show time only for system battery
+battery_format = "Time"
+
+# Show icon + time for peripheral batteries
+peripheral_battery_format = "IconAndTime"
+
+# Example outputs:
+# Charging: "45m" or "🔋 45m"
+# Discharging: "2h 15m" or "🔋 2h 15m"
+# Full: "100%" or "🔋 100%"
+```
 
 With the `peripheral_indicators` you can decide which peripheral battery indicators
 are shown in the status bar.
@@ -209,6 +234,10 @@ bluetooth_more_cmd = "blueman-manager"
 remove_airplane_btn = true
 remove_idle_btn = true
 indicators = ["Battery", "Bluetooth", "Network", "Audio"]
+
+battery_format = "IconAndTime"
+peripheral_battery_format = "Time"
+peripheral_indicators = "All"
 
 [[settings.CustomButton]]
 name = "Virtual Keyboard"


### PR DESCRIPTION
Add two new battery format variants (Time and IconAndTime) to display remaining charge/discharge time instead of percentage. Extract time formatting logic into format_time_for_battery helper function that handles charging, discharging, and full battery states. Show "Calculating..." when duration is zero during discharge, and display "100%" for full batteries or when charging is complete.