### PR TITLE
reduce unnecessary allocations

### DIFF
--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use iced::{
     Alignment, Border, Color, Element, Length, Subscription,
-    widget::{Row, container, row},
+    widget::{Row, container},
     window::Id,
 };
 
@@ -49,7 +49,7 @@ impl App {
             &self.general_config.modules.right,
         ]
         .map(|modules_def| {
-            let mut row = row!()
+            let mut row = Row::with_capacity(modules_def.len())
                 .height(Length::Shrink)
                 .align_y(Alignment::Center)
                 .spacing(self.theme.space.xxs);

--- a/src/modules/privacy.rs
+++ b/src/modules/privacy.rs
@@ -41,7 +41,7 @@ impl Privacy {
         {
             Some(
                 container(
-                    Row::new()
+                    Row::with_capacity(3)
                         .push_maybe(
                             service
                                 .screenshare_access()

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -436,7 +436,7 @@ impl AudioSettings {
         volume_changed: &'a dyn Fn(i32) -> Message,
         with_submenu: Option<(Option<SubMenu>, Message)>,
     ) -> Element<'a, Message> {
-        Row::new()
+        Row::with_capacity(3)
             .push(
                 MouseArea::new(
                     icon_button(

--- a/src/modules/settings/bluetooth.rs
+++ b/src/modules/settings/bluetooth.rs
@@ -236,7 +236,7 @@ impl BluetoothSettings {
             let some_known = known_devices.peek().is_some();
             let some_available = available_devices.peek().is_some();
 
-            Column::new()
+            Column::with_capacity(6)
                 .push(
                     row![
                         text("Bluetooth Devices").width(Length::Fill),
@@ -267,7 +267,7 @@ impl BluetoothSettings {
                 .push_maybe(if some_known {
                     let known_device_entry = |d: &BluetoothDevice| {
                         button(
-                            Row::new()
+                            Row::with_capacity(3)
                                 .push(
                                     text(d.name.clone())
                                         .color_maybe(if d.connected {

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -23,9 +23,7 @@ use crate::{
 };
 use iced::{
     Alignment, Background, Border, Element, Length, Padding, Subscription, Task, Theme,
-    widget::{
-        Column, MouseArea, Row, Space, button, column, container, horizontal_space, row, text,
-    },
+    widget::{Column, MouseArea, Row, Space, button, container, horizontal_space, row, text},
     window::Id,
 };
 
@@ -495,7 +493,7 @@ impl Settings {
                 .power
                 .battery_menu_indicator(theme)
                 .map(|e| e.map(Message::Power));
-            let right_buttons = Row::new()
+            let right_buttons = Row::with_capacity(2)
                 .push_maybe(
                     self.lock_cmd
                         .as_ref()
@@ -514,7 +512,7 @@ impl Settings {
                 )
                 .spacing(theme.space.xs);
 
-            let header = Row::new()
+            let header = Row::with_capacity(3)
                 .push_maybe(battery_data)
                 .push(Space::with_width(Length::Fill))
                 .push(right_buttons)
@@ -617,7 +615,7 @@ impl Settings {
                 Position::Bottom => (None, source_slider.map(|e| e.map(Message::Audio))),
             };
 
-            Column::new()
+            Column::with_capacity(11)
                 .push(header)
                 .push_maybe(
                     self.sub_menu
@@ -671,7 +669,7 @@ impl Settings {
     }
 
     pub fn view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let mut row = Row::new();
+        let mut row = Row::with_capacity(self.indicators.len());
 
         for indicator in &self.indicators {
             match indicator {
@@ -794,7 +792,10 @@ fn quick_settings_section<'a>(
     theme: &'a AshellTheme,
     buttons: Vec<(Element<'a, Message>, Option<Element<'a, Message>>)>,
 ) -> Element<'a, Message> {
-    let mut section = column!().spacing(theme.space.xs);
+    // TODO trying to read this function gives me a headache; there's surely
+    // a better way to do this, maybe with Iterator::chunks or something?
+    // I might be way off though, I still don't fully understand how this works.
+    let mut section = Column::with_capacity(buttons.len() * 3).spacing(theme.space.xs);
 
     let mut before: Option<(Element<'a, Message>, Option<Element<'a, Message>>)> = None;
 
@@ -873,7 +874,7 @@ fn quick_setting_button<'a, Msg: Clone + 'static, I: Icon>(
     let main_content = row!(
         icon(icon_type).size(theme.font_size.lg),
         container(
-            Column::new()
+            Column::with_capacity(2)
                 .push(text(title).size(theme.font_size.sm))
                 .push_maybe(subtitle.map(|s| {
                     text(s)
@@ -890,7 +891,7 @@ fn quick_setting_button<'a, Msg: Clone + 'static, I: Icon>(
     .align_y(Alignment::Center);
 
     let btn = button(
-        Row::new()
+        Row::with_capacity(2)
             .push(main_content)
             .push_maybe(with_submenu.map(|(menu_type, submenu, msg)| {
                 icon_button(

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -207,13 +207,14 @@ impl PowerSettings {
                         .peripherals
                         .iter()
                         .map(|p| {
-                            Row::new()
-                                .push(icon(p.kind.get_icon()))
-                                .push(text(p.name.to_string()).width(Length::Fill))
-                                .push(self.menu_indicator(theme, p.data, None))
-                                .align_y(Vertical::Center)
-                                .spacing(theme.space.sm)
-                                .into()
+                            row![
+                                icon(p.kind.get_icon()),
+                                text(p.name.to_string()).width(Length::Fill),
+                                self.menu_indicator(theme, p.data, None),
+                            ]
+                            .align_y(Vertical::Center)
+                            .spacing(theme.space.sm)
+                            .into()
                         })
                         .collect::<Vec<Element<Message>>>(),
                 )
@@ -236,7 +237,7 @@ impl PowerSettings {
                         })
                 })
                 .map(|service| {
-                    let mut row = Row::new()
+                    let mut row = Row::with_capacity(service.peripherals.len())
                         .spacing(ashell_theme.space.xxs)
                         .align_y(Alignment::Center);
 
@@ -357,7 +358,7 @@ impl PowerSettings {
 
         container({
             let battery_info = container(
-                Row::new()
+                Row::with_capacity(3)
                     .push_maybe(peripheral_icon.map(icon))
                     .push(icon(battery.get_icon()))
                     .push(text(format!("{}%", battery.capacity)))

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -258,7 +258,7 @@ impl SystemInfo {
             column!(
                 text("System Info").size(theme.font_size.lg),
                 horizontal_rule(1),
-                Column::new()
+                Column::with_capacity(6)
                     .push(Self::info_element(
                         theme,
                         StaticIcon::Cpu,

--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -179,7 +179,7 @@ impl Tempo {
                 .unwrap_or_else(|| self.date.format(format).to_string())
         };
 
-        Row::new()
+        Row::with_capacity(2)
             .push_maybe(self.weather_indicator(theme))
             .push(text(display_text))
             .align_y(Vertical::Center)
@@ -204,7 +204,7 @@ impl Tempo {
 
     pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
         container(
-            Row::new()
+            Row::with_capacity(2)
                 .push(self.calendar(theme))
                 .push_maybe(self.weather(theme))
                 .spacing(theme.space.lg),
@@ -237,53 +237,49 @@ impl Tempo {
             6
         };
 
-        let calendar = Column::new()
-            .push(
-                row!(
-                    button(icon(StaticIcon::LeftChevron))
-                        .on_press(Message::ChangeSelectDate(
-                            selected_date.checked_sub_months(Months::new(1)),
-                        ))
-                        .padding([theme.space.xs, theme.space.md])
-                        .style(theme.settings_button_style()),
-                    text(selected_date.format("%B").to_string())
-                        .size(theme.font_size.md)
+        let calendar = column![
+            row![
+                button(icon(StaticIcon::LeftChevron))
+                    .on_press(Message::ChangeSelectDate(
+                        selected_date.checked_sub_months(Months::new(1)),
+                    ))
+                    .padding([theme.space.xs, theme.space.md])
+                    .style(theme.settings_button_style()),
+                text(selected_date.format("%B").to_string())
+                    .size(theme.font_size.md)
+                    .width(Length::Fill)
+                    .align_x(Horizontal::Center),
+                button(icon(StaticIcon::RightChevron))
+                    .on_press(Message::ChangeSelectDate(
+                        selected_date.checked_add_months(Months::new(1))
+                    ))
+                    .padding([theme.space.xs, theme.space.md])
+                    .style(theme.settings_button_style())
+            ]
+            .width(Length::Fill)
+            .align_y(Vertical::Center),
+            Row::with_children(
+                [
+                    Weekday::Mon,
+                    Weekday::Tue,
+                    Weekday::Wed,
+                    Weekday::Thu,
+                    Weekday::Fri,
+                    Weekday::Sat,
+                    Weekday::Sun,
+                ]
+                .into_iter()
+                .map(|i| {
+                    text(i.to_string())
+                        .align_x(Horizontal::Center)
                         .width(Length::Fill)
-                        .align_x(Horizontal::Center),
-                    button(icon(StaticIcon::RightChevron))
-                        .on_press(Message::ChangeSelectDate(
-                            selected_date.checked_add_months(Months::new(1))
-                        ))
-                        .padding([theme.space.xs, theme.space.md])
-                        .style(theme.settings_button_style())
-                )
-                .width(Length::Fill)
-                .align_y(Vertical::Center),
+                        .into()
+                })
+                .collect::<Vec<Element<'a, Message>>>(),
             )
-            .push(
-                Row::with_children(
-                    [
-                        Weekday::Mon,
-                        Weekday::Tue,
-                        Weekday::Wed,
-                        Weekday::Thu,
-                        Weekday::Fri,
-                        Weekday::Sat,
-                        Weekday::Sun,
-                    ]
-                    .into_iter()
-                    .map(|i| {
-                        text(i.to_string())
-                            .align_x(Horizontal::Center)
-                            .width(Length::Fill)
-                            .into()
-                    })
-                    .collect::<Vec<Element<'a, Message>>>(),
-                )
-                .width(Length::Fill)
-                .spacing(theme.space.sm),
-            )
-            .push(Column::with_children(
+            .width(Length::Fill)
+            .spacing(theme.space.sm),
+            Column::with_children(
                 (0..weeks_in_month)
                     .map(|_| {
                         Row::with_children(
@@ -329,9 +325,10 @@ impl Tempo {
                         .into()
                     })
                     .collect::<Vec<Element<'a, Message>>>(),
-            ))
-            .spacing(theme.space.md)
-            .width(Length::Fixed(225.));
+            ),
+        ]
+        .spacing(theme.space.md)
+        .width(Length::Fixed(225.));
 
         column!(
             button(

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -128,7 +128,7 @@ impl TrayModule {
                 ..
             } if display == "submenu" => {
                 let is_open = self.submenus.contains(&layout.0);
-                Column::new()
+                Column::with_capacity(2)
                     .push(
                         button(row!(
                             text(label.replace("_", "").to_owned()).width(Length::Fill),


### PR DESCRIPTION
# rationale
calls to `Row::new()`/`Column::new()` followed by a bunch of `.push`/`.push_maybe` result in a lot of unnecessary allocations as buffers grow; with the way stuff like opening/closing a menu is currently implemented, this happens every time a menu is opened.

this is mostly relevant for low-end mobile end user hardware, such as my tiny N100 laptop. in addition to the randomly occuring delays I'm still trying to figure out the cause of, without this patch there is a consistent noticeable delay when opening menus.

# my current/first approach
for a first go at fixing this, I picked the option that's the least intrusive to the codebase: replacing calls to `Row::new()` and `Column::new` with `::with_capacity` calls instead (since the max length is almost always known in advance). this should be fine in terms of memory usage (since at least on linux-shaped kernels, allocated memory isn't actually used until it's written to), it will reduce overall allocation count, and it might actually cause smaller allocations than pushing without setting the capacity (https://doc.rust-lang.org/std/vec/struct.Vec.html#capacity-and-reallocation). I have also replaced instances of `::new().push().push().push()` with the row!/column! macro where possible.

# possible alternatives
alternative approaches to this, for example ones which always allocate exactly as much memory as needed, are possible and not hard to implement, but they would require touching a lot more lines of code; I think the easiest replacement for `::new().push().push_maybe()` chains would be creating an iterator chain using `Option::into_iter()`, `Iterator::chain` and `std::iter::once()`, and then passing that iterator to Row/Column's `with_children`. I am open to changing to this if it is preferred.