### PR TITLE
feat: Media Player Visualizer (cava integration)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -409,7 +409,6 @@ pub struct SettingsCustomButton {
     pub tooltip: Option<String>,
 }
 
-
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]
 pub enum MediaPlayerFormat {
     Icon,

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,6 +409,7 @@ pub struct SettingsCustomButton {
     pub tooltip: Option<String>,
 }
 
+
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]
 pub enum MediaPlayerFormat {
     Icon,
@@ -416,11 +417,33 @@ pub enum MediaPlayerFormat {
     IconAndTitle,
 }
 
+#[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Hash, Debug)]
+pub enum VisualizerChannels {
+    #[default]
+    Stereo,
+    Mono,
+}
+
+#[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Hash, Debug)]
+pub enum VisualizerMonoOption {
+    #[default]
+    Average,
+    Left,
+    Right,
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct MediaPlayerModuleConfig {
     pub max_title_length: u32,
     pub indicator_format: MediaPlayerFormat,
+    pub show_visualizer: bool,
+    pub visualizer_bar_count: u32,
+    pub visualizer_framerate: u32,
+    pub visualizer_padding: u16,
+    pub visualizer_color: VisualizerColor,
+    pub visualizer_channels: VisualizerChannels,
+    pub visualizer_mono_option: VisualizerMonoOption,
 }
 
 impl Default for MediaPlayerModuleConfig {
@@ -428,6 +451,67 @@ impl Default for MediaPlayerModuleConfig {
         MediaPlayerModuleConfig {
             max_title_length: 100,
             indicator_format: MediaPlayerFormat::default(),
+            show_visualizer: false,
+            visualizer_bar_count: 8,
+            visualizer_framerate: 60,
+            visualizer_padding: 3,
+            visualizer_color: VisualizerColor::default(),
+            visualizer_channels: VisualizerChannels::default(),
+            visualizer_mono_option: VisualizerMonoOption::default(),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub enum VisualizerColor {
+    #[default]
+    Text,
+    Primary,
+    Success,
+    Danger,
+    Hex(HexColor),
+    Gradient {
+        low: HexColor,
+        mid: Option<HexColor>,
+        high: HexColor,
+    },
+}
+
+impl<'de> Deserialize<'de> for VisualizerColor {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(untagged)]
+        enum Raw {
+            Str(String),
+            Gradient {
+                low: HexColor,
+                mid: Option<HexColor>,
+                high: HexColor,
+            },
+        }
+
+        match Raw::deserialize(deserializer)? {
+            Raw::Gradient { low, mid, high } => Ok(VisualizerColor::Gradient { low, mid, high }),
+            Raw::Str(s) => {
+                if s.starts_with('#') {
+                    HexColor::parse(&s)
+                        .map(VisualizerColor::Hex)
+                        .map_err(serde::de::Error::custom)
+                } else {
+                    match s.as_str() {
+                        "Text" => Ok(VisualizerColor::Text),
+                        "Primary" => Ok(VisualizerColor::Primary),
+                        "Success" => Ok(VisualizerColor::Success),
+                        "Danger" => Ok(VisualizerColor::Danger),
+                        other => Err(serde::de::Error::custom(format!(
+                            "unknown visualizer color '{other}', expected Text, Primary, Success, Danger, a hex code like #rrggbb, or a gradient table"
+                        ))),
+                    }
+                }
+            }
         }
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::icons::{IconButtonSize, StaticIcon, icon, icon_button},
-    config::{MediaPlayerFormat, MediaPlayerModuleConfig},
+    config::{MediaPlayerFormat, MediaPlayerModuleConfig, VisualizerChannels, VisualizerColor, VisualizerMonoOption},
     menu::MenuSize,
     services::{
         ReadOnlyService, Service, ServiceEvent,
@@ -12,11 +12,171 @@ use crate::{
     utils::truncate_text,
 };
 use iced::{
-    Background, Border, Element, Length, Subscription, Task, Theme,
+    Background, Border, Color, Element, Length, Subscription, Task, Theme,
     alignment::Vertical,
-    widget::{column, container, horizontal_rule, horizontal_space, image, row, slider, text},
+    futures::SinkExt,
+    stream::channel,
+    widget::{
+        canvas::{self, Canvas, Fill, Frame, Geometry, Path},
+        column, container, horizontal_rule, horizontal_space, image, row, slider, text,
+    },
 };
 use std::collections::{HashMap, HashSet};
+
+fn cava_subscription<M, F>(
+    id: impl std::hash::Hash + 'static,
+    bar_count: u32,
+    framerate: u32,
+    channels: VisualizerChannels,
+    mono_option: VisualizerMonoOption,
+    make_msg: F,
+) -> Subscription<M>
+where
+    M: Send + 'static,
+    F: Fn(Vec<f32>) -> M + Send + 'static,
+{
+    Subscription::run_with_id(
+        id,
+        channel(16, async move |mut output| {
+            let mono_opt = match mono_option {
+                VisualizerMonoOption::Average => "average",
+                VisualizerMonoOption::Left => "left",
+                VisualizerMonoOption::Right => "right",
+            };
+            let channels_str = match channels {
+                VisualizerChannels::Stereo => "stereo",
+                VisualizerChannels::Mono => "mono",
+            };
+            let cava_config = format!(
+                "[general]\nbars = {bar_count}\nframerate = {framerate}\n\n\
+                 [output]\nmethod = raw\nraw_target = /dev/stdout\ndata_format = ascii\nascii_max_range = 1000\n\
+                 channels = {channels_str}\nmono_option = {mono_opt}\n\n\
+                 [smoothing]\nmonstercat = 1\n"
+            );
+
+            let config_path = std::env::temp_dir().join("ashell_cava.cfg");
+            if let Err(e) = tokio::fs::write(&config_path, &cava_config).await {
+                log::error!("cava: failed to write config: {e}");
+                return;
+            }
+
+            let mut child = match tokio::process::Command::new("cava")
+                .arg("-p")
+                .arg(&config_path)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null())
+                .spawn()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    log::error!("cava: failed to spawn process: {e}");
+                    return;
+                }
+            };
+
+            let stdout = match child.stdout.take() {
+                Some(s) => s,
+                None => {
+                    log::error!("cava: no stdout");
+                    return;
+                }
+            };
+
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let bars: Vec<f32> = line
+                    .split(';')
+                    .filter(|s| !s.is_empty())
+                    .filter_map(|s| s.trim().parse::<f32>().ok())
+                    .map(|v| v / 1000.0)
+                    .collect();
+
+                if !bars.is_empty() {
+                    let _ = output.send(make_msg(bars)).await;
+                }
+            }
+
+            let _ = child.kill().await;
+        }),
+    )
+}
+
+enum VisualizerFill {
+    Flat(Color),
+    Gradient { low: Color, mid: Option<Color>, high: Color },
+}
+
+struct VisualizerCanvas {
+    bars: Vec<f32>,
+    bar_count: usize,
+    fill: VisualizerFill,
+}
+
+impl<M> canvas::Program<M> for VisualizerCanvas {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &iced::Renderer,
+        _theme: &iced::Theme,
+        bounds: iced::Rectangle,
+        _cursor: iced::mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let mut frame = Frame::new(renderer, bounds.size());
+
+        if self.bars.is_empty() {
+            return vec![frame.into_geometry()];
+        }
+
+        let n = self.bar_count.min(self.bars.len());
+        let bar_width = (bounds.width / (n as f32 * 4.0 / 3.0)).max(1.0);
+        let gap = (bar_width / 3.0).max(1.0);
+        let step = bar_width + gap;
+
+        for i in 0..n {
+            let height = self.bars[i] * bounds.height;
+            let x = i as f32 * step;
+            let y = bounds.height - height;
+
+            let rect = Path::rectangle(iced::Point::new(x, y), iced::Size::new(bar_width, height));
+
+            let fill: Fill = match &self.fill {
+                VisualizerFill::Flat(color) => (*color).into(),
+                VisualizerFill::Gradient { low, mid, high } => {
+                    use iced::gradient::ColorStop;
+                    let stops: &[ColorStop] = match mid {
+                        Some(mid) => &[
+                            ColorStop { offset: 0.0, color: *high },
+                            ColorStop { offset: 0.5, color: *mid },
+                            ColorStop { offset: 1.0, color: *low },
+                        ],
+                        None => &[
+                            ColorStop { offset: 0.0, color: *high },
+                            ColorStop { offset: 1.0, color: *low },
+                        ],
+                    };
+                    let grad = canvas::gradient::Linear::new(
+                        iced::Point::new(x, 0.0),
+                        iced::Point::new(x, bounds.height),
+                    )
+                    .add_stops(stops.iter().copied());
+                    Fill {
+                        style: canvas::Style::Gradient(canvas::Gradient::Linear(grad)),
+                        ..Fill::default()
+                    }
+                }
+            };
+
+            frame.fill(&rect, fill);
+        }
+
+        vec![frame.into_geometry()]
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -26,6 +186,7 @@ pub enum Message {
     SetVolume(String, f64),
     Event(ServiceEvent<MprisPlayerService>),
     ConfigReloaded(MediaPlayerModuleConfig),
+    Bars(Vec<f32>),
 }
 
 pub enum Action {
@@ -37,6 +198,7 @@ pub struct MediaPlayer {
     config: MediaPlayerModuleConfig,
     service: Option<MprisPlayerService>,
     covers: HashMap<String, image::Handle>,
+    bars: Vec<f32>,
 }
 
 impl MediaPlayer {
@@ -45,6 +207,7 @@ impl MediaPlayer {
             config,
             service: None,
             covers: HashMap::new(),
+            bars: vec![],
         }
     }
 
@@ -68,12 +231,24 @@ impl MediaPlayer {
                         service.update(d);
                     }
                     self.sync_cover_handles();
+                    let is_playing = self
+                        .service
+                        .as_ref()
+                        .and_then(|s| s.players().first().map(|p| p.state == PlaybackStatus::Playing))
+                        .unwrap_or(false);
+                    if !is_playing {
+                        self.bars.clear();
+                    }
                     Action::None
                 }
                 ServiceEvent::Error(_) => Action::None,
             },
             Message::ConfigReloaded(c) => {
                 self.config = c;
+                Action::None
+            }
+            Message::Bars(bars) => {
+                self.bars = bars;
                 Action::None
             }
         }
@@ -247,8 +422,41 @@ impl MediaPlayer {
                         .clip(true)
                     });
 
+                let visualizer = (self.config.show_visualizer
+                    && player.state == PlaybackStatus::Playing
+                    && !self.bars.is_empty())
+                .then(|| {
+                    let bar_count = self.config.visualizer_bar_count as usize;
+                    let padding = self.config.visualizer_padding;
+                    let palette = theme.get_theme().palette();
+                    let fill = match &self.config.visualizer_color {
+                        VisualizerColor::Text => VisualizerFill::Flat(palette.text),
+                        VisualizerColor::Primary => VisualizerFill::Flat(palette.primary),
+                        VisualizerColor::Success => VisualizerFill::Flat(palette.success),
+                        VisualizerColor::Danger => VisualizerFill::Flat(palette.danger),
+                        VisualizerColor::Hex(h) => VisualizerFill::Flat(Color::from_rgb8(h.r, h.g, h.b)),
+                        VisualizerColor::Gradient { low, mid, high } => VisualizerFill::Gradient {
+                            low: Color::from_rgb8(low.r, low.g, low.b),
+                            mid: mid.map(|m| Color::from_rgb8(m.r, m.g, m.b)),
+                            high: Color::from_rgb8(high.r, high.g, high.b),
+                        },
+                    };
+                    container(
+                        Canvas::new(VisualizerCanvas {
+                            bars: self.bars.clone(),
+                            bar_count,
+                            fill,
+                        })
+                        .width(Length::Fixed((bar_count * 4).max(20) as f32))
+                        .height(Length::Fill),
+                    )
+                    .padding([padding, 0])
+                    .height(Length::Fill)
+                });
+
                 row![icon(StaticIcon::MusicNote)]
                     .push_maybe(title)
+                    .push_maybe(visualizer)
                     .align_y(Vertical::Center)
                     .spacing(theme.space.xs)
                     .into()
@@ -257,7 +465,28 @@ impl MediaPlayer {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        MprisPlayerService::subscribe().map(Message::Event)
+        let cava = self.config.show_visualizer.then(|| {
+            cava_subscription(
+                (
+                    "media_player_cava",
+                    self.config.visualizer_bar_count,
+                    self.config.visualizer_framerate,
+                    self.config.visualizer_channels,
+                    self.config.visualizer_mono_option,
+                ),
+                self.config.visualizer_bar_count,
+                self.config.visualizer_framerate,
+                self.config.visualizer_channels,
+                self.config.visualizer_mono_option,
+                Message::Bars,
+            )
+        });
+        Subscription::batch([
+            Some(MprisPlayerService::subscribe().map(Message::Event)),
+            cava,
+        ]
+        .into_iter()
+        .flatten())
     }
 
     fn sync_cover_handles(&mut self) {

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -1,6 +1,9 @@
 use crate::{
     components::icons::{IconButtonSize, StaticIcon, icon, icon_button},
-    config::{MediaPlayerFormat, MediaPlayerModuleConfig, VisualizerChannels, VisualizerColor, VisualizerMonoOption},
+    config::{
+        MediaPlayerFormat, MediaPlayerModuleConfig, VisualizerChannels, VisualizerColor,
+        VisualizerMonoOption,
+    },
     menu::MenuSize,
     services::{
         ReadOnlyService, Service, ServiceEvent,
@@ -106,7 +109,11 @@ where
 
 enum VisualizerFill {
     Flat(Color),
-    Gradient { low: Color, mid: Option<Color>, high: Color },
+    Gradient {
+        low: Color,
+        mid: Option<Color>,
+        high: Color,
+    },
 }
 
 struct VisualizerCanvas {
@@ -150,13 +157,28 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
                     use iced::gradient::ColorStop;
                     let stops: &[ColorStop] = match mid {
                         Some(mid) => &[
-                            ColorStop { offset: 0.0, color: *high },
-                            ColorStop { offset: 0.5, color: *mid },
-                            ColorStop { offset: 1.0, color: *low },
+                            ColorStop {
+                                offset: 0.0,
+                                color: *high,
+                            },
+                            ColorStop {
+                                offset: 0.5,
+                                color: *mid,
+                            },
+                            ColorStop {
+                                offset: 1.0,
+                                color: *low,
+                            },
                         ],
                         None => &[
-                            ColorStop { offset: 0.0, color: *high },
-                            ColorStop { offset: 1.0, color: *low },
+                            ColorStop {
+                                offset: 0.0,
+                                color: *high,
+                            },
+                            ColorStop {
+                                offset: 1.0,
+                                color: *low,
+                            },
                         ],
                     };
                     let grad = canvas::gradient::Linear::new(
@@ -234,7 +256,11 @@ impl MediaPlayer {
                     let is_playing = self
                         .service
                         .as_ref()
-                        .and_then(|s| s.players().first().map(|p| p.state == PlaybackStatus::Playing))
+                        .and_then(|s| {
+                            s.players()
+                                .first()
+                                .map(|p| p.state == PlaybackStatus::Playing)
+                        })
                         .unwrap_or(false);
                     if !is_playing {
                         self.bars.clear();
@@ -434,7 +460,9 @@ impl MediaPlayer {
                         VisualizerColor::Primary => VisualizerFill::Flat(palette.primary),
                         VisualizerColor::Success => VisualizerFill::Flat(palette.success),
                         VisualizerColor::Danger => VisualizerFill::Flat(palette.danger),
-                        VisualizerColor::Hex(h) => VisualizerFill::Flat(Color::from_rgb8(h.r, h.g, h.b)),
+                        VisualizerColor::Hex(h) => {
+                            VisualizerFill::Flat(Color::from_rgb8(h.r, h.g, h.b))
+                        }
                         VisualizerColor::Gradient { low, mid, high } => VisualizerFill::Gradient {
                             low: Color::from_rgb8(low.r, low.g, low.b),
                             mid: mid.map(|m| Color::from_rgb8(m.r, m.g, m.b)),
@@ -481,12 +509,14 @@ impl MediaPlayer {
                 Message::Bars,
             )
         });
-        Subscription::batch([
-            Some(MprisPlayerService::subscribe().map(Message::Event)),
-            cava,
-        ]
-        .into_iter()
-        .flatten())
+        Subscription::batch(
+            [
+                Some(MprisPlayerService::subscribe().map(Message::Event)),
+                cava,
+            ]
+            .into_iter()
+            .flatten(),
+        )
     }
 
     fn sync_cover_handles(&mut self) {

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -41,6 +41,18 @@ where
     Subscription::run_with_id(
         id,
         channel(16, async move |mut output| {
+            if tokio::process::Command::new("cava")
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .await
+                .is_err()
+            {
+                log::warn!("cava: not found, visualizer disabled");
+                return;
+            }
+
             let mono_opt = match mono_option {
                 VisualizerMonoOption::Average => "average",
                 VisualizerMonoOption::Left => "left",

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -21,6 +21,67 @@ the current title. Configure this with the `indicator_format` field:
 
 Use `Icon` if you want a compact indicator or have limited space.
 
+## Visualizer
+
+The media player module includes an optional audio visualizer powered by [CAVA](https://github.com/karlstav/cava). It renders animated bars in the status bar indicator, visible only while a player is actively playing.
+
+> **Requires** `cava` to be installed and available on your `$PATH`.
+
+Enable it with:
+
+```toml
+[media_player]
+show_visualizer = true
+```
+
+### Visualizer Options
+
+| Field                    | Type    | Default    | Description                                              |
+| ------------------------ | ------- | ---------- | -------------------------------------------------------- |
+| `show_visualizer`        | bool    | `false`    | Enable or disable the visualizer.                        |
+| `visualizer_bar_count`   | integer | `8`        | Number of frequency bars to display.                     |
+| `visualizer_framerate`   | integer | `60`       | Target framerate for CAVA output.                        |
+| `visualizer_padding`     | integer | `3`        | Horizontal padding around the visualizer canvas (px).    |
+| `visualizer_color`       | color   | `"Text"`   | Bar colour — see [Colour](#colour) below.                |
+| `visualizer_channels`    | string  | `"Stereo"` | `"Stereo"` or `"Mono"`.                                  |
+| `visualizer_mono_option` | string  | `"Average"`| Mono mix mode: `"Average"`, `"Left"`, or `"Right"`.      |
+
+### Colour
+
+`visualizer_color` accepts several formats:
+
+**Theme palette names:**
+
+| Value       | Description                          |
+| ----------- | ------------------------------------ |
+| `"Text"`    | Uses the theme text colour (default).|
+| `"Primary"` | Uses the theme primary colour.       |
+| `"Success"` | Uses the theme success colour.       |
+| `"Danger"`  | Uses the theme danger colour.        |
+
+**Hex code:**
+
+```toml
+visualizer_color = "#a6e3a1"
+```
+
+**Per-bar gradient** (colour depends on bar height — low frequencies/quiet levels show `low`, loud/high levels show `high`):
+
+```toml
+visualizer_color = { low = "#a6e3a1", mid = "#f9e2af", high = "#f38ba8" }
+```
+
+`mid` is optional. When omitted the gradient interpolates directly between `low` and `high`.
+
+### Channels
+
+By default CAVA outputs stereo, which mirrors the frequency spectrum (bass in the centre). Switch to mono for the classic left-to-right low-to-high layout:
+
+```toml
+visualizer_channels = "Mono"
+visualizer_mono_option = "Average"  # "Average" | "Left" | "Right"
+```
+
 ## Menu
 
 The menu shows all active media players with playback controls:
@@ -33,5 +94,12 @@ The menu shows all active media players with playback controls:
 ```toml
 [media_player]
 max_title_length = 50
-indicator_format = "Icon"
+indicator_format = "IconAndTitle"
+show_visualizer = true
+visualizer_bar_count = 12
+visualizer_framerate = 60
+visualizer_padding = 3
+visualizer_channels = "Mono"
+visualizer_mono_option = "Average"
+visualizer_color = { low = "#a6e3a1", mid = "#f9e2af", high = "#f38ba8" }
 ```


### PR DESCRIPTION
Feature addition of a [cava](https://github.com/karlstav/cava) visualizer to media player. Only shows media is playing through the active player. 
Includes configuration options for the following:

| Field                    | Type    | Default    | Description                                              |
| ------------------------ | ------- | ---------- | -------------------------------------------------------- |
| `show_visualizer`        | bool    | `false`    | Enable or disable the visualizer.                        |
| `visualizer_bar_count`   | integer | `8`        | Number of frequency bars to display.                     |
| `visualizer_framerate`   | integer | `60`       | Target framerate for CAVA output.                        |
| `visualizer_padding`     | integer | `3`        | Horizontal padding around the visualizer canvas (px).    |
| `visualizer_color`       | color   | `"Text"`   | Bar colour — see Color below.                |
| `visualizer_channels`    | string  | `"Stereo"` | `"Stereo"` or `"Mono"`.                                  |
| `visualizer_mono_option` | string  | `"Average"`| Mono mix mode: `"Average"`, `"Left"`, or `"Right"`.      |

Example Config:

```toml
[media_player]
show_visualizer = true
visualizer_bar_count = 32
visualizer_color =  { low = "#a6e3a1", mid = "#f9e2af", high = "#f38ba8" }
visualizer_channels = "Mono"
visualizer_mono_option = "Average"
```

<img width="598" height="40" alt="image" src="https://github.com/user-attachments/assets/2aeb3f39-02ed-4653-833f-b2ded8067483" />
