### PR TITLE
2| Feature: open network warning

### DIFF
--- a/src/password_dialog.rs
+++ b/src/password_dialog.rs
@@ -23,43 +23,71 @@ pub fn view<'a>(
     wifi_ssid: &str,
     current_password: &str,
     show_password: bool,
+    warning_only: bool,
 ) -> Element<'a, Message> {
+    let title = if warning_only {
+        "Open network"
+    } else {
+        "Authentication required"
+    };
+
+    let description = if warning_only {
+        format!(
+            "\"{}\" is an open network. Data sent over this connection may be visible to others.
+Do you want to connect anyway?",
+            wifi_ssid
+        )
+    } else {
+        format!("Insert password to connect to: {}", wifi_ssid)
+    };
+
     column!(
         row!(
-            icon(StaticIcon::WifiLock4).size(theme.font_size.xxl),
-            text("Authentication required").size(theme.font_size.xl),
+            icon(if warning_only {
+                StaticIcon::Wifi4
+            } else {
+                StaticIcon::WifiLock4
+            })
+            .size(theme.font_size.xxl),
+            text(title).size(theme.font_size.xl),
         )
         .spacing(theme.space.md)
         .align_y(Alignment::Center),
-        text(format!("Insert password to connect to: {wifi_ssid}")),
-        row!(
-            text_input("", current_password)
-                .secure(!show_password)
-                .size(theme.font_size.md)
-                .padding([theme.space.xs, theme.space.md])
-                .style(theme.text_input_style())
-                .on_input(Message::PasswordChanged)
-                .on_submit(Message::DialogConfirmed(id))
-                .width(Length::Fill),
-            button(
-                container(
-                    icon(if show_password {
-                        StaticIcon::EyeOpened
-                    } else {
-                        StaticIcon::EyeClosed
-                    })
+        text(description),
+    )
+    .push_maybe(
+        (!warning_only).then_some(
+            row!(
+                text_input("", current_password)
+                    .secure(!show_password)
                     .size(theme.font_size.md)
+                    .padding([theme.space.xs, theme.space.md])
+                    .style(theme.text_input_style())
+                    .on_input(Message::PasswordChanged)
+                    .on_submit(Message::DialogConfirmed(id))
+                    .width(Length::Fill),
+                button(
+                    container(
+                        icon(if show_password {
+                            StaticIcon::EyeOpened
+                        } else {
+                            StaticIcon::EyeClosed
+                        })
+                        .size(theme.font_size.md)
+                    )
+                    .center(Length::Fill)
                 )
-                .center(Length::Fill)
+                .padding(0)
+                .style(theme.round_button_style())
+                .on_press(Message::TogglePasswordVisibility)
+                .height(Length::Fixed(32.))
+                .width(Length::Fixed(32.)),
             )
-            .padding(0)
-            .style(theme.round_button_style())
-            .on_press(Message::TogglePasswordVisibility)
-            .height(Length::Fixed(32.))
-            .width(Length::Fixed(32.)),
-        )
-        .spacing(theme.space.sm)
-        .align_y(Alignment::Center),
+            .spacing(theme.space.sm)
+            .align_y(Alignment::Center),
+        ),
+    )
+    .push(
         row!(
             horizontal_space(),
             button(text("Cancel").align_y(Vertical::Center))
@@ -71,10 +99,14 @@ pub fn view<'a>(
                 .padding([theme.space.xxs, theme.space.xl])
                 .height(Length::Fixed(50.))
                 .style(theme.confirm_button_style())
-                .on_press(Message::DialogConfirmed(id))
+                .on_press_maybe(if !warning_only && current_password.is_empty() {
+                    None
+                } else {
+                    Some(Message::DialogConfirmed(id))
+                })
         )
         .spacing(theme.space.xs)
-        .width(Length::Fill)
+        .width(Length::Fill),
     )
     .spacing(theme.space.md)
     .padding(theme.space.md)


### PR DESCRIPTION
This one sounds simple but I hope we can have some discussion about that topic. 
First and foremost, be warned I am really bad at naming things and even after naming things I am unsure if they are properly named :) 

Note: This branch is on top of https://github.com/MalpenZibo/ashell/pull/497 otherwise rebasing is always a lot of work.

I noticed that there is a password prompt for open networks. 
In my opinion we should warn users of the risks of open networks and not ask for a password.

Therefore, **for now** I have put the content for open networks in the `src/password_dialog.rs`.
Here comes the first pool of questions: 
* do we want to keep that together, if so, do we want to rename that (one argument is that a pw prompt for secured networks is the eloquent to a warning for an open network)
* for now we just support open and normal secured networks, there are enterprise ones which have user,password and enterprise with user, password and cert, do we want to support these at some point? Or do we say let the user do that on the NM of their choice? 
* for now I use `network_dialog` instead of `password_dialog` in the code, depending what we want I will change that accordingly.

There is one fundamental difference between secured and open networks, 
I kept that the secured network PW prompt is not shown if it is in the known networks, 
but I changed that for open networks that they always show the warning/info 
(the same SSID could be used somewhere else and I don't want users to automatically connect). 

The current warning looks like that for now (sorry multiple bars open)

<img width="397" height="320" alt="xdph_screenshot_1fc07593" src="https://github.com/user-attachments/assets/62a2e08c-8673-4365-8857-f3392150e3bf" />

one small change is that I disabled the confirm button on secured network PW prompts if the PW field is empty.

@clotodex @MalpenZibo thanks in advance for your feedback 

I hope this was related to your message in 
https://github.com/MalpenZibo/ashell/issues/91#issue-2809171717

> Sometimes, it asks for a password even if it's not required, 
