### PR TITLE
MangoWC support integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## What is ashell?
 
-ashell is a ready to go Wayland status bar for Hyprland and Niri.
+ashell is a ready to go Wayland status bar for Hyprland, Niri, and MangoWC.
 
 Feel free to fork this project and customize it for your needs or just open an
 issue to request a particular feature.
@@ -21,11 +21,11 @@ page on website
 - App Launcher button
 - Сlipboard button
 - OS Updates indicator
-- Hyprland/Niri Active Window
-- Hyprland/Niri Workspaces
+- Hyprland/Niri/MangoWC Active Window
+- Hyprland/Niri/MangoWC Workspaces
 - System Information (CPU, RAM, Temperature)
-- Hyprland/Niri Keyboard Layout
-- Hyprland Keyboard Submap
+- Hyprland/Niri/MangoWC Keyboard Layout
+- Hyprland/MangoWC Keyboard Submap
 - Tray
 - Date time
 - Privacy (check microphone, camera and screenshare usage)

--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -198,6 +198,7 @@ fn fetch_full_state(internal_state: &HyprInternalState) -> Result<CompositorStat
         workspaces,
         monitors,
         active_workspace_id,
+        active_workspace_ids: active_workspace_id.into_iter().collect(),
         active_window,
         keyboard_layout,
         submap: if internal_state.submap.is_empty() {

--- a/src/services/compositor/mangowc.rs
+++ b/src/services/compositor/mangowc.rs
@@ -1,0 +1,357 @@
+use super::types::{
+    ActiveWindow, ActiveWindowMango, CompositorCommand, CompositorEvent, CompositorMonitor,
+    CompositorService, CompositorState, CompositorWorkspace,
+};
+use crate::services::ServiceEvent;
+use anyhow::{Context, Result, anyhow};
+use std::collections::{HashMap, HashSet};
+use std::process::Command as StdCommand;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::Command,
+    sync::broadcast,
+};
+
+#[derive(Debug, Default, Clone)]
+struct TagInfo {
+    clients: u16,
+    selected: bool,
+}
+
+#[derive(Debug, Default, Clone)]
+struct OutputTagState {
+    tags: HashMap<i32, TagInfo>,
+    selected_mask: u32,
+    occupied_mask: u32,
+    urgent_mask: u32,
+}
+
+pub fn is_available() -> bool {
+    StdCommand::new("mmsg")
+        .args(["-g", "-O"])
+        .output()
+        .map(|out| out.status.success())
+        .unwrap_or(false)
+}
+
+pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
+    match cmd {
+        CompositorCommand::FocusWorkspace(id) => {
+            run_mmsg(["-s", "-t", &id.to_string()]).await?;
+        }
+        CompositorCommand::FocusSpecialWorkspace(_) => {
+            return Err(anyhow!(
+                "Special workspaces are not supported in the MangoWC backend"
+            ));
+        }
+        CompositorCommand::ToggleSpecialWorkspace(_) => {
+            return Err(anyhow!(
+                "Special workspaces are not supported in the MangoWC backend"
+            ));
+        }
+        CompositorCommand::FocusMonitor(_) => {
+            return Err(anyhow!(
+                "FocusMonitor by ID is not supported in the MangoWC backend"
+            ));
+        }
+        CompositorCommand::ScrollWorkspace(dir) => {
+            let dispatch = if dir > 0 {
+                "viewtoleft_have_client"
+            } else {
+                "viewtoright_have_client"
+            };
+            run_mmsg(["-s", "-d", dispatch]).await?;
+        }
+        CompositorCommand::NextLayout => {
+            run_mmsg(["-s", "-d", "switch_keyboard_layout"]).await?;
+        }
+        CompositorCommand::CustomDispatch(dispatcher, args) => {
+            let full_dispatch = if args.is_empty() {
+                dispatcher
+            } else {
+                format!("{dispatcher},{args}")
+            };
+            run_mmsg(["-s", "-d", &full_dispatch]).await?;
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn run_listener(tx: &broadcast::Sender<ServiceEvent<CompositorService>>) -> Result<()> {
+    send_latest_state(tx).await?;
+
+    let mut child = Command::new("mmsg")
+        .args(["-w", "-t", "-c", "-k", "-b"])
+        .stdout(std::process::Stdio::piped())
+        .spawn()
+        .context("Failed to spawn mmsg watch process")?;
+
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| anyhow!("Failed to capture mmsg stdout"))?;
+    let mut reader = BufReader::new(stdout);
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        let read = reader.read_line(&mut line).await?;
+        if read == 0 {
+            break;
+        }
+
+        if !line.trim().is_empty() {
+            send_latest_state(tx).await?;
+        }
+    }
+
+    Err(anyhow!("mmsg watch stream exited"))
+}
+
+async fn send_latest_state(tx: &broadcast::Sender<ServiceEvent<CompositorService>>) -> Result<()> {
+    let state = fetch_full_state().await?;
+    let _ = tx.send(ServiceEvent::Update(CompositorEvent::StateChanged(
+        Box::new(state),
+    )));
+    Ok(())
+}
+
+async fn fetch_full_state() -> Result<CompositorState> {
+    let tags_raw = run_mmsg(["-g", "-t"]).await?;
+    let outputs_raw = run_mmsg(["-g", "-O"]).await?;
+    let active_client_raw = run_mmsg(["-g", "-c"]).await?;
+    let keyboard_raw = run_mmsg(["-g", "-k"]).await?;
+    let keymode_raw = run_mmsg(["-g", "-b"]).await?;
+
+    let (tag_state, fallback_outputs) = parse_tags(&tags_raw);
+    let mut outputs = parse_outputs(&outputs_raw);
+    for output in fallback_outputs {
+        if !outputs.contains(&output) {
+            outputs.push(output);
+        }
+    }
+
+    let mut active_workspace_ids = HashSet::new();
+    let mut monitors = Vec::new();
+    let mut workspaces = Vec::new();
+
+    for (idx, output_name) in outputs.iter().enumerate() {
+        let state = tag_state.get(output_name).cloned().unwrap_or_default();
+        let selected_ids = resolve_selected_tag_ids(&state);
+        for id in &selected_ids {
+            active_workspace_ids.insert(*id);
+        }
+
+        for (tag_id, info) in state.tags {
+            workspaces.push(CompositorWorkspace {
+                id: tag_id,
+                index: tag_id,
+                name: tag_id.to_string(),
+                monitor: output_name.clone(),
+                monitor_id: Some(idx as i128),
+                windows: info.clients,
+                is_special: false,
+            });
+        }
+
+        monitors.push(CompositorMonitor {
+            id: idx as i128,
+            name: output_name.clone(),
+            active_workspace_id: selected_ids.first().copied().unwrap_or(-1),
+            special_workspace_id: -1,
+        });
+    }
+
+    workspaces.sort_by(|a, b| {
+        a.monitor
+            .cmp(&b.monitor)
+            .then(a.index.cmp(&b.index))
+            .then(a.id.cmp(&b.id))
+    });
+
+    let active_window = parse_active_window(&active_client_raw);
+    let keyboard_layout = parse_keyboard_layout(&keyboard_raw);
+    let submap = parse_keymode(&keymode_raw);
+
+    let mut active_workspace_ids = active_workspace_ids.into_iter().collect::<Vec<_>>();
+    active_workspace_ids.sort_unstable();
+    active_workspace_ids.dedup();
+
+    Ok(CompositorState {
+        workspaces,
+        monitors,
+        active_workspace_id: active_workspace_ids.first().copied(),
+        active_workspace_ids,
+        active_window,
+        keyboard_layout,
+        submap,
+    })
+}
+
+async fn run_mmsg<const N: usize>(args: [&str; N]) -> Result<String> {
+    let output = Command::new("mmsg")
+        .args(args)
+        .output()
+        .await
+        .with_context(|| format!("Failed to run mmsg with args: {args:?}"))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(anyhow!("mmsg command failed ({args:?}): {stderr}"));
+    }
+
+    String::from_utf8(output.stdout).context("mmsg output was not valid UTF-8")
+}
+
+fn parse_outputs(raw: &str) -> Vec<String> {
+    raw.lines()
+        .filter_map(|line| {
+            let stripped = line.trim().strip_prefix('+')?;
+            Some(stripped.trim().to_string())
+        })
+        .collect()
+}
+
+fn parse_active_window(raw: &str) -> Option<ActiveWindow> {
+    let mut title = String::new();
+    let mut class = String::new();
+    let mut monitor = String::new();
+
+    for line in raw.lines() {
+        let mut parts = line.split_whitespace();
+        let output = parts.next().unwrap_or_default();
+        let key = parts.next().unwrap_or_default();
+        let value = parts.collect::<Vec<_>>().join(" ");
+
+        match key {
+            "title" => {
+                title = value;
+                monitor = output.to_string();
+            }
+            "appid" => class = value,
+            _ => {}
+        }
+    }
+
+    if title.is_empty() && class.is_empty() {
+        None
+    } else {
+        Some(ActiveWindow::Mango(ActiveWindowMango {
+            title,
+            class: class.clone(),
+            address: if monitor.is_empty() {
+                class
+            } else {
+                format!("{monitor}:{class}")
+            },
+        }))
+    }
+}
+
+fn parse_keyboard_layout(raw: &str) -> String {
+    for line in raw.lines() {
+        let mut parts = line.split_whitespace();
+        let _output = parts.next();
+        let key = parts.next().unwrap_or_default();
+        if key == "kb_layout" {
+            let value = parts.collect::<Vec<_>>().join(" ");
+            if !value.is_empty() {
+                return value;
+            }
+        }
+    }
+    "Unknown".to_string()
+}
+
+fn parse_keymode(raw: &str) -> Option<String> {
+    for line in raw.lines() {
+        let mut parts = line.split_whitespace();
+        let _output = parts.next();
+        let key = parts.next().unwrap_or_default();
+        if key == "keymode" {
+            let value = parts.collect::<Vec<_>>().join(" ");
+            if !value.is_empty() && value != "default" {
+                return Some(value);
+            }
+        }
+    }
+    None
+}
+
+fn parse_tags(raw: &str) -> (HashMap<String, OutputTagState>, Vec<String>) {
+    let mut output_states: HashMap<String, OutputTagState> = HashMap::new();
+    let mut outputs = Vec::new();
+
+    for line in raw.lines() {
+        let parts = line.split_whitespace().collect::<Vec<_>>();
+        if parts.len() < 2 {
+            continue;
+        }
+
+        let output = parts[0].to_string();
+        if !outputs.contains(&output) {
+            outputs.push(output.clone());
+        }
+
+        let state = output_states.entry(output).or_default();
+
+        if parts[1] == "tag" && parts.len() >= 6 {
+            let tag_id = parts[2].parse::<i32>().unwrap_or(0);
+            if tag_id <= 0 {
+                continue;
+            }
+
+            let selected = parts[3].parse::<u8>().unwrap_or(0) != 0;
+            let clients = parts[4].parse::<u16>().unwrap_or(0);
+
+            state.tags.insert(tag_id, TagInfo { clients, selected });
+        }
+
+        if parts[1] == "tags" && parts.len() >= 5 {
+            state.selected_mask = parse_mask(parts[2]).unwrap_or(state.selected_mask);
+            state.occupied_mask = parse_mask(parts[3]).unwrap_or(state.occupied_mask);
+            state.urgent_mask = parse_mask(parts[4]).unwrap_or(state.urgent_mask);
+        }
+    }
+
+    (output_states, outputs)
+}
+
+fn resolve_selected_tag_ids(state: &OutputTagState) -> Vec<i32> {
+    // Prefer explicit per-tag selected flags from `mmsg -g/-w -t`.
+    // The bitmask field order can vary across compositor versions/configs.
+    let mut selected = state
+        .tags
+        .iter()
+        .filter_map(|(id, info)| info.selected.then_some(*id))
+        .collect::<Vec<_>>();
+
+    if selected.is_empty() {
+        selected = mask_to_tag_ids(state.selected_mask);
+    }
+
+    selected.sort_unstable();
+    selected.dedup();
+    selected
+}
+
+fn mask_to_tag_ids(mask: u32) -> Vec<i32> {
+    let mut ids = Vec::new();
+    for idx in 0..32 {
+        if (mask & (1 << idx)) != 0 {
+            ids.push((idx + 1) as i32);
+        }
+    }
+    ids
+}
+
+fn parse_mask(value: &str) -> Option<u32> {
+    if value.chars().all(|c| c == '0' || c == '1') {
+        u32::from_str_radix(value, 2)
+            .ok()
+            .or_else(|| value.parse::<u32>().ok())
+    } else {
+        value.parse::<u32>().ok()
+    }
+}

--- a/src/services/compositor/mod.rs
+++ b/src/services/compositor/mod.rs
@@ -1,4 +1,5 @@
 pub mod hyprland;
+pub mod mangowc;
 pub mod niri;
 pub mod types;
 
@@ -43,6 +44,7 @@ async fn broadcaster_event_loop(tx: broadcast::Sender<ServiceEvent<CompositorSer
     let result = match backend {
         CompositorChoice::Hyprland => hyprland::run_listener(&tx).await,
         CompositorChoice::Niri => niri::run_listener(&tx).await,
+        CompositorChoice::Mango => mangowc::run_listener(&tx).await,
     };
 
     if let Err(e) = result {
@@ -56,6 +58,8 @@ fn detect_backend() -> Option<CompositorChoice> {
         Some(CompositorChoice::Hyprland)
     } else if niri::is_available() {
         Some(CompositorChoice::Niri)
+    } else if mangowc::is_available() {
+        Some(CompositorChoice::Mango)
     } else {
         None
     }
@@ -144,6 +148,7 @@ async fn execute_command(
     match backend {
         CompositorChoice::Hyprland => hyprland::execute_command(command).await,
         CompositorChoice::Niri => niri::execute_command(command).await,
+        CompositorChoice::Mango => mangowc::execute_command(command).await,
     }
     .map_err(|e| e.to_string())
 }

--- a/src/services/compositor/niri.rs
+++ b/src/services/compositor/niri.rs
@@ -266,6 +266,7 @@ fn map_state(niri: &EventStreamState) -> CompositorState {
         workspaces,
         monitors,
         active_workspace_id,
+        active_workspace_ids: active_workspace_id.into_iter().collect(),
         active_window,
         keyboard_layout,
         submap: None,

--- a/src/services/compositor/types.rs
+++ b/src/services/compositor/types.rs
@@ -33,10 +33,18 @@ pub struct ActiveWindowNiri {
     pub address: String,
 }
 
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ActiveWindowMango {
+    pub title: String,
+    pub class: String,
+    pub address: String,
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum ActiveWindow {
     Hyprland(ActiveWindowHyprland),
     Niri(ActiveWindowNiri),
+    Mango(ActiveWindowMango),
 }
 
 impl ActiveWindow {
@@ -44,6 +52,7 @@ impl ActiveWindow {
         match self {
             ActiveWindow::Hyprland(w) => &w.title,
             ActiveWindow::Niri(w) => &w.title,
+            ActiveWindow::Mango(w) => &w.title,
         }
     }
 
@@ -51,6 +60,7 @@ impl ActiveWindow {
         match self {
             ActiveWindow::Hyprland(w) => &w.class,
             ActiveWindow::Niri(w) => &w.class,
+            ActiveWindow::Mango(w) => &w.class,
         }
     }
 
@@ -58,6 +68,7 @@ impl ActiveWindow {
         match self {
             ActiveWindow::Hyprland(w) => Ok(&w.initial_title),
             ActiveWindow::Niri(_) => Err("InitialTitle isn't supported on Niri"),
+            ActiveWindow::Mango(_) => Err("InitialTitle isn't supported on MangoWC"),
         }
     }
 
@@ -65,6 +76,7 @@ impl ActiveWindow {
         match self {
             ActiveWindow::Hyprland(w) => Ok(&w.initial_class),
             ActiveWindow::Niri(_) => Err("InitialClass isn't supported on Niri"),
+            ActiveWindow::Mango(_) => Err("InitialClass isn't supported on MangoWC"),
         }
     }
 }
@@ -74,6 +86,7 @@ pub struct CompositorState {
     pub workspaces: Vec<CompositorWorkspace>,
     pub monitors: Vec<CompositorMonitor>,
     pub active_workspace_id: Option<i32>,
+    pub active_workspace_ids: Vec<i32>,
     pub active_window: Option<ActiveWindow>,
     pub keyboard_layout: String,
     pub submap: Option<String>,
@@ -83,6 +96,7 @@ pub struct CompositorState {
 pub enum CompositorChoice {
     Hyprland,
     Niri,
+    Mango,
 }
 
 #[derive(Debug, Clone)]

--- a/website/docs/configuration/modules/keyboard.md
+++ b/website/docs/configuration/modules/keyboard.md
@@ -40,3 +40,5 @@ the "Italian" layout to the 🇮🇹 flag.
 
 This module displays the current keyboard submap in use. It only appears when a submap is active. You can find more information
 about submap in the [Hyprland documentation](https://wiki.hypr.land/Configuring/Binds/#submaps).
+
+On MangoWC this reflects the current keybind mode (keymode).

--- a/website/docs/configuration/modules/window_title.md
+++ b/website/docs/configuration/modules/window_title.md
@@ -15,7 +15,7 @@ Using the `mode` field, you can choose what information to display:
 - `InitialTitle`: The window's initial title text (ex - *kitty* instead of *hyprctl clients*)
 - `InitialClass`: The initial application name or class. This is unlikely to differ from the current class but Hyprland exposes it
 
-Note that *InitialTitle* and *InitialClass* are Hyprland-only and should not be used when running Niri.
+Note that *InitialTitle* and *InitialClass* are Hyprland-only and should not be used when running Niri or MangoWC.
 
 ## Title Length Control
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -4,14 +4,14 @@ sidebar_position: 1
 
 # 🚀 Getting Started
 
-Ashell is a status bar for Hyprland and Niri, written in Rust using the `iced` library.
+Ashell is a status bar for Hyprland, Niri, and MangoWC, written in Rust using the `iced` library.
 
-## Does it only work on Hyprland and Niri?
+## Does it only work on Hyprland, Niri, and MangoWC?
 
 This project originally supported only Hyprland, primarily because
 it is the compositor I use to test ashell.
 
-Thanks to community support, ashell now supports Niri as well.
+Thanks to community support, ashell now supports Niri and MangoWC as well.
 
 In the future, we plan to expand this functionality to other
 Wayland compositors.
@@ -19,11 +19,11 @@ Wayland compositors.
 ## Features
 
 - OS Updates indicator
-- Hyprland/Niri Active Window
-- Hyprland/Niri Workspaces
+- Hyprland/Niri/MangoWC Active Window
+- Hyprland/Niri/MangoWC Workspaces/Tags
 - System Information (CPU, RAM, Temperature)
-- Hyprland/Niri Keyboard Layout
-- Hyprland Keyboard Submap
+- Hyprland/Niri/MangoWC Keyboard Layout
+- Hyprland/MangoWC Keyboard Submap
 - Tray
 - Date and Time
 - Privacy indicators (microphone, camera, and screen sharing usage)

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -6,7 +6,7 @@ import type * as Preset from "@docusaurus/preset-classic";
 
 const config: Config = {
   title: "Ashell",
-  tagline: "A ready to go Wayland status bar for Hyprland and Niri",
+  tagline: "A ready to go Wayland status bar for Hyprland, Niri, and MangoWC",
   favicon: "img/favicon.svg",
 
   // Future flags, see https://docusaurus.io/docs/api/docusaurus-config#future

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -41,7 +41,7 @@ export default function Home(): ReactNode {
   return (
     <Layout
       title={`${siteConfig.title}`}
-      description="A ready to go Wayland status bar for Hyprland and Niri"
+      description="A ready to go Wayland status bar for Hyprland, Niri, and MangoWC"
     >
       <HomepageHeader />
       <main>


### PR DESCRIPTION
Hi @MalpenZibo,

Owing to the roadmap (#450) where you intended to support more compositors I took a crack at implementing support for MangoWC's ipc system i.e `mmsg`. Mango is a tag-based compositor rather than a workspace based compositor which also supports multiple active-tags. From what I could see the assumption earlier was only one active tag/workspace at any time. I introduced `active_workspace_ids` to indicate this with a fallback to the old behavior when multi-tag isn't present. I have added the relevant docs too. This was tested on `mango 0.12.3(cea2bca)` and this seems to work. 

Would appreciate any feedback!

Thanks
Sachin