### PR TITLE
tempo: timezones in menu

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -420,40 +420,6 @@ impl Tempo {
                 .collect::<Vec<Element<'a, Message>>>(),
         );
 
-        let timezones = Column::with_children(
-            self.config
-                .timezones
-                .iter()
-                .enumerate()
-                .map(|(index, tz_name)| {
-                    if self.current_timezone_index == index {
-                        container(text(format!(
-                            "{}: {}",
-                            tz_name,
-                            self.time_str("%d %h %R", index)
-                        )))
-                        .padding([theme.space.xxs, theme.space.sm])
-                        .style(|theme: &Theme| container::Style {
-                            text_color: Some(theme.palette().success),
-                            ..Default::default()
-                        })
-                        .into()
-                    } else {
-                        button(text(format!(
-                            "{}: {}",
-                            tz_name,
-                            self.time_str("%d %h %R", index)
-                        )))
-                        .on_press(Message::SetTimezone(index))
-                        .padding([theme.space.xxs, theme.space.sm])
-                        .width(Length::Fixed(225.))
-                        .style(theme.ghost_button_style())
-                        .into()
-                    }
-                })
-                .collect::<Vec<Element<'a, Message>>>(),
-        );
-
         column!(
             button(
                 column!(


### PR DESCRIPTION
<img width="1379" height="1170" alt="image" src="https://github.com/user-attachments/assets/ec4d9c52-7318-43e1-b175-573a8264d57d" />

What do you guys think about adding the timezones as a list of buttons in the tempo menu view, so that it is easy to see what timezone is what time, and also enabling laptop users to change the displayed timezone (since scrolling doesnt work on touchpad).