### PR TITLE
Filter out stopped players from MPRIS player list

### DIFF
--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -264,6 +264,7 @@ impl MprisPlayerService {
         .await
         .into_iter()
         .flatten()
+        .filter(|player| player.state != PlaybackStatus::Stopped)
         .collect()
     }
 


### PR DESCRIPTION
@clotodex can you check if this resolves it for you? 

I have testes with chromium 
open chromium, 
open 2 YT tabs, 
play the first one, 
open spotify, 
play spotify, 
close the YT tab that is active 
shifts to the second non-playing YT video, without this there is an entry in the mplayer menu with this one it is gone.


closes  https://github.com/MalpenZibo/ashell/issues/498