### PR TITLE
Allow configuration of ashell on top-layer

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -618,6 +618,7 @@ pub enum Position {
 pub enum Layer {
     #[default]
     Bottom,
+    Top,
     Overlay,
 }
 

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -82,6 +82,7 @@ impl Outputs {
         let height = Self::get_height(style, scale_factor);
 
         let iced_layer = match layer {
+            config::Layer::Top => Layer::Top,
             config::Layer::Bottom => Layer::Bottom,
             config::Layer::Overlay => Layer::Overlay,
         };

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -102,6 +102,7 @@ Configure the bar position and Wayland layer.
 ### Layer Options
 
 - `"Overlay"` - Above everything including fullscreen
+- `"Top"` - Above everything excluding fullscreen
 - `"Bottom"` - Above background, below windows (default)
 
 ### Examples


### PR DESCRIPTION
#493 for reference.

In my opinion putting a bar on the Top layer, such that it is always on top except for fullscreen windows, makes the most sense for the default setting of a status bar.

In niri, for example, scrolling out to the overview also makes ashell small and appear on each workspace individually.
Also, when comparing to something like windows, the bar is always displayed above any window that you move over it.

If, however, it is your personal wish @MalpenZibo to keep bottom as the default for some reason, I will of course accept that.
I hope I made it reasonably clear why the Top layer might be the most sensible choice for some (if not most) users, and therefore the value of adding this at least as a configurable option.