### PR TITLE
adjust menu width based on weather data availability

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -107,11 +107,18 @@ impl Tempo {
     }
 
     pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+        let has_weather = self.weather_data.is_some() && self.location.is_some();
+        let width: Length = if has_weather {
+            MenuSize::XLarge.into()
+        } else {
+            Length::Shrink
+        };
+
         Row::new()
             .push(self.calendar(theme))
             .push_maybe(self.weather(theme))
             .spacing(theme.space.lg)
-            .width(MenuSize::XLarge)
+            .width(width)
             .into()
     }
 


### PR DESCRIPTION
@MalpenZibo

sorry missed that during review. 

<img width="688" height="394" alt="xdph_screenshot_160f82ef" src="https://github.com/user-attachments/assets/d5a8724d-9c13-4f47-bd33-298c3084970f" />
  
  
when there is no weather enabled we want to shrink the menu 
<img width="448" height="421" alt="xdph_screenshot_6a1f0409" src="https://github.com/user-attachments/assets/d0142ef2-e492-4bd2-b033-deaa6e30e8f9" />
