### PR TITLE
Brightness Slider

### DIFF
--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -6,19 +6,18 @@ use crate::{
         brightness::{BrightnessCommand, BrightnessService},
     },
     theme::AshellTheme,
+    utils::remote_value,
 };
 use iced::{
-    Alignment, Element, Length, Subscription, Task,
-    futures::stream,
-    widget::{MouseArea, container, row, slider, text},
+    Alignment, Element, Subscription, Task,
+    mouse::ScrollDelta,
+    widget::{MouseArea, Text, container, row, slider, text},
 };
 
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(ServiceEvent<BrightnessService>),
-    Change(u32),
-    MenuOpened,
-    ResetUserAdjusting,
+    Changed(remote_value::Message<u32>),
     ConfigReloaded(SettingsFormat),
 }
 
@@ -30,9 +29,6 @@ pub enum Action {
 pub struct BrightnessSettings {
     config: SettingsFormat,
     service: Option<BrightnessService>,
-    ui_percentage: u32,
-    is_user_adjusting: bool,
-    reset_timer_active: bool,
 }
 
 impl BrightnessSettings {
@@ -40,86 +36,47 @@ impl BrightnessSettings {
         Self {
             config,
             service: None,
-            ui_percentage: 50,
-            is_user_adjusting: false,
-            reset_timer_active: false,
         }
     }
 
-    fn calculate_scroll_brightness(
-        current_percentage: u32,
-        max_value: u32,
-        delta: iced::mouse::ScrollDelta,
-    ) -> Message {
-        let delta = match delta {
-            iced::mouse::ScrollDelta::Lines { y, .. } => y,
-            iced::mouse::ScrollDelta::Pixels { y, .. } => y,
-        };
-        // brightness is always changed by one less than expected
-        let new_percentage = if delta > 0.0 {
-            (current_percentage + 5 + 1).min(100)
-        } else {
-            current_percentage.saturating_sub(5 + 1)
-        };
-        let new_brightness = new_percentage * max_value / 100;
-        Message::Change(new_brightness)
+    fn on_scroll(current: u32, max: u32) -> impl Fn(ScrollDelta) -> Message {
+        move |delta| {
+            let y = match delta {
+                ScrollDelta::Lines { y, .. } => y,
+                ScrollDelta::Pixels { y, .. } => y,
+            };
+            let step = (5 * max / 100).max(1);
+            let new = if y > 0.0 {
+                (current + step).min(max)
+            } else {
+                current.saturating_sub(step)
+            };
+            Message::Changed(remote_value::Message::RequestAndTimeout(new))
+        }
     }
 
     pub fn update(&mut self, message: Message) -> Action {
         match message {
             Message::Event(event) => match event {
                 ServiceEvent::Init(service) => {
-                    self.ui_percentage = service.current * 100 / service.max;
                     self.service = Some(service);
                     Action::None
                 }
                 ServiceEvent::Update(data) => {
                     if let Some(service) = self.service.as_mut() {
                         service.update(data);
-                        // Only update UI if the difference is significant and user isn't actively adjusting
-                        if !self.is_user_adjusting {
-                            let new_percentage = service.current * 100 / service.max;
-                            if (new_percentage as i32 - self.ui_percentage as i32).abs() > 2 {
-                                self.ui_percentage = new_percentage;
-                            }
-                        }
                     }
                     Action::None
                 }
                 _ => Action::None,
             },
-            Message::Change(value) => {
-                self.is_user_adjusting = true;
-                self.reset_timer_active = true;
-                self.ui_percentage = value * 100
-                    / if let Some(service) = &self.service {
-                        service.max
-                    } else {
-                        100
-                    };
-                match self.service.as_mut() {
-                    Some(service) => Action::Command(
-                        service
-                            .command(BrightnessCommand::Set(value))
-                            .map(Message::Event),
-                    ),
-                    _ => Action::None,
-                }
-            }
-            Message::MenuOpened => {
+            Message::Changed(message) => {
                 if let Some(service) = self.service.as_mut() {
-                    Action::Command(
-                        service
-                            .command(BrightnessCommand::Refresh)
-                            .map(Message::Event),
-                    )
-                } else {
-                    Action::None
+                    if let Some(value) = message.value() {
+                        let _ = service.command(BrightnessCommand(value));
+                    }
+                    return Action::Command(service.current.update(message).map(Message::Changed));
                 }
-            }
-            Message::ResetUserAdjusting => {
-                self.is_user_adjusting = false;
-                self.reset_timer_active = false;
                 Action::None
             }
             Message::ConfigReloaded(format) => {
@@ -129,27 +86,25 @@ impl BrightnessSettings {
         }
     }
 
-    pub fn slider(&'_ self, theme: &AshellTheme) -> Option<Element<'_, Message>> {
+    pub fn slider<'a>(&'a self, theme: &AshellTheme) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
-            let max = service.max;
-            let current_percentage = self.ui_percentage;
             row!(
                 container(icon_mono(StaticIcon::Brightness))
                     .center_x(32.)
                     .center_y(32.)
                     .clip(true),
                 MouseArea::new(
-                    slider(0..=100, current_percentage, move |v| {
-                        Message::Change(v * max / 100)
-                    })
-                    .step(1_u32)
-                    .width(Length::Fill),
+                    Element::<'a, remote_value::Message<u32>>::from(
+                        slider(
+                            0..=service.max,
+                            service.current.value(),
+                            remote_value::Message::Request,
+                        )
+                        .on_release(remote_value::Message::Timeout),
+                    )
+                    .map(Message::Changed)
                 )
-                .on_scroll(move |delta| Self::calculate_scroll_brightness(
-                    current_percentage,
-                    max,
-                    delta
-                )),
+                .on_scroll(Self::on_scroll(service.current.value(), service.max))
             )
             .align_y(Alignment::Center)
             .spacing(theme.space.xs)
@@ -162,11 +117,7 @@ impl BrightnessSettings {
         theme: &'a AshellTheme,
     ) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
-            let percentage = self.ui_percentage;
-            let max_value = service.max;
-
-            let scroll_handler =
-                move |delta| Self::calculate_scroll_brightness(percentage, max_value, delta);
+            let scroll_handler = Self::on_scroll(service.current.value(), service.max);
 
             match self.config {
                 SettingsFormat::Icon => {
@@ -174,14 +125,14 @@ impl BrightnessSettings {
                     MouseArea::new(icon).on_scroll(scroll_handler).into()
                 }
                 SettingsFormat::Percentage | SettingsFormat::Time => {
-                    MouseArea::new(text(format!("{}%", percentage)))
+                    MouseArea::new(Self::percent_text(service))
                         .on_scroll(scroll_handler)
                         .into()
                 }
                 SettingsFormat::IconAndPercentage | SettingsFormat::IconAndTime => {
                     let icon = icon_mono(StaticIcon::Brightness);
                     MouseArea::new(
-                        row!(icon, text(format!("{}%", percentage)))
+                        row!(icon, Self::percent_text(service))
                             .spacing(theme.space.xxs)
                             .align_y(Alignment::Center),
                     )
@@ -193,19 +144,13 @@ impl BrightnessSettings {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        Subscription::batch([
-            BrightnessService::subscribe().map(Message::Event),
-            if self.reset_timer_active {
-                Subscription::run_with_id(
-                    0,
-                    stream::once(async {
-                        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
-                        Message::ResetUserAdjusting
-                    }),
-                )
-            } else {
-                Subscription::none()
-            },
-        ])
+        BrightnessService::subscribe().map(Message::Event)
+    }
+
+    pub fn percent_text<'a>(service: &BrightnessService) -> Text<'a> {
+        let percent = (service.current.value() * 100)
+            .checked_div(service.max)
+            .unwrap_or(0); // Always show 0%, if max_brightness happens to be 0
+        text(format!("{percent}%"))
     }
 }

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -415,14 +415,7 @@ impl Settings {
                     )
                 };
 
-                // Batch both tasks to run in parallel
-                let brightness_task = match self.brightness.update(brightness::Message::MenuOpened)
-                {
-                    brightness::Action::None => Task::none(),
-                    brightness::Action::Command(task) => task.map(Message::Brightness),
-                };
-
-                Action::Command(Task::batch([custom_buttons_task, brightness_task]))
+                Action::Command(custom_buttons_task)
             }
             Message::ConfigReloaded(config) => {
                 self.lock_cmd = config.lock_cmd;

--- a/src/services/brightness.rs
+++ b/src/services/brightness.rs
@@ -1,4 +1,5 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
+use crate::{services::throttle::ThrottleExt, utils::remote_value::Remote};
 use iced::{
     Subscription, Task,
     futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending},
@@ -8,23 +9,27 @@ use log::{debug, error, info, warn};
 use std::{
     any::TypeId,
     fs,
-    ops::Deref,
+    ops::{Deref, DerefMut},
     path::{Path, PathBuf},
+    time::Duration,
 };
-use tokio::io::{Interest, unix::AsyncFd};
+use tokio::{
+    io::{Interest, unix::AsyncFd},
+    sync::mpsc::{UnboundedReceiver, UnboundedSender},
+};
+use tokio_stream::wrappers::UnboundedReceiverStream;
 use zbus::proxy;
 
 #[derive(Debug, Clone, Default)]
 pub struct BrightnessData {
-    pub current: u32,
+    pub current: Remote<u32>,
     pub max: u32,
 }
 
 #[derive(Debug, Clone)]
 pub struct BrightnessService {
     data: BrightnessData,
-    device_path: PathBuf,
-    conn: zbus::Connection,
+    commander: UnboundedSender<BrightnessCommand>,
 }
 
 impl Deref for BrightnessService {
@@ -32,6 +37,12 @@ impl Deref for BrightnessService {
 
     fn deref(&self) -> &Self::Target {
         &self.data
+    }
+}
+
+impl DerefMut for BrightnessService {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.data
     }
 }
 
@@ -43,21 +54,17 @@ impl BrightnessService {
         Ok(max_brightness)
     }
 
-    async fn get_actual_brightness(device_path: &Path) -> anyhow::Result<u32> {
-        let actual_brightness = fs::read_to_string(device_path.join("actual_brightness"))?;
-        let actual_brightness = actual_brightness.trim().parse::<u32>()?;
-
-        Ok(actual_brightness)
+    async fn get_brightness(device_path: &Path) -> anyhow::Result<u32> {
+        let brightness = fs::read_to_string(device_path.join("brightness"))?;
+        let brightness = brightness.trim().parse::<u32>()?;
+        Ok(brightness)
     }
 
     async fn initialize_data(device_path: &Path) -> anyhow::Result<BrightnessData> {
         let max_brightness = Self::get_max_brightness(device_path).await?;
-        let actual_brightness = Self::get_actual_brightness(device_path).await?;
-
-        debug!("Max brightness: {max_brightness}, current brightness: {actual_brightness}");
-
+        let actual_brightness = Self::get_brightness(device_path).await?;
         Ok(BrightnessData {
-            current: actual_brightness,
+            current: Remote::new(actual_brightness),
             max: max_brightness,
         })
     }
@@ -101,6 +108,20 @@ impl BrightnessService {
         Ok(enumerator.scan_devices()?.collect())
     }
 
+    fn start_commander(
+        conn: zbus::Connection,
+        device_path: PathBuf,
+        to_server_rx: UnboundedReceiver<BrightnessCommand>,
+    ) {
+        tokio::spawn(async move {
+            let mut stream =
+                UnboundedReceiverStream::new(to_server_rx).throttle(Duration::from_millis(100));
+            while let Some(cmd) = stream.next().await {
+                let _ = BrightnessService::set_brightness(&conn, &device_path, cmd.0).await;
+            }
+        });
+    }
+
     async fn start_listening(state: State, output: &mut Sender<ServiceEvent<Self>>) -> State {
         match state {
             State::Init => match Self::init_service().await {
@@ -109,11 +130,12 @@ impl BrightnessService {
 
                     match data {
                         Ok(data) => {
+                            let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+                            Self::start_commander(conn.clone(), device_path.clone(), rx);
                             let _ = output
                                 .send(ServiceEvent::Init(BrightnessService {
                                     data,
-                                    device_path: device_path.to_path_buf(),
-                                    conn,
+                                    commander: tx,
                                 }))
                                 .await;
 
@@ -134,9 +156,7 @@ impl BrightnessService {
             },
             State::Active(device_path) => {
                 info!("Listening for brightness events");
-                let current_value = Self::get_actual_brightness(&device_path)
-                    .await
-                    .unwrap_or_default();
+                let current_value = Self::get_brightness(&device_path).await.unwrap_or_default();
 
                 match BrightnessService::backlight_monitor_listener().await {
                     Ok(mut socket) => {
@@ -158,7 +178,7 @@ impl BrightnessService {
                                                         evt.syspath()
                                                     );
                                                     let new_value =
-                                                        Self::get_actual_brightness(&device_path)
+                                                        Self::get_brightness(&device_path)
                                                             .await
                                                             .unwrap_or_default();
 
@@ -241,7 +261,7 @@ impl ReadOnlyService for BrightnessService {
     type Error = ();
 
     fn update(&mut self, event: Self::UpdateEvent) {
-        self.data.current = event.0;
+        self.data.current.receive(event.0);
     }
 
     fn subscribe() -> Subscription<ServiceEvent<Self>> {
@@ -261,39 +281,14 @@ impl ReadOnlyService for BrightnessService {
 }
 
 #[derive(Debug, Clone)]
-pub enum BrightnessCommand {
-    Set(u32),
-    Refresh,
-}
+pub struct BrightnessCommand(pub u32);
 
 impl Service for BrightnessService {
     type Command = BrightnessCommand;
 
     fn command(&mut self, command: Self::Command) -> Task<ServiceEvent<Self>> {
-        Task::perform(
-            {
-                let conn = self.conn.clone();
-                let device_path = self.device_path.clone();
-
-                async move {
-                    match command {
-                        BrightnessCommand::Set(v) => {
-                            debug!("Setting brightness to {v}");
-                            let _ = BrightnessService::set_brightness(&conn, &device_path, v).await;
-
-                            v
-                        }
-                        BrightnessCommand::Refresh => {
-                            debug!("Refreshing brightness data");
-                            BrightnessService::get_actual_brightness(&device_path)
-                                .await
-                                .unwrap_or_default()
-                        }
-                    }
-                }
-            },
-            |v| ServiceEvent::Update(BrightnessEvent(v)),
-        )
+        let _ = self.commander.send(command);
+        Task::none()
     }
 }
 

--- a/src/utils/remote_value.rs
+++ b/src/utils/remote_value.rs
@@ -13,6 +13,15 @@ pub struct Remote<Value> {
     timeout: Option<iced::task::Handle>,
 }
 
+impl<Value: Default> Remote<Value> {
+    pub fn new(value: Value) -> Self {
+        Self {
+            received: value,
+            ..Default::default()
+        }
+    }
+}
+
 impl<Value> Remote<Value>
 where
     Value: Copy + Send + 'static,


### PR DESCRIPTION
This PR contains fixes for brightness slider.

> **Quick context:** while the brightness value can be simply read from the `/sys/class...` filesystem, writing it requires a privileged process - so we must send a dbus message to `org.freedesktop.login1` so `systemd-logind` can handle it. This is why reading and getting and setting uses two different approaches.

- Adopt `Remote<Value>` #531
- Add throttled commander so we don't spam DBUS on every frame.
- Remove retained `ui_percentage` value in favor of computing the percent string only before displaying the `Text` label.
- Remove _refresh values on menu open_ - this must be redundant because we show the value in the status icon too => hence brightness value has to be always up-to-date anyway.
- Use `/sys/class/../brightness` instead of `/sys/class/../actual_brighteness` This is what both [`brightnessctl`](https://github.com/Hummer12007/brightnessctl/blob/e70bc55cf053caa285695ac77507e009b5508ee3/brightnessctl.c#L257) and [`cosmic-settings-daemon`](https://github.com/pop-os/cosmic-settings-daemon/blob/ee782f454a09310a28abe73653e6c82d06a79855/src/brightness_device.rs#L28) are using. On my system there is persistent difference between those values.