### PR TITLE
fix/config threshold validation

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -65,6 +65,12 @@ impl Default for Config {
     }
 }
 
+impl Config {
+    fn validate(&mut self) {
+        self.system_info.validate();
+    }
+}
+
 #[derive(Deserialize, Clone, Debug)]
 pub struct UpdatesModuleConfig {
     pub check_cmd: String,
@@ -139,6 +145,25 @@ pub struct SystemInfoCpu {
     pub alert_threshold: u32,
 }
 
+fn validate_thresholds<T: PartialOrd + Copy + std::fmt::Display>(
+    warn: &mut T,
+    alert: &mut T,
+    name: &str,
+) {
+    if *warn >= *alert {
+        warn!(
+            "{name} warn_threshold ({warn}) >= alert_threshold ({alert}), setting both to {alert}"
+        );
+        *warn = *alert;
+    }
+}
+
+impl SystemInfoCpu {
+    fn validate(&mut self) {
+        validate_thresholds(&mut self.warn_threshold, &mut self.alert_threshold, "CPU");
+    }
+}
+
 impl Default for SystemInfoCpu {
     fn default() -> Self {
         Self {
@@ -153,6 +178,16 @@ impl Default for SystemInfoCpu {
 pub struct SystemInfoMemory {
     pub warn_threshold: u32,
     pub alert_threshold: u32,
+}
+
+impl SystemInfoMemory {
+    fn validate(&mut self) {
+        validate_thresholds(
+            &mut self.warn_threshold,
+            &mut self.alert_threshold,
+            "Memory",
+        );
+    }
 }
 
 impl Default for SystemInfoMemory {
@@ -172,6 +207,16 @@ pub struct SystemInfoTemperature {
     pub sensor: String,
 }
 
+impl SystemInfoTemperature {
+    fn validate(&mut self) {
+        validate_thresholds(
+            &mut self.warn_threshold,
+            &mut self.alert_threshold,
+            "Temperature",
+        );
+    }
+}
+
 impl Default for SystemInfoTemperature {
     fn default() -> Self {
         Self {
@@ -187,6 +232,12 @@ impl Default for SystemInfoTemperature {
 pub struct SystemInfoDisk {
     pub warn_threshold: u32,
     pub alert_threshold: u32,
+}
+
+impl SystemInfoDisk {
+    fn validate(&mut self) {
+        validate_thresholds(&mut self.warn_threshold, &mut self.alert_threshold, "Disk");
+    }
 }
 
 impl Default for SystemInfoDisk {
@@ -234,6 +285,13 @@ pub struct SystemInfoModuleConfig {
 impl SystemInfoModuleConfig {
     const fn default_interval() -> u64 {
         5
+    }
+
+    fn validate(&mut self) {
+        self.cpu.validate();
+        self.memory.validate();
+        self.temperature.validate();
+        self.disk.validate();
     }
 }
 
@@ -861,6 +919,8 @@ fn read_config(path: &Path) -> Result<Config, Box<dyn Error + Send>> {
     match res {
         Ok(config) => {
             info!("Config file loaded successfully");
+            let mut config: Config = config;
+            config.validate();
             Ok(config)
         }
         Err(e) => {

--- a/src/config.rs
+++ b/src/config.rs
@@ -67,6 +67,9 @@ impl Default for Config {
 
 impl Config {
     fn validate(&mut self) {
+        if let Some(ref mut updates) = self.updates {
+            updates.validate();
+        }
         self.system_info.validate();
     }
 }
@@ -82,6 +85,13 @@ pub struct UpdatesModuleConfig {
 impl UpdatesModuleConfig {
     const fn default_interval() -> u64 {
         3600
+    }
+
+    fn validate(&mut self) {
+        if self.interval == 0 {
+            warn!("UpdatesModuleConfig.interval is 0, setting to 1");
+            self.interval = 1;
+        }
     }
 }
 
@@ -288,6 +298,10 @@ impl SystemInfoModuleConfig {
     }
 
     fn validate(&mut self) {
+        if self.interval == 0 {
+            warn!("SystemInfoModuleConfig.interval is 0, setting to 1");
+            self.interval = 1;
+        }
         self.cpu.validate();
         self.memory.validate();
         self.temperature.validate();


### PR DESCRIPTION
fixed the panic when setting the interval to 0. 

Also there was no validation if warn < alert threshold. 


```
/srv/opensource/ashell remove/clock-module* ≡ 15s
❯ ashell
INFO [ashell::config] Decoding config file "/home/roman/.config/ashell/config.toml"
INFO [ashell::config] Config file loaded successfully
WARN [ashell::modules::clock] Clock module is deprecated and will be removed in a future release. Please migrate to the Tempo module.
ERROR [ashell] Panic: panicked at /home/roman/.cargo/git/checkouts/iced-a711726c6f80dbab/ba37674/futures/src/backend/native/tokio.rs:58:32:
`period` must be non-zero. 
 disabled backtrace
fish: Job 1, 'ashell' terminated by signal SIGABRT (Abort)

/srv/opensource/ashell remove/clock-module* ≡
❯ cargo r
    Blocking waiting for file lock on build directory
   Compiling ashell v0.8.0 (/srv/opensource/ashell)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 18.56s
     Running `target/debug/ashell`
INFO [ashell::config] Decoding config file "/home/roman/.config/ashell/config.toml"
INFO [ashell::config] Config file loaded successfully
WARN [ashell::config] SystemInfoModuleConfig.interval is 0, setting to 1
WARN [ashell::config] CPU warn_threshold (90) >= alert_threshold (80), setting both to 80
WARN [ashell::modules::clock] Clock module is deprecated and will be removed in a future release. Please migrate to the Tempo module.
WARN [ashell::services::upower] Failed to get power profile: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
WARN [wgpu_hal::gles::egl] Re-initializing Gles context due to Wayland window
^C⏎                                                                                                                                                           
```
