### PR TITLE
feat(updates): add configurable polling interval for update checks

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,14 @@ impl Default for Config {
 pub struct UpdatesModuleConfig {
     pub check_cmd: String,
     pub update_cmd: String,
+    #[serde(default = "UpdatesModuleConfig::default_interval")]
+    pub interval: u64,
+}
+
+impl UpdatesModuleConfig {
+    const fn default_interval() -> u64 {
+        3600
+    }
 }
 
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/modules/updates.rs
+++ b/src/modules/updates.rs
@@ -275,6 +275,7 @@ impl Updates {
 
     pub fn subscription(&self) -> Subscription<Message> {
         let check_cmd = self.config.check_cmd.clone();
+        let interval = Duration::from_secs(self.config.interval.max(60));
         let id = TypeId::of::<Self>();
 
         Subscription::run_with_id(
@@ -285,7 +286,7 @@ impl Updates {
 
                     let _ = output.try_send(Message::UpdatesCheckCompleted(updates));
 
-                    sleep(Duration::from_secs(3600)).await;
+                    sleep(interval).await;
                 }
             }),
         )

--- a/website/docs/configuration/modules/updates.md
+++ b/website/docs/configuration/modules/updates.md
@@ -15,7 +15,15 @@ Without this configuration, the module will not appear in the status bar.
 
 :::
 
-The module automatically checks for updates every hour. You can also manually check for updates using the "Check now" button in the menu.
+The module automatically checks for updates on a configurable interval (defaults to once per hour). You can also manually check for updates using the "Check now" button in the menu.
+
+### Configuration
+
+| Field        | Description                                                      |
+| ------------ | ---------------------------------------------------------------- |
+| `check_cmd`  | Command that outputs pending updates (one per line).             |
+| `update_cmd` | Command that launches your system updates workflow.              |
+| `interval`   | Optional polling interval in seconds (minimum 60, default 3600). |
 
 The check command should return a list of updates,
 one package per line in the following format:
@@ -39,4 +47,5 @@ AUR package manager and `alacritty` as a terminal emulator.
 [updates]
 check_cmd = "checkupdates; paru -Qua"
 update_cmd = 'alacritty -e bash -c "paru; echo Done - Press enter to exit; read" &'
+interval = 3600
 ```


### PR DESCRIPTION
Add an optional `interval` configuration field to the updates module to control how frequently the system checks for updates. 
The interval is specified in seconds with a minimum value of 60 and defaults to 3600 (1 hour). 
Update documentation to reflect the new configuration option.