### PR TITLE
Add configurable workspace scrolling direction

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -121,9 +121,8 @@ pub struct WorkspacesModuleConfig {
 pub enum InvertScrollDirection {
     #[default]
     All,
-    Mice,
-    Trackpads,
-    None,
+    Mouse,
+    Trackpad,
 }
 
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -112,6 +112,7 @@ pub struct WorkspacesModuleConfig {
     pub max_workspaces: Option<u32>,
     pub workspace_names: Vec<String>,
     pub enable_virtual_desktops: bool,
+    pub invert_workspace_scroll_direction: bool,
 }
 
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,16 @@ pub struct WorkspacesModuleConfig {
     pub max_workspaces: Option<u32>,
     pub workspace_names: Vec<String>,
     pub enable_virtual_desktops: bool,
-    pub invert_workspace_scroll_direction: bool,
+    pub invert_scroll_direction: Option<InvertScrollDirection>,
+}
+
+#[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]
+pub enum InvertScrollDirection {
+    #[default]
+    All,
+    Mice,
+    Trackpads,
+    None,
 }
 
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -482,14 +482,22 @@ impl Workspaces {
         )
         .on_scroll(move |direction| match direction {
             iced::mouse::ScrollDelta::Lines { y, .. } => {
-                match self.config.invert_scroll_direction {
-                    Some(InvertScrollDirection::All | InvertScrollDirection::Mice) => {
-                        Message::Scroll(-y as i32)
+                if y.is_sign_positive() {
+                    match self.config.invert_scroll_direction {
+                        Some(InvertScrollDirection::All | InvertScrollDirection::Mouse) => {
+                            Message::Scroll(-1)
+                        }
+                        Some(InvertScrollDirection::Trackpad) => Message::Scroll(1),
+                        None => Message::Scroll(1),
                     }
-                    Some(InvertScrollDirection::Trackpads | InvertScrollDirection::None) => {
-                        Message::Scroll(y as i32)
+                } else {
+                    match self.config.invert_scroll_direction {
+                        Some(InvertScrollDirection::All | InvertScrollDirection::Mouse) => {
+                            Message::Scroll(1)
+                        }
+                        Some(InvertScrollDirection::Trackpad) => Message::Scroll(-1),
+                        None => Message::Scroll(-1),
                     }
-                    None => Message::Scroll(y as i32),
                 }
             }
             iced::mouse::ScrollDelta::Pixels { y, .. } => {
@@ -497,15 +505,21 @@ impl Workspaces {
 
                 if self.scroll_accumulator.abs() < sensibility {
                     Message::ScrollAccumulator(y)
+                } else if self.scroll_accumulator.is_sign_positive() {
+                    match self.config.invert_scroll_direction {
+                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
+                            Message::Scroll(1)
+                        }
+                        Some(InvertScrollDirection::Mouse) => Message::Scroll(-1),
+                        None => Message::Scroll(-1),
+                    }
                 } else {
                     match self.config.invert_scroll_direction {
-                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpads) => {
-                            Message::Scroll(-y as i32)
+                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
+                            Message::Scroll(-1)
                         }
-                        Some(InvertScrollDirection::Mice | InvertScrollDirection::None) => {
-                            Message::Scroll(y as i32)
-                        }
-                        None => Message::Scroll(y as i32),
+                        Some(InvertScrollDirection::Mouse) => Message::Scroll(1),
+                        None => Message::Scroll(1),
                     }
                 }
             }

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -508,18 +508,18 @@ impl Workspaces {
                 } else if self.scroll_accumulator.is_sign_positive() {
                     match self.config.invert_scroll_direction {
                         Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
-                            Message::Scroll(1)
-                        }
-                        Some(InvertScrollDirection::Mouse) => Message::Scroll(-1),
-                        None => Message::Scroll(-1),
-                    }
-                } else {
-                    match self.config.invert_scroll_direction {
-                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
                             Message::Scroll(-1)
                         }
                         Some(InvertScrollDirection::Mouse) => Message::Scroll(1),
                         None => Message::Scroll(1),
+                    }
+                } else {
+                    match self.config.invert_scroll_direction {
+                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
+                            Message::Scroll(1)
+                        }
+                        Some(InvertScrollDirection::Mouse) => Message::Scroll(-1),
+                        None => Message::Scroll(-1),
                     }
                 }
             }

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -1,5 +1,5 @@
 use crate::{
-    config::{WorkspaceVisibilityMode, WorkspacesModuleConfig},
+    config::{InvertScrollDirection, WorkspaceVisibilityMode, WorkspacesModuleConfig},
     outputs::Outputs,
     services::{
         ReadOnlyService, Service, ServiceEvent,
@@ -482,9 +482,14 @@ impl Workspaces {
         )
         .on_scroll(move |direction| match direction {
             iced::mouse::ScrollDelta::Lines { y, .. } => {
-                match self.config.invert_workspace_scroll_direction {
-                    true => Message::Scroll(y as i32),
-                    false => Message::Scroll(-y as i32),
+                match self.config.invert_scroll_direction {
+                    Some(InvertScrollDirection::All | InvertScrollDirection::Mice) => {
+                        Message::Scroll(-y as i32)
+                    }
+                    Some(InvertScrollDirection::Trackpads | InvertScrollDirection::None) => {
+                        Message::Scroll(y as i32)
+                    }
+                    None => Message::Scroll(y as i32),
                 }
             }
             iced::mouse::ScrollDelta::Pixels { y, .. } => {
@@ -492,10 +497,16 @@ impl Workspaces {
 
                 if self.scroll_accumulator.abs() < sensibility {
                     Message::ScrollAccumulator(y)
-                } else if self.scroll_accumulator.is_sign_positive() {
-                    Message::Scroll(-1)
                 } else {
-                    Message::Scroll(1)
+                    match self.config.invert_scroll_direction {
+                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpads) => {
+                            Message::Scroll(-y as i32)
+                        }
+                        Some(InvertScrollDirection::Mice | InvertScrollDirection::None) => {
+                            Message::Scroll(y as i32)
+                        }
+                        None => Message::Scroll(y as i32),
+                    }
                 }
             }
         })

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -486,8 +486,8 @@ impl Workspaces {
         .on_scroll(move |direction| match direction {
             iced::mouse::ScrollDelta::Lines { y, .. } => {
                 match self.config.invert_workspace_scroll_direction {
-                    true => Message::Scroll(y as i32 * 1),
-                    false => Message::Scroll(y as i32 * -1)
+                    true => Message::Scroll(y as i32),
+                    false => Message::Scroll(-y as i32)
                 }
             }
             iced::mouse::ScrollDelta::Pixels { y, .. } => {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -485,10 +485,9 @@ impl Workspaces {
         )
         .on_scroll(move |direction| match direction {
             iced::mouse::ScrollDelta::Lines { y, .. } => {
-                if y > 0. {
-                    Message::Scroll(-1)
-                } else {
-                    Message::Scroll(1)
+                match self.config.invert_workspace_scroll_direction {
+                    true => Message::Scroll(y as i32 * 1),
+                    false => Message::Scroll(y as i32 * -1)
                 }
             }
             iced::mouse::ScrollDelta::Pixels { y, .. } => {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -487,7 +487,7 @@ impl Workspaces {
             iced::mouse::ScrollDelta::Lines { y, .. } => {
                 match self.config.invert_workspace_scroll_direction {
                     true => Message::Scroll(y as i32),
-                    false => Message::Scroll(-y as i32)
+                    false => Message::Scroll(-y as i32),
                 }
             }
             iced::mouse::ScrollDelta::Pixels { y, .. } => {

--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -119,10 +119,11 @@ enable_virtual_desktops = true
 
 ## Workspace Scrolling Direction
 
-You can use the `invert_workspace_scroll_direction` bool to choose between 2 modes of scrolling:
+You can use the `invert_scroll_direction` field to choose whether to invert the scrolling direction for mice and trackpads:
 
-- `true`: Scrolling up will go to the previous workspace and down will go to the next one
-- `false`: Scrolling up will go to the next workspace and down will go to the previous one (default)
+- `All`: Affects both mice and trackpads. Scrolling down will go to the previous workspace and up will go to the next one
+- `Mouse`: Scrolling up will go to the next workspace and down will go to the previous one
+- `Trackpad`: Swiping up will go to the next workspace and down will go to the previous one
 
 ## Default Configuration
 
@@ -134,7 +135,7 @@ visibility_mode = "All"
 group_by_monitor = false
 enable_workspace_filling = false
 disable_special_workspaces = false
-invert_workspace_scroll_direction = false
+invert_scroll_direction = None
 ```
 
 ## Examples

--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -117,6 +117,13 @@ enabled.
 enable_virtual_desktops = true
 ```
 
+## Workspace Scrolling Direction
+
+You can use the `invert_workspace_scroll_direction` bool to choose between 2 modes of scrolling:
+
+- `true`: Scrolling up will go to the previous workspace and down will go to the next one
+- `false`: Scrolling up will go to the next workspace and down will go to the previous one (default)
+
 ## Default Configuration
 
 The default configuration is:
@@ -127,6 +134,7 @@ visibility_mode = "All"
 group_by_monitor = false
 enable_workspace_filling = false
 disable_special_workspaces = false
+invert_workspace_scroll_direction = false
 ```
 
 ## Examples

--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -121,9 +121,9 @@ enable_virtual_desktops = true
 
 You can use the `invert_scroll_direction` field to choose whether to invert the scrolling direction for mice and trackpads:
 
-- `All`: Affects both mice and trackpads. Scrolling down will go to the previous workspace and up will go to the next one
+- `All`: Enables both *Mouse* and *Trackpad* options below.
 - `Mouse`: Scrolling up will go to the next workspace and down will go to the previous one
-- `Trackpad`: Swiping up will go to the next workspace and down will go to the previous one
+- `Trackpad`: Swiping up will go to the previous workspace and down will go to the next one
 
 ## Default Configuration
 


### PR DESCRIPTION
As discussed here: https://github.com/MalpenZibo/ashell/issues/616, adds a setting to configure the workspace scroll mode.

2 modes:
1. Natural, the default option, makes it so scrolling up will go to the next sequential workspace and scrolling down will go to the previous one. This is the current behavior in master.
2. Traditional is the opposite of this.

I'm not very good with naming things, so let me know if these need to change.

Tested on hyprland and niri.