### PR TITLE
Add coordinates-based weather location and improve location name formatting

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -284,6 +284,7 @@ pub enum WeatherLocation {
     #[default]
     Current,
     City(String),
+    Coordinates(f32, f32),
 }
 
 impl Default for TempoModuleConfig {

--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -455,9 +455,13 @@ impl Tempo {
                                 .width(Length::Shrink),
                             column!(
                                 text(format!(
-                                    "{}, {} - {}",
+                                    "{}{} - {}",
                                     location.city,
-                                    location.region_name,
+                                    if location.region_name.is_empty() {
+                                        String::new()
+                                    } else {
+                                        format!(", {}", location.region_name)
+                                    },
                                     data.current.time.format("%R")
                                 ))
                                 .size(theme.font_size.sm),
@@ -822,7 +826,79 @@ async fn fetch_location(location: &WeatherLocation) -> anyhow::Result<Location> 
 
             Ok(data.into())
         }
+        WeatherLocation::Coordinates(lat, lon) => {
+            let (city, region_name) = match try_reverse_geocode(&client, *lat, *lon).await {
+                Ok(Some((city, region))) => (city, region),
+                _ => (format!("Lat: {}, Lon: {}", lat, lon), String::new()),
+            };
+
+            Ok(Location {
+                latitude: *lat,
+                longitude: *lon,
+                city,
+                region_name,
+            })
+        }
     }
+}
+
+async fn try_reverse_geocode(
+    client: &reqwest::Client,
+    lat: f32,
+    lon: f32,
+) -> anyhow::Result<Option<(String, String)>> {
+    let url = format!(
+        "https://nominatim.openstreetmap.org/reverse?format=json&lat={}&lon={}&accept-language=en",
+        lat, lon
+    );
+
+    // Nominatim requires a custom User-Agent header per their usage policy
+    let response = client
+        .get(&url)
+        .header("User-Agent", "ashell")
+        .send()
+        .await?;
+
+    if response.status().is_success() {
+        let raw_data = response.text().await?;
+
+        if let Ok(json) = serde_json::from_str::<serde_json::Value>(&raw_data)
+            && let Some(address) = json.get("address")
+        {
+            let mut city = None;
+
+            if let Some(c) = address.get("city").and_then(|v| v.as_str()) {
+                city = Some(c);
+            } else if let Some(t) = address.get("town").and_then(|v| v.as_str()) {
+                city = Some(t);
+            } else if let Some(v) = address.get("village").and_then(|v| v.as_str()) {
+                city = Some(v);
+            } else if let Some(h) = address.get("hamlet").and_then(|v| v.as_str()) {
+                city = Some(h);
+            }
+
+            // Return city and country if both available and different
+            if let Some(country) = address.get("country").and_then(|v| v.as_str())
+                && let Some(city_name) = city
+            {
+                return Ok(Some((
+                    city_name.to_string(),
+                    if city_name != country {
+                        country.to_string()
+                    } else {
+                        String::new() // Don't repeat city name as region i.e. Singapore, Singapore
+                    },
+                )));
+            }
+
+            // Return just the city if no country found
+            if let Some(city_name) = city {
+                return Ok(Some((city_name.to_string(), String::new())));
+            }
+        }
+    }
+
+    Ok(None)
 }
 
 #[derive(Clone, Debug, Deserialize)]
@@ -844,11 +920,26 @@ pub struct GeoLocation {
 
 impl From<GeoLocation> for Location {
     fn from(value: GeoLocation) -> Self {
+        // Prefer country over admin1 if they're the same (avoids "Stockholm, Stockholm")
+        let region_name = if let Some(admin1) = &value.admin1 {
+            if let Some(country) = &value.country {
+                if admin1 == country || admin1 == &value.name {
+                    country.clone()
+                } else {
+                    admin1.clone()
+                }
+            } else {
+                admin1.clone()
+            }
+        } else {
+            value.country.unwrap_or_default()
+        };
+
         Location {
             latitude: value.latitude,
             longitude: value.longitude,
             city: value.name,
-            region_name: value.admin1.or(value.country).unwrap_or_default(),
+            region_name,
         }
     }
 }

--- a/website/docs/configuration/modules/tempo.md
+++ b/website/docs/configuration/modules/tempo.md
@@ -4,26 +4,29 @@ sidebar_position: 9
 
 # Tempo
 
-Tempo combines a highly configurable clock with an optional weather summary in the status bar—you can run it as a clock-only module or pair it with live conditions. Clicking the module opens a rich menu with a calendar, hourly forecast, and a seven-day outlook.
+Tempo combines a highly configurable clock with an optional weather summary in the status bar—you can run it as a
+clock-only module or pair it with live conditions. Clicking the module opens a rich menu with a calendar, hourly
+forecast, and a seven-day outlook.
 
 ## What Tempo shows
 
-- **Status bar** – current time (using your preferred `clock_format`) and, when weather data is available, an icon + temperature badge that match the current conditions.
+- **Status bar** – current time (using your preferred `clock_format`) and, when weather data is available, an icon +
+  temperature badge that match the current conditions.
 - **Menu** – a resizable panel containing:
-  - A calendar with month navigation and highlighted selections.
-  - Current city, timestamp, weather description, feels-like temperature, humidity, and wind information.
-  - A horizontally scrollable hourly forecast.
-  - A vertically stacked seven-day forecast with dominant wind direction and speeds.
+    - A calendar with month navigation and highlighted selections.
+    - Current city, timestamp, weather description, feels-like temperature, humidity, and wind information.
+    - A horizontally scrollable hourly forecast.
+    - A vertically stacked seven-day forecast with dominant wind direction and speeds.
 
 ## Configuration
 
-| Option             | Type     | Default       | Description                                                                                                                                                                                           |
-| ------------------ | -------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clock_format`     | `string` | `%a %d %b %R` | Strftime-compatible format used for the clock in the bar and in the menu header. See the [chrono formatting guide](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for placeholders. |
-| `formats`          | `array`  | `[]`          | Multiple datetime formats that can be cycled through by right-clicking the clock. When provided, clicking cycles through each format in sequence.                                                     |
-| `timezones`        | `array`  | `[]`          | Timezone identifiers that can be cycled through by scrolling. Supports both IANA names (e.g., `"UTC"`, `"America/New_York"`) and fixed offsets (e.g., `"+00:00"`, `"-05:00"`).                        |
-| `weather_location` | `enum`   | `None`        | Determines which coordinates are queried when requesting weather data. `Current` geo-locates via IP using `ip-api.com`. Use the `City` variant to pin the module to a specific place.                 |
-| `weather_indicator`| `enum`   | `IconAndTemperature`| Determines what information about the weather is shown in the bar, valid options are `None`, `Icon`, and `IconAndTemperature`.           |
+| Option              | Type     | Default              | Description                                                                                                                                                                                                                                      |
+|---------------------|----------|----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `clock_format`      | `string` | `%a %d %b %R`        | Strftime-compatible format used for the clock in the bar and in the menu header. See the [chrono formatting guide](https://docs.rs/chrono/latest/chrono/format/strftime/index.html) for placeholders.                                            |
+| `formats`           | `array`  | `[]`                 | Multiple datetime formats that can be cycled through by right-clicking the clock. When provided, clicking cycles through each format in sequence.                                                                                                |
+| `timezones`         | `array`  | `[]`                 | Timezone identifiers that can be cycled through by scrolling. Supports both IANA names (e.g., `"UTC"`, `"America/New_York"`) and fixed offsets (e.g., `"+00:00"`, `"-05:00"`).                                                                   |
+| `weather_location`  | `enum`   | `None`               | Determines which coordinates are queried when requesting weather data. `Current` geo-locates via IP using `ip-api.com`. Use the `City` variant to pin the module to a specific place. Use `Coordinates` to specify exact latitude and longitude. |
+| `weather_indicator` | `enum`   | `IconAndTemperature` | Determines what information about the weather is shown in the bar, valid options are `None`, `Icon`, and `IconAndTemperature`.                                                                                                                   |
 
 ### City-based weather
 
@@ -32,6 +35,14 @@ Tempo combines a highly configurable clock with an optional weather summary in t
 clock_format = "%a %d %b %R"
 weather_location = { City = "Rome" }
 weather_indicator = "Icon"
+```
+
+### Coordinates-based weather
+
+```toml
+[tempo]
+clock_format = "%a %d %b %R"
+weather_location = { Coordinates = [40.7128, -74.0060] }  # New York City
 ```
 
 ### Clock-only mode
@@ -46,7 +57,8 @@ clock_format = "%a %d %b %R"
 
 ### Format Cycling
 
-The Tempo module supports multiple datetime formats that can be cycled through by right-clicking on the clock. When the `formats` array is provided, right-clicking the clock will cycle through each format in sequence.
+The Tempo module supports multiple datetime formats that can be cycled through by right-clicking on the clock. When the
+`formats` array is provided, right-clicking the clock will cycle through each format in sequence.
 
 - If `formats` is empty or not provided, the clock uses the single `clock_format` string
 - If `formats` contains entries, right-clicking cycles through them and the single `clock_format` is ignored
@@ -73,7 +85,8 @@ formats = [
 
 ### Timezone Support
 
-Tempo supports cycling through multiple timezones by scrolling on the clock widget. The `timezones` array accepts both IANA timezone names and fixed offset strings.
+Tempo supports cycling through multiple timezones by scrolling on the clock widget. The `timezones` array accepts both
+IANA timezone names and fixed offset strings.
 
 - IANA names (e.g., `"UTC"`, `"America/New_York"`) are used when the format contains `%Z` to show timezone abbreviations
 - Fixed offsets (e.g., `"+00:00"`, `"-05:00"`) are used for numeric offset display with `%z`, `%:z`, etc.
@@ -125,12 +138,16 @@ weather_location = "Current"
 
 ## Networking & privacy
 
-- Tempo fetches location data either from `ip-api.com` (for `Current`) or from Open-Meteo's geocoding endpoint (for `City`).
-- Weather observations and forecasts are requested from the Open-Meteo API every 30 minutes. Ensure `ashell` has network access.
+- Tempo fetches location data either from `ip-api.com` (for `Current`), from Open-Meteo's geocoding endpoint (for
+  `City`), or uses reverse geocoding from Nominatim (OpenStreetMap) to get location names for `Coordinates`.
+- Weather observations and forecasts are requested from the Open-Meteo API every 30 minutes. Ensure `ashell` has network
+  access.
 - If an API call fails the module keeps showing the last successful reading and logs a warning.
 
 ## Tips
 
-1. Include seconds in `clock_format` (e.g., `%T`) only if you need them—the module automatically increases the refresh rate when second specifiers are present.
+1. Include seconds in `clock_format` (e.g., `%T`) only if you need them—the module automatically increases the refresh
+   rate when second specifiers are present.
 2. Use `City` when running behind VPNs or privacy relays, so the weather is tied to a predictable location.
-3. Combine Tempo with the dynamic menu wrapper branch to get a spacious layout for the weather panel.
+3. Use `Coordinates` when you need precise weather data for a specific location that doesn't correspond to a well-known
+   city.


### PR DESCRIPTION
This PR introduces a new Coordinates variant for the `weather_location` configuration option, allowing users to specify exact latitude and longitude coordinates for weather data instead of relying on city names or IP geolocation.
`weather_location = { Coordinates = [48.10462851097691, 17.230284715357683] }`

The implementation includes reverse geocoding via Nominatim (OpenStreetMap) to convert coordinates into readable location names, displaying them in the format "City, Country". When reverse geocoding fails, the coordinates are displayed in a compact "Lat: X, Lon: Y" format.
@MalpenZibo I am not sure if you are OK with OSM

<img width="422" height="180" alt="image" src="https://github.com/user-attachments/assets/acd608cf-387f-4e5c-ad24-62f007d44531" />


Key improvements include proper separation of city and region names in the UI, avoiding redundant displays like "Stockholm, Stockholm", and ensuring consistent formatting across all location types. The coordinates are validated to ensure they fall within valid geographic bounds, and the implementation follows the existing code patterns for error handling and API integration.

<img width="1229" height="522" alt="Image" src="https://github.com/user-attachments/assets/9255c286-d0c0-4b15-bd23-1944c410898b" />

<img width="2247" height="607" alt="image" src="https://github.com/user-attachments/assets/c58459c2-b519-4e0d-815c-da0a5e1330e2" />


And where city == country like Singapore 
<img width="447" height="165" alt="image" src="https://github.com/user-attachments/assets/e2589c04-ffb2-4983-8f8c-a99456a527d3" />


The documentation has been updated to include examples of the new coordinates configuration format.


closes https://github.com/MalpenZibo/ashell/issues/528