### PR TITLE
AudioService improvements

### DIFF
--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -315,7 +315,6 @@ impl AudioSettings {
                     }
                 }
             })
-        // })
     }
 
     pub fn sliders<'a>(

--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -19,7 +19,7 @@ use libpulse_binding::{
     proplist::{Proplist, properties::APPLICATION_NAME},
     volume::ChannelVolumes,
 };
-use log::{debug, error, trace};
+use log::{debug, error, trace, warn};
 use std::{
     any::TypeId,
     cell::RefCell,
@@ -285,7 +285,7 @@ impl AudioService {
             if device.is_filter {
                 if device.ports.len() > 1 {
                     let device_name = device.name.as_str();
-                    error!("Unexpected multiple ports in a filter node: {device_name}")
+                    warn!("Unexpected multiple ports in a filter node: {device_name}")
                 }
                 Either::Left(std::iter::once(Route { device, port: None }))
             } else {


### PR DESCRIPTION
### [Smart Filters](https://pipewire.pages.freedesktop.org/wireplumber/policies/smart_filters.html) Support

Smart filters are virtual sources and sinks which provide ability to use system-wide audio effects like EQ, background noise cancellation, feedback prevention etc. Most of the time these filter nodes will have no ports [^1]. According to pipewire docs smart filters can be recognized by having their `node.link-group` property being set. This PR adds ability to select such filters as default audio route from ashell.

### Volume Slider Jitter

Currently we update volume slider twice per each user input:
1. The cached volume gets [scaled locally](https://github.com/MalpenZibo/ashell/blob/485ff80f3d471033f984784697c1a60863d9114e/src/services/audio.rs#L87)
2. Then we call `libpulse::(...)::set_source_volume` which causes sink list to be updated.

Since the second update can be slightly delayed (for BT headsets for example) - pulseaudio events can start arriving after the next local update, creating jittery appearance. 

The solution is to remove the local update and create a copy of channel volumes to send to pulse audio. This ensures a unidirectional data flow and keeps the libpulse as a single source of truth.

### `AudioService` Interface

Due to inherent complexity of selecting audio routes like multi-port or virtual sinks/sources - I've made the actual sink/source arrays private and exposed methods to access them in a coherent way. Removes some code duplication too.

### Preview

The top bar is `main` and the botton one is on this branch. Notice that the volume slider no longer "jumps around" and audio selectors are now working.

https://github.com/user-attachments/assets/0a06a7e2-8344-43ae-bdd2-10b481370733


[^1]: There is a single default port in case of blue-tooth headphones, where the filter is used for profile switching