### PR TITLE
Better logging when search for target output fails.

### DIFF
--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -247,7 +247,10 @@ impl Outputs {
 
             Task::batch(vec![destroy_task, destroy_fallback_task, task])
         } else {
-            debug!("Output {:?} does not match configured output target {:?}",name,request_outputs);
+            debug!(
+                "Output {:?} does not match configured output target {:?}",
+                name, request_outputs
+            );
 
             self.0.push((name.to_owned(), None, Some(wl_output)));
 


### PR DESCRIPTION
Ashell will run fine on first boot even if the outputs in the config file do not exist. Coming back from DPMS off, ashell will sometimes randomly disappear when wayland destroys/creates the output. This change lets a user catch this error in the log files as it silently fails before.