### PR TITLE
fix(iwd): properly toggle WiFi by controlling all adapters

### DIFF
--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -142,10 +142,10 @@ impl super::NetworkBackend for IwdDbus<'_> {
     }
 
     async fn set_wifi_enabled(&self, enabled: bool) -> anyhow::Result<()> {
-        AdapterProxy::new(self.inner().connection())
-            .await?
-            .set_powered(enabled)
-            .await?;
+        let adapters = self.adapters().await?;
+        for adapter in adapters {
+            adapter.set_powered(enabled).await?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION

The IWD backend's `set_wifi_enabled()` method was only creating a single
AdapterProxy without specifying a path, causing the WiFi toggle to have
no effect. The proxy was not pointing to any actual hardware adapter.
 
This fix:
- Gets all available adapters using `self.adapters()`
- Iterates through each real adapter with proper D-Bus paths
- Sets the powered state on all adapters instead of a non-existent one
 
Resolves the issue where clicking the WiFi button in settings would log
"WiFi enabled: true" but not actually change the WiFi state.
 
Debug logs showed the command being executed but no actual hardware
state change because the original code was controlling a null/invalid
adapter instead of the real MediaTek adapter at `/net/connman/iwd/0`.

`RUST_LOG=ashell::modules::settings::network=debug,ashell::services::network=debug,ashell::services::network::iwd_dbus=debug ./target/debug/ashell`
Before
```
DEBUG [ashell::services::network] Command: ToggleWiFi
DEBUG [ashell::services::network] WiFi enabled: true
DEBUG [ashell::services::network] Command: ToggleWiFi
DEBUG [ashell::services::network] WiFi enabled: true
DEBUG [ashell::services::network] Command: ToggleWiFi
DEBUG [ashell::services::network] WiFi enabled: true
```
After
```
DEBUG [ashell::services::network] WiFi enabled: true
DEBUG [ashell::services::network] Command: ToggleWiFi
DEBUG [ashell::services::network] WiFi enabled: false
DEBUG [ashell::services::network::iwd_dbus] Adapter Powered changed: false
DEBUG [ashell::services::network] WiFi enabled: false
DEBUG [ashell::services::network] Command: ToggleWiFi
DEBUG [ashell::services::network::iwd_dbus] Adapter Powered changed: true
DEBUG [ashell::services::network] WiFi enabled: true
DEBUG [ashell::services::network] WiFi enabled: true
```
@clotodex 


```
DEBUG [ashell::services::network::iwd_dbus] BROKEN CODE: Using adapter path: /org/freedesktop/Adapter
```