### PR TITLE
fix: replace logger init unwrap with stderr fallback

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -73,7 +73,16 @@ fn main() -> iced::Result {
     } else {
         logger
     };
-    let logger = logger.start().unwrap();
+    let logger = logger.start().unwrap_or_else(|e| {
+        eprintln!("Failed to initialize file logger: {e}, falling back to stderr-only");
+        Logger::with(
+            LogSpecBuilder::new()
+                .default(log::LevelFilter::Info)
+                .build(),
+        )
+        .start()
+        .expect("critical: cannot initialize any logger")
+    });
     panic::set_hook(Box::new(|info| {
         let b = Backtrace::capture();
         error!("Panic: {info} \n {b}");


### PR DESCRIPTION
I want to go trough all `.unwrap()` or places where a panic could occur and be more forgiving(if possible) or at least add a comment in which cases something can happen to have at least some idea why something is how it is.
I think and hope this shouldn't affect @MalpenZibo rework of the backend too much.

In this case the previous `unwrap() `on `logger.start()` would crash the entire bar if `flexi_logger` failed to initialize 
(e.g. /tmp/ashell unwritable). 
Now falls back to a stderr-only logger if file logging fails.

If both fail(writing to stdout/stderr not possible), then something is badly wrong and we crash with an expect.