### PR TITLE
implement simple custom background option for menus

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -538,6 +538,7 @@ impl App {
                     if let Some(updates) = self.updates.as_ref() {
                         self.menu_wrapper(
                             id,
+                            &self.theme,
                             updates.menu_view(id, &self.theme).map(Message::Updates),
                             *button_ui_ref,
                         )
@@ -547,11 +548,13 @@ impl App {
                 }
                 Some((MenuType::Tray(name), button_ui_ref)) => self.menu_wrapper(
                     id,
+                    &self.theme,
                     self.tray.menu_view(&self.theme, name).map(Message::Tray),
                     *button_ui_ref,
                 ),
                 Some((MenuType::Settings, button_ui_ref)) => self.menu_wrapper(
                     id,
+                    &self.theme,
                     self.settings
                         .menu_view(id, &self.theme, self.theme.bar_position)
                         .map(Message::Settings),
@@ -559,6 +562,7 @@ impl App {
                 ),
                 Some((MenuType::MediaPlayer, button_ui_ref)) => self.menu_wrapper(
                     id,
+                    &self.theme,
                     self.media_player
                         .menu_view(&self.theme)
                         .map(Message::MediaPlayer),
@@ -566,6 +570,7 @@ impl App {
                 ),
                 Some((MenuType::SystemInfo, button_ui_ref)) => self.menu_wrapper(
                     id,
+                    &self.theme,
                     self.system_info
                         .menu_view(&self.theme)
                         .map(Message::SystemInfo),
@@ -574,6 +579,7 @@ impl App {
 
                 Some((MenuType::Tempo, button_ui_ref)) => self.menu_wrapper(
                     id,
+                    &self.theme,
                     self.tempo.menu_view(&self.theme).map(Message::Tempo),
                     *button_ui_ref,
                 ),

--- a/src/config.rs
+++ b/src/config.rs
@@ -507,11 +507,22 @@ pub enum AppearanceStyle {
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]
+pub enum MenuBackground {
+    Background,
+    Primary,
+    Secondary,
+    Success,
+    Danger,
+    Custom(AppearanceColor),
+}
+
+#[derive(Deserialize, Clone, Copy, Debug)]
 #[serde(default)]
 pub struct MenuAppearance {
     #[serde(deserialize_with = "opacity_deserializer")]
     pub opacity: f32,
     pub backdrop: f32,
+    pub background: Option<MenuBackground>,
 }
 
 impl Default for MenuAppearance {
@@ -519,6 +530,7 @@ impl Default for MenuAppearance {
         Self {
             opacity: default_opacity(),
             backdrop: f32::default(),
+            background: None,
         }
     }
 }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -1,6 +1,6 @@
 use crate::app::{self, App};
 use crate::config::{AppearanceStyle, Position};
-use crate::theme::backdrop_color;
+use crate::theme::{AshellTheme, backdrop_color};
 use crate::widgets::{self, ButtonUIRef};
 use iced::alignment::Vertical;
 use iced::platform_specific::shell::commands::layer_surface::{
@@ -146,21 +146,20 @@ impl App {
     pub fn menu_wrapper<'a>(
         &'a self,
         id: Id,
+        theme: &'a AshellTheme,
         content: Element<'a, app::Message>,
         button_ui_ref: ButtonUIRef,
     ) -> Element<'a, app::Message> {
+        let menu_bg = theme.menu_background;
         widgets::MenuWrapper::new(
             button_ui_ref.position.x,
             container(content)
                 .padding(self.theme.space.md)
                 .style(move |theme: &Theme| Style {
-                    background: Some(
-                        theme
-                            .palette()
-                            .background
-                            .scale_alpha(self.theme.menu.opacity)
-                            .into(),
-                    ),
+                    background: menu_bg
+                        .map(|mb| mb.base.color)
+                        .or(Some(theme.palette().background))
+                        .map(|color| color.scale_alpha(self.theme.menu.opacity).into()),
                     border: Border {
                         color: theme
                             .extended_palette()

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,4 +1,6 @@
-use crate::config::{Appearance, AppearanceColor, AppearanceStyle, MenuAppearance, Position};
+use crate::config::{
+    Appearance, AppearanceColor, AppearanceStyle, MenuAppearance, MenuBackground, Position,
+};
 use iced::{
     Background, Border, Color, Theme,
     theme::{Palette, palette},
@@ -90,6 +92,7 @@ pub struct AshellTheme {
     pub bar_style: AppearanceStyle,
     pub opacity: f32,
     pub menu: MenuAppearance,
+    pub menu_background: Option<palette::Background>,
     pub workspace_colors: Vec<AppearanceColor>,
     pub special_workspace_colors: Option<Vec<AppearanceColor>>,
     pub scale_factor: f64,
@@ -105,6 +108,31 @@ impl AshellTheme {
             bar_style: appearance.style,
             opacity: appearance.opacity,
             menu: appearance.menu,
+            menu_background: appearance.menu.background.as_ref().map(|menu| {
+                let color = match menu {
+                    MenuBackground::Background => &appearance.background_color,
+                    MenuBackground::Primary => &appearance.primary_color,
+                    MenuBackground::Secondary => &appearance.secondary_color,
+                    MenuBackground::Success => &appearance.success_color,
+                    MenuBackground::Danger => &appearance.danger_color,
+                    MenuBackground::Custom(color) => color,
+                };
+                let default_text = appearance.text_color.get_base();
+                let default_menu = palette::Background::new(
+                    color.get_base(),
+                    color.get_text().unwrap_or(default_text),
+                );
+                palette::Background {
+                    base: default_menu.base,
+                    weak: color
+                        .get_weak_pair(default_text)
+                        .unwrap_or(default_menu.weak),
+                    strong: appearance
+                        .background_color
+                        .get_strong_pair(default_text)
+                        .unwrap_or(default_menu.strong),
+                }
+            }),
             workspace_colors: appearance.workspace_colors.clone(),
             special_workspace_colors: appearance.special_workspace_colors.clone(),
             scale_factor: appearance.scale_factor,

--- a/website/docs/configuration/appearance/index.md
+++ b/website/docs/configuration/appearance/index.md
@@ -14,4 +14,4 @@ You can customize things like:
 - The scaling factor of the status bar
 - The style of the status bar
 - The opacity of the status bar components
-- The opacity of the status bar menus
+- The opacity and background colour of the status bar menus

--- a/website/docs/configuration/appearance/palette.md
+++ b/website/docs/configuration/appearance/palette.md
@@ -57,6 +57,27 @@ If `special_workspace_colors` is not defined, `workspace_colors` will be used.
 If neither `workspace_colors` is defined nor a color exists
 for a given monitor, the `primary_color` will be used.
 
+## Menu Background
+
+Using `appearance.menu.background`, it is possible to set the background
+colour for the status bar menus.
+
+This can be set to one of `Background`, `Primary`, `Secondary`, `Success`
+or `Danger` to use one of the palette colors specified (see above), or to
+`Custom = "#hex code"` to use a fully custom background.
+
+Example:
+
+```toml
+[appearance.menu]
+background.Custom = "#36363aff"
+
+# or
+
+[appearance.menu]
+background = "Primary"
+```
+
 ## Complete Examples
 
 For complete theme examples with full palette configurations, see the [Theme documentation](./theme.md). These examples show popular color schemes like Catppuccin Mocha, Tokyo Night, and Nord with all colors configured.


### PR DESCRIPTION
as per the title.

for my specific usecase, this allows me to style the top bar exactly like the one in GNOME - solid black bar, drop-down menus in grey/gtk colour. it remains backwards comspatible by using an Option and falling back to `background_color` if menu_background was not set in config.

I'm open for criticism or input/design suggestions, but also open to just getting a "no" (in which case I'd just maintain a downstream fork for this :)