### PR TITLE
docs: update features in README to reflect Tempo changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,22 @@ page on website
 
 ## ✨ Features
 
-- App Launcher button
-- Сlipboard button
 - OS Updates indicator
 - Hyprland/Niri Active Window
 - Hyprland/Niri Workspaces
-- System Information (CPU, RAM, Temperature)
+- System Information (CPU, RAM, Disk, Network, Temperature)
 - Hyprland/Niri Keyboard Layout
 - Hyprland Keyboard Submap
 - Tray
-- Date time
+- Clock with calendar, weather, timezone cycling, and format cycling (Tempo)
 - Privacy (check microphone, camera and screenshare usage)
-- Media Player
+- Media Player with album art
 - Settings panel
   - Power menu
   - Battery information
-  - Audio sources and sinks
+  - Audio sources and sinks (with microphone)
   - Screen brightness
-  - Network stuff
+  - Network
   - VPN
   - Bluetooth
   - Power profiles


### PR DESCRIPTION
forgot this one 

No idea if you want to keep the default images or if you want to make a full featured screenshot 
like 
<img width="3824" height="30" alt="image" src="https://github.com/user-attachments/assets/8d68791b-95a4-4209-8b51-f54e93d30c85" />

related #507 