### PR TITLE
Improve tray icon discovery and reliability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ vendor
 
 .worktrees
 
+.idea
+.vscode

--- a/src/services/tray/dbus.rs
+++ b/src/services/tray/dbus.rs
@@ -1,5 +1,5 @@
 use iced::futures::StreamExt;
-use log::{info, warn};
+use log::{debug, info, warn};
 use std::time::Duration;
 use zbus::{
     Connection, Result,
@@ -18,7 +18,7 @@ const OBJECT_PATH: &str = "/StatusNotifierWatcher";
 
 #[derive(Debug, Default)]
 pub struct StatusNotifierWatcher {
-    items: Vec<(UniqueName<'static>, String)>,
+    items: std::collections::HashMap<String, String>,
 }
 
 impl StatusNotifierWatcher {
@@ -65,19 +65,20 @@ impl StatusNotifierWatcher {
                             }
                         } else if let BusName::Unique(name) = &args.name {
                             let mut interface = internal_interface.get_mut().await;
-                            if let Some(idx) = interface
-                                .items
-                                .iter()
-                                .position(|(unique_name, _)| unique_name == name)
-                            {
-                                let emitter =
-                                    SignalEmitter::new(&internal_connection, OBJECT_PATH).unwrap();
-                                let service = interface.items.remove(idx).1;
-                                StatusNotifierWatcher::status_notifier_item_unregistered(
+                            if let Some(service) = interface.items.remove(&name.to_string()) {
+                                let emitter = match SignalEmitter::new(&internal_connection, OBJECT_PATH) {
+                                    Ok(emitter) => emitter,
+                                    Err(err) => {
+                                        warn!("Failed to create signal emitter for unregistration: {err}");
+                                        continue;
+                                    }
+                                };
+                                if let Err(err) = StatusNotifierWatcher::status_notifier_item_unregistered(
                                     &emitter, &service,
                                 )
-                                .await
-                                .unwrap();
+                                .await {
+                                    warn!("Failed to emit status notifier item unregistered signal for service '{service}': {err}");
+                                }
                             }
                         }
                     }
@@ -116,47 +117,60 @@ impl StatusNotifierWatcher {
 
             // Only try to register services that explicitly mention StatusNotifierItem
             if name_str.contains("StatusNotifierItem") {
-                let sender = match dbus_proxy.get_name_owner(BusName::from(name.clone())).await {
-                    Ok(owner) => owner,
-                    Err(_) => continue,
-                };
-
-                let mut watcher = interface.get_mut().await;
-                let emitter = SignalEmitter::new(conn, OBJECT_PATH).unwrap();
-                watcher
-                    .register_status_notifier_item_manual(
-                        "/StatusNotifierItem",
-                        sender.into_inner(),
-                        &emitter,
-                    )
-                    .await;
+                Self::try_register_item(
+                    conn,
+                    interface,
+                    &dbus_proxy,
+                    &BusName::from(name.clone()),
+                    "/StatusNotifierItem",
+                )
+                .await;
             } else {
                 // Try introspection for other services
                 if let Some(path_hint) = Self::find_status_notifier_path(conn, name_str).await {
-                    let sender = match dbus_proxy.get_name_owner(BusName::from(name.clone())).await
-                    {
-                        Ok(owner) => owner,
-                        Err(_) => continue,
-                    };
-
-                    let mut watcher = interface.get_mut().await;
-                    let emitter = SignalEmitter::new(conn, OBJECT_PATH).unwrap();
-                    watcher
-                        .register_status_notifier_item_manual(
-                            &path_hint,
-                            sender.into_inner(),
-                            &emitter,
-                        )
-                        .await;
+                    Self::try_register_item(
+                        conn,
+                        interface,
+                        &dbus_proxy,
+                        &BusName::from(name.clone()),
+                        &path_hint,
+                    )
+                    .await;
                 }
             }
         }
         Ok(())
     }
+
+    async fn try_register_item(
+        conn: &Connection,
+        interface: &zbus::object_server::InterfaceRef<StatusNotifierWatcher>,
+        dbus_proxy: &DBusProxy<'_>,
+        name: &BusName<'_>,
+        service_path: &str,
+    ) {
+        let sender = match dbus_proxy.get_name_owner(name.clone()).await {
+            Ok(owner) => owner,
+            Err(_) => return,
+        };
+
+        let mut watcher = interface.get_mut().await;
+        let emitter = match SignalEmitter::new(conn, OBJECT_PATH) {
+            Ok(emitter) => emitter,
+            Err(err) => {
+                warn!("Failed to create signal emitter for registration: {err}");
+                return;
+            }
+        };
+        watcher
+            .register_status_notifier_item_manual(service_path, sender.into_inner(), &emitter)
+            .await;
+    }
 }
 
 impl StatusNotifierWatcher {
     async fn find_status_notifier_path(conn: &Connection, name: &str) -> Option<String> {
+        debug!("Attempting to find StatusNotifier path for service: {name}");
         let candidates = [
             "/StatusNotifierItem",
             "/org/ayatana/NotificationItem",
@@ -164,28 +178,50 @@ impl StatusNotifierWatcher {
         ];
 
         for path in candidates {
+            debug!("Trying path: {path} for service: {name}");
             let builder = match IntrospectableProxy::builder(conn).destination(name.to_string()) {
                 Ok(builder) => builder,
-                Err(_) => continue,
+                Err(err) => {
+                    debug!("Failed to create proxy builder for {name} at {path}: {err}");
+                    continue;
+                }
             };
 
             let builder = match builder.path(path) {
                 Ok(builder) => builder,
-                Err(_) => continue,
+                Err(err) => {
+                    debug!("Failed to set path {path} for {name}: {err}");
+                    continue;
+                }
             };
 
             let proxy = match builder.build().await {
                 Ok(proxy) => proxy,
-                Err(_) => continue,
+                Err(err) => {
+                    debug!("Failed to build proxy for {name} at {path}: {err}");
+                    continue;
+                }
             };
 
-            if let Ok(xml) = proxy.introspect().await
-                && xml.contains("org.kde.StatusNotifierItem")
+            if let Ok(xml_result) =
+                tokio::time::timeout(tokio::time::Duration::from_secs(5), proxy.introspect()).await
             {
-                return Some(path.to_string());
+                if let Ok(xml) = xml_result
+                    && xml.contains("org.kde.StatusNotifierItem")
+                {
+                    info!("Found StatusNotifierItem at {path} for service: {name}");
+                    return Some(path.to_string());
+                } else {
+                    debug!(
+                        "Introspection successful for {name} at {path}, but no StatusNotifierItem interface found"
+                    );
+                }
+            } else {
+                warn!("Introspection timeout for {name} at {path} after 5 seconds");
             }
         }
 
+        debug!("No StatusNotifierItem path found for service: {name}");
         None
     }
 
@@ -201,15 +237,35 @@ impl StatusNotifierWatcher {
             service.to_string()
         };
 
-        if self.items.iter().any(|(_, s)| s == &service) {
+        let sender_key = sender.to_string();
+
+        if let Some(existing_service) = self.items.get(&sender_key)
+            && existing_service == &service
+        {
             return;
+        }
+
+        // Check if this service is already registered by a different sender
+        if let Some((old_sender, old_service)) = self
+            .items
+            .iter()
+            .find(|(_, s)| *s == &service)
+            .map(|(k, v)| (k.clone(), v.clone()))
+        {
+            // Emit unregistered signal for the old entry before removing it
+            if let Err(err) = Self::status_notifier_item_unregistered(emitter, &old_service).await {
+                warn!(
+                    "Failed to emit status_notifier_item_unregistered for duplicate service '{old_service}': {err}"
+                );
+            }
+            self.items.remove(&old_sender);
         }
 
         if let Err(err) = Self::status_notifier_item_registered(emitter, &service).await {
             warn!("Failed to emit status_notifier_item_registered for '{service}': {err:?}");
         }
 
-        self.items.push((sender, service));
+        self.items.insert(sender_key, service);
     }
 }
 
@@ -228,7 +284,13 @@ impl StatusNotifierWatcher {
         #[zbus(header)] header: Header<'_>,
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
     ) {
-        let sender = header.sender().unwrap().to_owned();
+        let sender = match header.sender() {
+            Some(sender) => sender.to_owned(),
+            None => {
+                warn!("Received status notifier item registration signal without sender header");
+                return;
+            }
+        };
         self.register_status_notifier_item_manual(service, sender, &emitter)
             .await;
     }
@@ -237,7 +299,7 @@ impl StatusNotifierWatcher {
 
     #[zbus(property)]
     fn registered_status_notifier_items(&self) -> Vec<String> {
-        self.items.iter().map(|(_, x)| x.clone()).collect()
+        self.items.values().cloned().collect()
     }
 
     #[zbus(property)]
@@ -274,6 +336,16 @@ pub struct Icon {
     pub width: i32,
     pub height: i32,
     pub bytes: Vec<u8>,
+}
+
+/// Convert ARGB pixel format to RGBA
+/// ARGB format is [A, R, G, B], RGBA format is [R, G, B, A]
+/// rotate_left(1) moves the alpha byte from position 0 to position 3
+pub fn convert_argb_to_rgba(mut icon: Icon) -> Icon {
+    for pixel in icon.bytes.chunks_exact_mut(4) {
+        pixel.rotate_left(1);
+    }
+    icon
 }
 
 #[proxy(interface = "org.kde.StatusNotifierItem")]

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -1,7 +1,7 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
 use dbus::{
     DBusMenuProxy, Layout, StatusNotifierItemProxy, StatusNotifierWatcher,
-    StatusNotifierWatcherProxy,
+    StatusNotifierWatcherProxy, convert_argb_to_rgba,
 };
 use freedesktop_icons::lookup;
 use iced::{
@@ -43,7 +43,8 @@ struct DesktopEntryIcon {
     icon: String,
 }
 
-static DESKTOP_ENTRY_ICONS: Lazy<Vec<DesktopEntryIcon>> = Lazy::new(load_desktop_entry_icons);
+static DESKTOP_ENTRY_ICONS: LazyLock<Vec<DesktopEntryIcon>> =
+    LazyLock::new(load_desktop_entry_icons);
 
 fn load_desktop_entry_icons() -> Vec<DesktopEntryIcon> {
     let mut entries = Vec::new();
@@ -124,14 +125,24 @@ fn parse_desktop_entry(path: &Path) -> Option<DesktopEntryIcon> {
 }
 
 fn desktop_directories() -> Vec<PathBuf> {
+    collect_xdg_directories(&["applications"])
+}
+
+fn collect_xdg_directories(subdirs: &[&str]) -> Vec<PathBuf> {
     let mut dirs = Vec::new();
 
     if let Ok(data_home) = env::var("XDG_DATA_HOME") {
-        dirs.push(PathBuf::from(data_home).join("applications"));
+        let base = PathBuf::from(data_home);
+        for subdir in subdirs {
+            dirs.push(base.join(subdir));
+        }
     }
 
     if let Ok(home) = env::var("HOME") {
-        dirs.push(PathBuf::from(home).join(".local/share/applications"));
+        let base = PathBuf::from(home);
+        for subdir in subdirs {
+            dirs.push(base.join(".local/share").join(subdir));
+        }
     }
 
     let data_dirs =
@@ -140,10 +151,15 @@ fn desktop_directories() -> Vec<PathBuf> {
         if dir.is_empty() {
             continue;
         }
-        dirs.push(PathBuf::from(dir).join("applications"));
+        let base = PathBuf::from(dir);
+        for subdir in subdirs {
+            dirs.push(base.join(subdir));
+        }
     }
 
-    dirs.push(PathBuf::from("/usr/share/applications"));
+    for subdir in subdirs {
+        dirs.push(PathBuf::from("/usr/share").join(subdir));
+    }
 
     dirs.sort();
     dirs.dedup();
@@ -207,6 +223,19 @@ fn get_icon_from_name(icon_name: &str) -> Option<TrayIcon> {
     }
 
     None
+}
+
+fn try_fallback_icons(fallbacks: &[String]) -> Option<TrayIcon> {
+    fallbacks.iter().find_map(|name| get_icon_from_name(name))
+}
+
+fn add_fallback(fallbacks: &mut Vec<String>, value: Option<&String>) {
+    if let Some(value) = value {
+        let value = value.trim();
+        if !value.is_empty() && !fallbacks.contains(&value.to_string()) {
+            fallbacks.push(value.to_string());
+        }
+    }
 }
 
 fn tray_icon_from_path(path: PathBuf) -> Option<TrayIcon> {
@@ -329,37 +358,7 @@ fn collect_icon_names_recursive(dir: &Path, names: &mut BTreeSet<String>) {
 }
 
 fn icon_directories() -> Vec<PathBuf> {
-    let mut dirs = Vec::new();
-
-    if let Ok(data_home) = env::var("XDG_DATA_HOME") {
-        let base = PathBuf::from(data_home);
-        dirs.push(base.join("icons"));
-        dirs.push(base.join("pixmaps"));
-    }
-
-    if let Ok(home) = env::var("HOME") {
-        let base = PathBuf::from(home);
-        dirs.push(base.join(".local/share/icons"));
-        dirs.push(base.join(".local/share/pixmaps"));
-    }
-
-    let data_dirs =
-        env::var("XDG_DATA_DIRS").unwrap_or_else(|_| "/usr/local/share:/usr/share".into());
-    for dir in data_dirs.split(':') {
-        if dir.is_empty() {
-            continue;
-        }
-        let base = PathBuf::from(dir);
-        dirs.push(base.join("icons"));
-        dirs.push(base.join("pixmaps"));
-    }
-
-    dirs.push(PathBuf::from("/usr/share/icons"));
-    dirs.push(PathBuf::from("/usr/share/pixmaps"));
-
-    dirs.sort();
-    dirs.dedup();
-    dirs
+    collect_xdg_directories(&["icons", "pixmaps"])
 }
 
 #[derive(Debug, Clone)]
@@ -407,69 +406,29 @@ impl StatusNotifierItem {
         let title_prop = item_proxy.title().await.ok();
 
         let mut fallbacks = Vec::new();
-        if let Some(ref icon_name) = icon_name_prop {
-            let icon_name = icon_name.trim();
-            if !icon_name.is_empty() && !fallbacks.contains(&icon_name.to_string()) {
-                fallbacks.push(icon_name.to_string());
-            }
-        }
-        if let Some(ref id) = id_prop {
-            let id = id.trim();
-            if !id.is_empty() && !fallbacks.contains(&id.to_string()) {
-                fallbacks.push(id.to_string());
-            }
-        }
-        if let Some(ref title) = title_prop {
-            let title = title.trim();
-            if !title.is_empty() && !fallbacks.contains(&title.to_string()) {
-                fallbacks.push(title.to_string());
-            }
-        }
+        add_fallback(&mut fallbacks, icon_name_prop.as_ref());
+        add_fallback(&mut fallbacks, id_prop.as_ref());
+        add_fallback(&mut fallbacks, title_prop.as_ref());
 
         let icon_pixmap = item_proxy.icon_pixmap().await;
 
         let icon = match icon_pixmap {
-            Ok(icons) => {
-                icons
-                    .into_iter()
-                    .max_by_key(|i| {
-                        trace!("tray icon w {}, h {}", i.width, i.height);
-                        (i.width, i.height)
-                    })
-                    .map(|mut i| {
-                        // Convert ARGB to RGBA
-                        for pixel in i.bytes.chunks_exact_mut(4) {
-                            pixel.rotate_left(1);
-                        }
-                        TrayIcon::Image(image::Handle::from_rgba(
-                            i.width as u32,
-                            i.height as u32,
-                            i.bytes,
-                        ))
-                    })
-                    .or_else(|| {
-                        // Try each fallback candidate
-                        let mut found_icon = None;
-                        for candidate in fallbacks.iter() {
-                            if let Some(icon) = get_icon_from_name(candidate) {
-                                found_icon = Some(icon);
-                                break;
-                            }
-                        }
-                        found_icon
-                    })
-            }
-            Err(_) => {
-                // Try each fallback candidate
-                let mut found_icon = None;
-                for candidate in fallbacks.iter() {
-                    if let Some(icon) = get_icon_from_name(candidate) {
-                        found_icon = Some(icon);
-                        break;
-                    }
-                }
-                found_icon
-            }
+            Ok(icons) => icons
+                .into_iter()
+                .max_by_key(|i| {
+                    trace!("tray icon w {}, h {}", i.width, i.height);
+                    (i.width, i.height)
+                })
+                .map(|i| {
+                    let i = convert_argb_to_rgba(i);
+                    TrayIcon::Image(image::Handle::from_rgba(
+                        i.width as u32,
+                        i.height as u32,
+                        i.bytes,
+                    ))
+                })
+                .or_else(|| try_fallback_icons(&fallbacks)),
+            Err(_) => try_fallback_icons(&fallbacks),
         };
 
         let menu_path = item_proxy.menu().await?;
@@ -620,11 +579,8 @@ impl TrayService {
                                             trace!("tray icon w {}, h {}", i.width, i.height);
                                             (i.width, i.height)
                                         })
-                                        .map(|mut i| {
-                                            // Convert ARGB to RGBA
-                                            for pixel in i.bytes.chunks_exact_mut(4) {
-                                                pixel.rotate_left(1);
-                                            }
+                                        .map(|i| {
+                                            let i = convert_argb_to_rgba(i);
                                             TrayEvent::IconChanged(
                                                 name.to_owned(),
                                                 TrayIcon::Image(image::Handle::from_rgba(
@@ -758,19 +714,12 @@ impl TrayService {
         }
     }
 
-    async fn menu_voice_selected(
-        menu_proxy: &DBusMenuProxy<'_>,
-        id: i32,
-    ) -> anyhow::Result<Layout> {
+    async fn menu_item_selected(menu_proxy: &DBusMenuProxy<'_>, id: i32) -> anyhow::Result<Layout> {
+        // Use 0 to indicate no X11 timestamp available (common in Wayland)
+        let timestamp: u32 = 0;
         let value = zbus::zvariant::Value::I32(32).try_to_owned()?;
-        menu_proxy
-            .event(
-                id,
-                "clicked",
-                &value,
-                chrono::offset::Local::now().timestamp_subsec_micros(),
-            )
-            .await?;
+        debug!("Sending menu item clicked event for id={id}, timestamp={timestamp}");
+        menu_proxy.event(id, "clicked", &value, timestamp).await?;
 
         let (_, layout) = menu_proxy.get_layout(0, -1, &[]).await?;
 
@@ -847,19 +796,19 @@ impl Service for TrayService {
             TrayCommand::MenuSelected(name, id) => {
                 let menu = self.data.iter().find(|item| item.name == name);
                 if let Some(menu) = menu {
-                    let name_cb = name.clone();
+                    let name_clone = name.clone();
                     Task::perform(
                         {
                             let proxy = menu.menu_proxy.clone();
 
                             async move {
-                                debug!("Click tray menu voice {name} : {id}");
-                                TrayService::menu_voice_selected(&proxy, id).await
+                                debug!("Click tray menu item {name} : {id}");
+                                TrayService::menu_item_selected(&proxy, id).await
                             }
                         },
                         move |new_layout| match new_layout {
                             Ok(new_layout) => ServiceEvent::Update(TrayEvent::MenuLayoutChanged(
-                                name_cb.clone(),
+                                name_clone.clone(),
                                 new_layout,
                             )),
                             _ => ServiceEvent::Update(TrayEvent::None),


### PR DESCRIPTION
### Improved tray service discovery and icon resolution

This PR fixes issues where certain apps (specifically **Spotify, Telegram, and JetBrains Toolbox**) weren't showing up or were missing icons in the tray because they don't follow the standard `StatusNotifierItem` naming conventions.

### What’s changing:

* Instead of just looking for names that explicitly say "StatusNotifierItem," the service now uses introspection. It checks common paths like `/StatusNotifierItem` and `/MenuBar` to see if they actually implement the required interface. If it looks like a tray item, we use it.
* I added a fallback chain for icons. It now tries to pull from the DBus pixmap first, then the icon name property, and finally falls back to the app's `.desktop` file.
* If one tray item fails to initialize, it won't hang the whole loop anymore. It’ll log the error and move on to the next item.

### Technical Notes:

The discovery flow now scans registered DBus services and runs an introspection check for the `org.kde.StatusNotifierItem` interface. For icons, the priority is now:

1. Raw pixmap data
2. Theme lookup via `icon_name`
3. ID/Title matching
4. Desktop file lookup.

closes https://github.com/MalpenZibo/ashell/issues/437
