### PR TITLE
docs: reorder module documentation sidebar positions

### DIFF
--- a/website/docs/configuration/modules/clock.md
+++ b/website/docs/configuration/modules/clock.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 1
 ---
 
 # Clock

--- a/website/docs/configuration/modules/custom_module.md
+++ b/website/docs/configuration/modules/custom_module.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 2
 ---
 
 # Custom Modules

--- a/website/docs/configuration/modules/keyboard.md
+++ b/website/docs/configuration/modules/keyboard.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 3
 ---
 
 # Keyboard

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 4
 ---
 
 # Media Player

--- a/website/docs/configuration/modules/privacy.md
+++ b/website/docs/configuration/modules/privacy.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 6
 ---
 
 # Privacy

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 7
 ---
 
 # Settings

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 8
 ---
 
 # System Info

--- a/website/docs/configuration/modules/tempo.md
+++ b/website/docs/configuration/modules/tempo.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 ---
 
 # Tempo

--- a/website/docs/configuration/modules/tray.md
+++ b/website/docs/configuration/modules/tray.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 10
 ---
 
 # Tray

--- a/website/docs/configuration/modules/updates.md
+++ b/website/docs/configuration/modules/updates.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 11
 ---
 
 # Updates

--- a/website/docs/configuration/modules/window_title.md
+++ b/website/docs/configuration/modules/window_title.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 12
 ---
 
 # Window Title

--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 13
 ---
 
 # Workspaces


### PR DESCRIPTION
respositioned all modules alphabetically in the docs sidebar

related to https://github.com/MalpenZibo/ashell/pull/456