### PR TITLE
Fix NFS disk indicator support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ chrono = { version = "0.4", default-features = false, features = [
 ] }
 hyprland = "0.4.0-beta.2"
 serde = { version = "1.0", default-features = false, features = [] }
-sysinfo = "0.37"
+sysinfo = { version = "0.37", features = ["linux-netdevs"] }
 tokio = { version = "1", default-features = false, features = [] }
 zbus = { version = "5", default-features = false, features = ["tokio"] }
 libpulse-binding = { version = "2.28", features = ["pa_v15"] }


### PR DESCRIPTION
Enable `linux-netdevs` feature in `sysinfo` to support NFS and CIFS network filesystems.

Previously, `sysinfo` excluded network devices (NFS/CIFS) by default on Linux,
preventing disk indicators from showing for network mounts. This change enables
the `linux-netdevs` feature to allow detection of network filesystems.

Note: If a network mount is unresponsive (e.g., NFS server down with hard mount
option), the disk refresh may hang. This is a known limitation of `sysinfo` when
using hard-mounted network shares. Users experiencing this issue should consider
using soft mounts or ensuring network mounts are available.

If it is a common issue we could work on some solution later.

Fixes #511