### PR TITLE
fix playback state

### DIFF
--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -11,7 +11,7 @@ use iced::{
     stream::channel,
 };
 use log::{debug, error, info};
-use std::{any::TypeId, collections::HashMap, fmt::Display, ops::Deref, sync::Arc};
+use std::{any::TypeId, collections::HashMap, fmt::Display, ops::Deref};
 use zbus::{fdo::DBusProxy, zvariant::OwnedValue};
 
 mod dbus;


### PR DESCRIPTION
Sorry for my english

You've already got changed state from dbus so there is no need to compare value with previous state. Also strings below did not work as you expected
```rust
let volume = s.volume;
```
```rust
let state = s.state;
```
These strings run once and do not change variable's value