### PR TITLE
feat(system_info): add configurable polling interval for updates

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -223,10 +223,18 @@ pub enum SystemInfoIndicator {
 #[serde(default)]
 pub struct SystemInfoModuleConfig {
     pub indicators: Vec<SystemInfoIndicator>,
+    #[serde(default = "SystemInfoModuleConfig::default_interval")]
+    pub interval: u64,
     pub cpu: SystemInfoCpu,
     pub memory: SystemInfoMemory,
     pub temperature: SystemInfoTemperature,
     pub disk: SystemInfoDisk,
+}
+
+impl SystemInfoModuleConfig {
+    const fn default_interval() -> u64 {
+        5
+    }
 }
 
 impl Default for SystemInfoModuleConfig {
@@ -237,6 +245,7 @@ impl Default for SystemInfoModuleConfig {
                 SystemInfoIndicator::Memory,
                 SystemInfoIndicator::Temperature,
             ],
+            interval: Self::default_interval(),
             cpu: SystemInfoCpu::default(),
             memory: SystemInfoMemory::default(),
             temperature: SystemInfoTemperature::default(),

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -512,6 +512,6 @@ impl SystemInfo {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        every(Duration::from_secs(5)).map(|_| Message::Update)
+        every(Duration::from_secs(self.config.interval)).map(|_| Message::Update)
     }
 }

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -35,6 +35,7 @@ truncate_title_after_length = 100
 
 [system_info]
 indicators = [ "Cpu", "Memory", "Temperature" ]
+interval = 5
 
 [system_info.cpu]
 warn_threshold = 60

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -116,6 +116,18 @@ Common sensor labels include:
 - `amdgpu edge` - AMD GPU temperature
 - `nvme Composite MODEL_NAME` - NVMe SSD temperature (use model from `lsblk` output)
 
+## Polling Interval
+
+You can configure how often the system information is refreshed using the `interval` option (in seconds). The default is `5` seconds.
+
+```toml
+[system_info]
+indicators = [ "Cpu", "Memory", "Temperature" ]
+interval = 10
+```
+
+Higher values reduce CPU usage at the cost of less frequent updates.
+
 ## Warning and Alert Thresholds
 
 You can also configure the warning and alert thresholds for the following indicators:
@@ -146,6 +158,7 @@ configure and can be one of:
 ```toml
 [system_info]
 indicators = [ "Cpu", "Memory", "Temperature" ]
+interval = 5
 
 [system_info.cpu]
 warn_threshold = 60


### PR DESCRIPTION
introduce interval field in SystemInfoModuleConfig with default 5 and wire it into subscription timing to allow dynamic refresh docs updated to describe the new option and its default