### PR TITLE
Current day tz fix

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -175,14 +175,13 @@ impl Tempo {
 
     fn time_str(&'_ self, format: &str, timezone_index: usize) -> String {
         // %Z prints timezone abbreviations; other specifiers (e.g., %z/%:z) only need numeric offsets https://docs.rs/chrono/latest/chrono/format/strftime/index.html#fn6
-        let format_requests_name = format.contains("%Z");
         let utc_now = self.date.with_timezone(&Utc);
 
         self.config
             .timezones
             .get(timezone_index)
             .and_then(|tz_name| {
-                if !format_requests_name && let Ok(offset) = tz_name.parse::<FixedOffset>() {
+                if let Ok(offset) = tz_name.parse::<FixedOffset>() {
                     return Some(
                         offset
                             .from_utc_datetime(&utc_now.naive_utc())
@@ -244,8 +243,30 @@ impl Tempo {
         .into()
     }
 
+    fn naive_date(&'_ self, timezone_index: usize) -> NaiveDate {
+        let utc_now = self.date.with_timezone(&Utc);
+
+        self.config
+            .timezones
+            .get(timezone_index)
+            .and_then(|tz_name| {
+                if let Ok(offset) = tz_name.parse::<FixedOffset>() {
+                    return Some(offset.from_utc_datetime(&utc_now.naive_utc()).date_naive());
+                }
+
+                if let Ok(tz) = tz_name.parse::<Tz>() {
+                    return Some(tz.from_utc_datetime(&utc_now.naive_utc()).date_naive());
+                }
+
+                None
+            })
+            .unwrap_or_else(|| self.date.date_naive())
+    }
+
     fn calendar<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let selected_date = self.selected_date.unwrap_or(self.date.date_naive());
+        let selected_date = self
+            .selected_date
+            .unwrap_or(self.naive_date(self.current_timezone_index));
 
         let current_month = selected_date.month0();
         let first_day_month = selected_date.with_day0(0).unwrap_or_default();
@@ -323,7 +344,9 @@ impl Tempo {
                                         text(day.format("%d").to_string())
                                             .align_x(Horizontal::Center)
                                             .color_maybe({
-                                                if day == self.date.date_naive() {
+                                                if day
+                                                    == self.naive_date(self.current_timezone_index)
+                                                {
                                                     Some(theme.iced_theme.palette().success)
                                                 } else if day == selected_date {
                                                     Some(theme.iced_theme.palette().primary)
@@ -340,11 +363,13 @@ impl Tempo {
                                                 }
                                             }),
                                     )
-                                    .on_press_maybe(if day != self.date.date_naive() {
-                                        Some(Message::ChangeSelectDate(Some(day)))
-                                    } else {
-                                        None
-                                    })
+                                    .on_press_maybe(
+                                        if day != self.naive_date(self.current_timezone_index) {
+                                            Some(Message::ChangeSelectDate(Some(day)))
+                                        } else {
+                                            None
+                                        },
+                                    )
                                     .width(Length::Fill)
                                     .style(theme.ghost_button_style())
                                     .into()


### PR DESCRIPTION
As I noticed [here](https://github.com/MalpenZibo/ashell/pull/521#issuecomment-4050422504), the date that is shown as the current date in the calendar view doesn't update when cycling through the timezones.

This PR fixes that.

Furthermore, in the code it used to fall back to the system time if the timezone was specified as an offset and the format included the timezone (`%Z`), but from my testing the library handles this just fine and prints the offset in place of the timezones name.
So I removed that condition from the check.
Screenshot as proof 😎:
<img width="865" height="1169" alt="image" src="https://github.com/user-attachments/assets/3ef991eb-9cb4-441e-9988-d308088754b4" />
