### PR TITLE
Tempo: Remove primary color highlight for current date in calendar if not current month

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -200,8 +200,6 @@ impl Tempo {
                                             .color_maybe({
                                                 if day == self.date.date_naive() {
                                                     Some(theme.iced_theme.palette().success)
-                                                } else if day == selected_date {
-                                                    Some(theme.iced_theme.palette().primary)
                                                 } else if day.month0() != current_month {
                                                     Some(
                                                         theme


### PR DESCRIPTION
found due to  https://github.com/MalpenZibo/ashell/issues/482
<img width="251" height="380" alt="xdph_screenshot_10249fca" src="https://github.com/user-attachments/assets/876d6650-a024-4dce-b1c1-30c099cb7b4e" />


