### PR TITLE
(Chore) Notification refactor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1710,7 +1710,7 @@ dependencies = [
 [[package]]
 name = "iced_layershell"
 version = "0.1.0"
-source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.0#99c26f3f6b37a0aa32a2edb0b97102163a32c30c"
+source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.1#6dcb8dc1fca8be1ce47222beae6d5a7d2c5c8f0c"
 dependencies = [
  "calloop",
  "calloop-wayland-source",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
-iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.0", features = [
+iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.1", features = [
   "tokio",
   "advanced",
   "wgpu",

--- a/src/app.rs
+++ b/src/app.rs
@@ -362,6 +362,10 @@ impl App {
                     info!("Output created: {info:?}");
                     let name = &info.name;
 
+                    if let Some((_, h)) = info.logical_size {
+                        self.outputs.set_output_logical_height(info.id, h as u32);
+                    }
+
                     self.outputs.add(
                         self.theme.bar_style,
                         &self.general_config.outputs,
@@ -407,17 +411,22 @@ impl App {
                 modules::notifications::Action::None => Task::none(),
                 modules::notifications::Action::Task(task) => task.map(Message::Notifications),
                 modules::notifications::Action::Show(task) => {
-                    let (width, height) = self.notifications.toast_layer_size(&self.theme);
                     let position = self.notifications.toast_position();
+                    let width = crate::menu::MenuSize::Medium.size() as u32;
                     Task::batch(vec![
                         task.map(Message::Notifications),
-                        self.outputs.show_toast_layer(width, height, position),
+                        self.outputs.show_toast_layer(width, position),
                     ])
                 }
                 modules::notifications::Action::Hide(task) => Task::batch(vec![
                     task.map(Message::Notifications),
                     self.outputs.hide_toast_layer(),
                 ]),
+                modules::notifications::Action::UpdateToastInputRegion(content_size) => {
+                    let position = self.notifications.toast_position();
+                    self.outputs
+                        .update_toast_input_region(content_size, position)
+                }
             },
             Message::None => Task::none(),
             Message::ToggleVisibility => {

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -124,6 +124,7 @@ pub enum StaticIcon {
     Remove,
     Bell,
     BellBadge,
+    Delete,
 }
 
 impl StaticIcon {
@@ -235,6 +236,7 @@ impl StaticIcon {
             StaticIcon::Remove => "\u{f0377}",
             StaticIcon::Bell => "\u{eaa2}",
             StaticIcon::BellBadge => "\u{eb9a}",
+            StaticIcon::Delete => "\u{f01b4}",
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -405,7 +405,6 @@ pub enum ToastPosition {
 pub struct NotificationsModuleConfig {
     pub format: String,
     pub show_timestamps: bool,
-    pub max_notifications: Option<usize>,
     pub show_bodies: bool,
     pub grouped: bool,
     pub toast: bool,
@@ -415,14 +414,12 @@ pub struct NotificationsModuleConfig {
     pub toast_width: u16,
     pub toast_summary_line_budget: u32,
     pub toast_body_line_budget: u32,
-    pub empty_state_height: f32,
 }
 impl Default for NotificationsModuleConfig {
     fn default() -> Self {
         Self {
             format: "%H:%M".to_string(),
             show_timestamps: true,
-            max_notifications: None,
             show_bodies: true,
             grouped: false,
             toast: true,
@@ -432,7 +429,6 @@ impl Default for NotificationsModuleConfig {
             toast_width: 380,
             toast_summary_line_budget: 3,
             toast_body_line_budget: 8,
-            empty_state_height: 200.0,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -424,7 +424,7 @@ impl Default for NotificationsModuleConfig {
             toast_position: ToastPosition::default(),
             toast_timeout: 5000,
             toast_limit: 5,
-            toast_height: 250,
+            toast_height: 150,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,7 +411,7 @@ pub struct NotificationsModuleConfig {
     pub toast_position: ToastPosition,
     pub toast_timeout: u64,
     pub toast_limit: usize,
-    pub toast_height: u32,
+    pub toast_max_height: u32,
 }
 impl Default for NotificationsModuleConfig {
     fn default() -> Self {
@@ -424,7 +424,7 @@ impl Default for NotificationsModuleConfig {
             toast_position: ToastPosition::default(),
             toast_timeout: 5000,
             toast_limit: 5,
-            toast_height: 150,
+            toast_max_height: 150,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -409,10 +409,9 @@ pub struct NotificationsModuleConfig {
     pub grouped: bool,
     pub toast: bool,
     pub toast_position: ToastPosition,
-    pub toast_default_timeout: u64,
-    pub toast_max_visible: usize,
-    pub toast_summary_line_budget: u32,
-    pub toast_body_line_budget: u32,
+    pub toast_timeout: u64,
+    pub toast_limit: usize,
+    pub toast_height: u32,
 }
 impl Default for NotificationsModuleConfig {
     fn default() -> Self {
@@ -423,10 +422,9 @@ impl Default for NotificationsModuleConfig {
             grouped: false,
             toast: true,
             toast_position: ToastPosition::default(),
-            toast_default_timeout: 5000,
-            toast_max_visible: 1,
-            toast_summary_line_budget: 3,
-            toast_body_line_budget: 8,
+            toast_timeout: 5000,
+            toast_limit: 5,
+            toast_height: 250,
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -411,7 +411,6 @@ pub struct NotificationsModuleConfig {
     pub toast_position: ToastPosition,
     pub toast_default_timeout: u64,
     pub toast_max_visible: usize,
-    pub toast_width: u16,
     pub toast_summary_line_budget: u32,
     pub toast_body_line_budget: u32,
 }
@@ -426,7 +425,6 @@ impl Default for NotificationsModuleConfig {
             toast_position: ToastPosition::default(),
             toast_default_timeout: 5000,
             toast_max_visible: 1,
-            toast_width: 380,
             toast_summary_line_budget: 3,
             toast_body_line_budget: 8,
         }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -118,7 +118,7 @@ pub enum MenuSize {
 }
 
 impl MenuSize {
-    fn size(&self) -> f32 {
+    pub fn size(&self) -> f32 {
         match self {
             MenuSize::Small => 250.,
             MenuSize::Medium => 350.,

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -15,8 +15,9 @@ use chrono::{DateTime, Local};
 use freedesktop_icons::lookup;
 use iced::{
     Alignment, Background, Border, Color, Column, Element, Length, Row, Subscription, Task, Theme,
-    widget::{Space, button, column, container, image, row, rule, scrollable, svg, text},
+    widget::{Space, button, column, container, image, row, scrollable, svg, text},
 };
+use itertools::Itertools;
 use linicon_theme::get_icon_theme;
 use log::error;
 use std::{
@@ -28,19 +29,6 @@ use zbus::Connection;
 use zbus::zvariant::OwnedValue;
 
 const ICON_SIZE: f32 = 20.0;
-const HORIZONTAL_RULE_HEIGHT: u32 = 1;
-
-fn strong_text_style(theme: &Theme) -> text::Style {
-    text::Style {
-        color: Some(theme.extended_palette().secondary.strong.text),
-    }
-}
-
-fn weak_text_style(theme: &Theme) -> text::Style {
-    text::Style {
-        color: Some(theme.extended_palette().secondary.weak.text),
-    }
-}
 
 fn palette_text_style(theme: &Theme) -> text::Style {
     text::Style {
@@ -261,11 +249,16 @@ pub enum Message {
     ExpireToast(u32),
     DismissToast(u32),
 }
+
+#[derive(Debug, PartialEq)]
 pub enum NotificationStyle {
-    Rectangular,
-    Rounded,
-    BottomRounded,
+    Toast,
+    Standalone,
+    GroupHeader,
+    GroupItem,
+    GroupLast,
 }
+
 pub enum Action {
     None,
     Task(Task<Message>),
@@ -330,20 +323,6 @@ impl Notifications {
             .filter(|notification| notification.app_name == app_name)
             .map(|notification| notification.id)
             .collect()
-    }
-
-    fn grouped_notifications_by_app(&self) -> Vec<(String, Vec<&Notification>)> {
-        let mut grouped: HashMap<String, Vec<&Notification>> = HashMap::new();
-        for notification in &self.notifications {
-            grouped
-                .entry(notification.app_name.clone())
-                .or_default()
-                .push(notification);
-        }
-
-        let mut grouped: Vec<(String, Vec<&Notification>)> = grouped.into_iter().collect();
-        grouped.sort_by(|(left, _), (right, _)| left.cmp(right));
-        grouped
     }
 
     fn icon_for_notification(&self, id: u32) -> &NotificationIcon {
@@ -533,95 +512,72 @@ impl Notifications {
         move |iced_theme: &Theme, status| {
             let mut button_style = iced::widget::button::Style {
                 text_color: iced_theme.palette().text,
+                border: match style {
+                    NotificationStyle::Standalone | NotificationStyle::Toast => {
+                        Border::default().rounded(theme.radius.lg)
+                    }
+                    NotificationStyle::GroupHeader => {
+                        Border::default().rounded(iced::border::Radius {
+                            top_left: theme.radius.lg,
+                            top_right: theme.radius.lg,
+                            bottom_left: theme.radius.sm,
+                            bottom_right: theme.radius.sm,
+                        })
+                    }
+                    NotificationStyle::GroupItem => Border::default().rounded(theme.radius.sm),
+                    NotificationStyle::GroupLast => {
+                        Border::default().rounded(iced::border::Radius {
+                            top_left: 0.0,
+                            top_right: 0.0,
+                            bottom_left: theme.radius.lg,
+                            bottom_right: theme.radius.lg,
+                        })
+                    }
+                },
                 ..iced::widget::button::Style::default()
             };
             match status {
                 iced::widget::button::Status::Hovered => {
-                    match style {
-                        NotificationStyle::Rectangular => (),
-                        NotificationStyle::Rounded => {
-                            button_style.border = Border::default().rounded(theme.radius.md)
-                        }
-                        NotificationStyle::BottomRounded => {
-                            button_style.border = Border::default().rounded(iced::border::Radius {
-                                top_left: 0.0,
-                                top_right: 0.0,
-                                bottom_left: theme.radius.md,
-                                bottom_right: theme.radius.md,
-                            })
-                        }
+                    if style == NotificationStyle::Toast {
+                        button_style.background = Some(
+                            iced_theme
+                                .extended_palette()
+                                .background
+                                .weak
+                                .color
+                                .scale_alpha(theme.menu.opacity)
+                                .into(),
+                        );
+                    } else {
+                        button_style.background = Some(
+                            iced_theme
+                                .extended_palette()
+                                .background
+                                .strong
+                                .color
+                                .scale_alpha(theme.menu.opacity)
+                                .into(),
+                        );
                     }
-                    button_style.background = Some(Background::Color(
-                        iced_theme
-                            .extended_palette()
-                            .background
-                            .weak
-                            .color
-                            .scale_alpha(theme.menu.opacity),
-                    ));
                 }
                 _ => {
-                    button_style.background = Some(Background::Color(iced::Color::TRANSPARENT));
+                    button_style.background = if style == NotificationStyle::Toast {
+                        Some(iced_theme.palette().background.into())
+                    } else {
+                        Some(iced_theme.extended_palette().background.weak.color.into())
+                    }
                 }
             }
             button_style
         }
     }
 
-    fn group_header_button_style(
-        theme: &AshellTheme,
-    ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style {
-        let theme = theme.clone();
-        move |iced_theme: &Theme, status| {
-            let mut style = iced::widget::button::Style::default();
-            let border = Border::default().rounded(iced::border::Radius {
-                top_left: theme.radius.md,
-                top_right: theme.radius.md,
-                bottom_left: 0.0,
-                bottom_right: 0.0,
-            });
-            match status {
-                iced::widget::button::Status::Hovered => {
-                    style.background = Some(Background::Color(
-                        iced_theme
-                            .extended_palette()
-                            .background
-                            .weak
-                            .color
-                            .scale_alpha(theme.menu.opacity),
-                    ));
-                    style.border = border;
-                }
-                _ => {
-                    style.background = Some(Background::Color(iced::Color::TRANSPARENT));
-                    style.border = border;
-                }
-            }
-            style
-        }
-    }
-
-    fn item_container_style(theme: &AshellTheme) -> impl Fn(&Theme) -> container::Style {
-        let theme = theme.clone();
-        move |app_theme: &Theme| container::Style {
-            background: Background::Color(
-                app_theme
-                    .palette()
-                    .background
-                    .scale_alpha(theme.menu.opacity),
-            )
-            .into(),
-            border: Border::default().rounded(theme.radius.md),
-            ..container::Style::default()
-        }
-    }
-
-    fn build_notification_card<'a>(
+    fn notification_card<'a>(
         &'a self,
         notification: &'a Notification,
         theme: &'a AshellTheme,
-        show_body: bool,
         on_press: Message,
+        toast: bool,
     ) -> Element<'a, Message> {
         let timestamp_element = if self.config.show_timestamps {
             Some(text(self.format_timestamp(notification.timestamp)).size(theme.font_size.sm))
@@ -629,7 +585,7 @@ impl Notifications {
             None
         };
 
-        let body_element = if show_body && !notification.body.is_empty() {
+        let body_element = if (!toast || self.config.show_bodies) && !notification.body.is_empty() {
             Some(
                 text(&notification.body)
                     .size(theme.font_size.sm)
@@ -672,11 +628,18 @@ impl Notifications {
 
         button(card)
             .on_press(on_press)
-            .style(theme.round_button_style())
+            .style(Self::notification_button_style(
+                theme,
+                if toast {
+                    NotificationStyle::Toast
+                } else {
+                    NotificationStyle::Standalone
+                },
+            ))
             .into()
     }
 
-    fn build_full_item<'a>(
+    fn group_item<'a>(
         &'a self,
         notification: &'a Notification,
         is_last: bool,
@@ -685,32 +648,22 @@ impl Notifications {
         button(
             column!(
                 row!(
-                    container(
-                        text(&notification.summary)
-                            .size(theme.font_size.md)
-                            .wrapping(text::Wrapping::WordOrGlyph)
-                            .style(strong_text_style)
-                    )
-                    .width(Length::Fill),
-                    text(self.format_timestamp(notification.timestamp))
-                        .size(theme.font_size.sm)
-                        .style(weak_text_style)
+                    text(&notification.summary)
+                        .wrapping(text::Wrapping::WordOrGlyph)
+                        .width(Length::Fill),
+                    text(self.format_timestamp(notification.timestamp)).size(theme.font_size.sm)
                 ),
-                text(&notification.body)
-                    .size(theme.font_size.sm)
-                    .wrapping(text::Wrapping::WordOrGlyph)
-                    .style(weak_text_style)
+                text(&notification.body).wrapping(text::Wrapping::WordOrGlyph)
             )
             .padding(theme.space.xs)
             .spacing(theme.space.xs),
         )
-        .width(Length::Fill)
         .style(Self::notification_button_style(
             theme,
             if is_last {
-                NotificationStyle::BottomRounded
+                NotificationStyle::GroupLast
             } else {
-                NotificationStyle::Rectangular
+                NotificationStyle::GroupItem
             },
         ))
         .on_press(Message::NotificationClicked(notification.id))
@@ -768,11 +721,11 @@ impl Notifications {
 
         for &toast_id in &self.toasts {
             if let Some(notification) = self.find_notification(toast_id) {
-                toast_column = toast_column.push(self.build_notification_card(
+                toast_column = toast_column.push(self.notification_card(
                     notification,
                     theme,
-                    true,
                     Message::DismissToast(notification.id),
+                    true,
                 ));
             }
         }
@@ -800,11 +753,33 @@ impl Notifications {
     fn grouped_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
         let mut content = column!().spacing(theme.space.sm);
 
-        for (app_name, notifications) in self.grouped_notifications_by_app() {
+        for (app_name, group) in self
+            .notifications
+            .iter()
+            .sorted_by(|a, b| a.app_name.cmp(&b.app_name))
+            .chunk_by(|n| n.app_name.clone())
+            .into_iter()
+        {
             let is_expanded = self.expanded_groups.contains(&app_name);
-            let app_icon: Element<'a, Message> = notifications
-                .first()
-                .map(|notification| self.icon_for_notification(notification.id))
+
+            let mut iter = group.peekable();
+            let first_id = iter.peek().map(|n| n.id);
+            let mut count = 0usize;
+            let mut group_notifications = vec![];
+
+            if is_expanded {
+                while let Some(notification) = iter.next() {
+                    count += 1;
+                    let is_last = iter.peek().is_none();
+                    group_notifications.push(self.group_item(notification, is_last, theme));
+                }
+            } else if let Some(first) = iter.next() {
+                count = 1 + iter.count(); // consume the rest just to count
+                group_notifications.push(self.group_item(first, true, theme));
+            }
+
+            let app_icon: Element<'a, Message> = first_id
+                .map(|id| self.icon_for_notification(id))
                 .map(notification_icon_with_frame)
                 .unwrap_or_else(|| icon(StaticIcon::Bell).size(ICON_SIZE).into());
 
@@ -812,49 +787,30 @@ impl Notifications {
             let toggle_msg = Message::ToggleGroup(app_name.clone());
 
             let header = row!(
-                button(app_icon)
-                    .style(icon_button_style)
-                    .on_press(clear_msg),
-                container(
-                    text(app_name)
-                        .size(theme.font_size.md)
-                        .wrapping(text::Wrapping::WordOrGlyph)
-                        .style(palette_text_style)
-                )
-                .width(Length::Fill),
-                text(format!("{} new", notifications.len()))
-                    .size(theme.font_size.sm)
-                    .style(weak_text_style),
+                app_icon,
+                text(app_name)
+                    .size(theme.font_size.md)
+                    .wrapping(text::Wrapping::WordOrGlyph)
+                    .width(Length::Fill),
+                text(format!("{count} new")).size(theme.font_size.sm),
+                icon_button(theme, StaticIcon::Delete).on_press(clear_msg)
             )
             .spacing(theme.space.xs)
             .align_y(Alignment::Center);
 
-            let mut preview = column!();
-            if is_expanded {
-                for (i, notification) in notifications.iter().enumerate() {
-                    let is_last = i == notifications.len() - 1;
-                    preview = preview.push(column!(
-                        rule::horizontal(HORIZONTAL_RULE_HEIGHT),
-                        self.build_full_item(notification, is_last, theme)
-                    ));
-                }
-            } else if let Some(first_notification) = notifications.first() {
-                preview = preview.push(rule::horizontal(HORIZONTAL_RULE_HEIGHT));
-                preview = preview.push(self.build_full_item(first_notification, true, theme))
-            }
+            let item = Column::new()
+                .push(
+                    button(header)
+                        .style(Self::notification_button_style(
+                            theme,
+                            NotificationStyle::GroupHeader,
+                        ))
+                        .on_press(toggle_msg),
+                )
+                .extend(group_notifications)
+                .spacing(theme.space.xxs);
 
-            let item = column!(
-                button(header)
-                    .width(Length::Fill)
-                    .style(Self::group_header_button_style(theme))
-                    .on_press(toggle_msg),
-                preview
-            );
-            content = content.push(
-                container(item)
-                    .style(Self::item_container_style(theme))
-                    .width(Length::Fill),
-            );
+            content = content.push(item);
         }
         content.into()
     }
@@ -864,11 +820,11 @@ impl Notifications {
             self.notifications
                 .iter()
                 .map(|notification| {
-                    self.build_notification_card(
+                    self.notification_card(
                         notification,
                         theme,
-                        self.config.show_bodies,
                         Message::NotificationClicked(notification.id),
+                        false,
                     )
                 })
                 .collect::<Vec<Element<'a, Message>>>(),

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -87,11 +87,11 @@ fn close_notification_by_id_task(connection: Option<Connection>, id: u32) -> Tas
     )
 }
 
-fn toast_timeout(expire_timeout: i32, default_timeout_ms: u64) -> Option<Duration> {
-    match expire_timeout {
-        -1 => Some(Duration::from_millis(default_timeout_ms)),
+fn toast_timeout(required_timeout: i32, timeout_ms: u64) -> Option<Duration> {
+    match required_timeout {
+        -1 => Some(Duration::from_millis(timeout_ms)),
         0 => None,
-        t if t > 0 => Some(Duration::from_millis(t as u64)),
+        required if required > 0 => Some(Duration::from_millis(required as u64)),
         _ => None,
     }
 }
@@ -208,17 +208,13 @@ impl Notifications {
 
         match update_event {
             NotificationEvent::Received(notification) => {
-                let was_empty = self.toasts.is_empty();
-                while self.toasts.len() >= self.config.toast_max_visible {
+                while self.toasts.len() >= self.config.toast_limit {
                     self.toasts.pop_front();
                 }
                 self.toasts.push_back(notification.id);
 
                 let notification_id = notification.id;
-                let timeout = toast_timeout(
-                    notification.expire_timeout,
-                    self.config.toast_default_timeout,
-                );
+                let timeout = toast_timeout(notification.expire_timeout, self.config.toast_timeout);
 
                 let timer_task = if let Some(timeout) = timeout {
                     Task::perform(
@@ -232,11 +228,7 @@ impl Notifications {
                     Task::none()
                 };
 
-                if was_empty {
-                    Action::Show(timer_task)
-                } else {
-                    Action::Task(timer_task)
-                }
+                Action::Show(timer_task)
             }
             NotificationEvent::Closed(id) => {
                 let id = *id;
@@ -697,17 +689,15 @@ impl Notifications {
     }
 
     pub fn toast_layer_size(&self, theme: &AshellTheme) -> (u32, u32) {
-        let n = self.config.toast_max_visible as u32;
-        let margin = theme.space.sm as u32;
-        let line_height = theme.font_size.sm as u32 + theme.space.xxs as u32;
-        let card_height = ICON_SIZE as u32
-            + (self.config.toast_summary_line_budget + self.config.toast_body_line_budget)
-                * line_height
-            + 3 * theme.space.sm as u32;
-        let spacing = theme.space.sm as u32;
-        let width = MenuSize::Medium.size() as u32 + 2 * margin;
-        let height = n * card_height + n.saturating_sub(1) * spacing + 2 * margin;
-        (width, height)
+        let limit = self.config.toast_limit;
+        let single_height = self.config.toast_height;
+        let spacing = theme.space.sm;
+
+        let n = limit.min(self.toasts.len()) as u32;
+
+        let height = n * single_height + (n - 1) * spacing as u32;
+
+        (MenuSize::Medium.size() as u32, height)
     }
 
     pub fn toast_position(&self) -> ToastPosition {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -210,6 +210,11 @@ impl Notifications {
 
         match update_event {
             NotificationEvent::Received(notification) => {
+                if self.config.toast_limit == 0 {
+                    self.toasts.clear();
+                    return Action::None;
+                }
+
                 while self.toasts.len() >= self.config.toast_limit {
                     self.toasts.pop_front();
                 }

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -14,7 +14,8 @@ use crate::{
 use chrono::{DateTime, Local};
 use freedesktop_icons::lookup;
 use iced::{
-    Alignment, Background, Border, Color, Column, Element, Length, Row, Subscription, Task, Theme,
+    Alignment, Background, Border, Color, Column, Element, Length, Padding, Row, Subscription,
+    Task, Theme,
     widget::{Space, button, column, container, image, row, scrollable, svg, text},
 };
 use itertools::Itertools;
@@ -751,7 +752,11 @@ impl Notifications {
     }
 
     fn grouped_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let mut content = column!().spacing(theme.space.sm);
+        let mut content = column!().spacing(theme.space.sm).padding(
+            Padding::default()
+                .right(theme.space.md)
+                .left(theme.space.xs),
+        );
 
         for (app_name, group) in self
             .notifications
@@ -828,6 +833,11 @@ impl Notifications {
                     )
                 })
                 .collect::<Vec<Element<'a, Message>>>(),
+        )
+        .padding(
+            Padding::default()
+                .right(theme.space.md)
+                .left(theme.space.xs),
         )
         .spacing(theme.space.sm)
         .into()

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -478,7 +478,7 @@ impl Notifications {
             )
             .spacing(theme.space.xxs),
         )
-        .max_height(self.config.toast_height);
+        .max_height(self.config.toast_max_height);
 
         button(card)
             .on_press(on_press)

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -448,7 +448,7 @@ impl Notifications {
 
         let app_icon_button = notification_icon(notification.icon.as_ref());
 
-        let card = container(
+        let mut card = container(
             column!(
                 Row::new()
                     .push(
@@ -477,8 +477,11 @@ impl Notifications {
                 .padding(Padding::new(theme.space.xxs).top(0.))
             )
             .spacing(theme.space.xxs),
-        )
-        .max_height(self.config.toast_max_height);
+        );
+
+        if toast {
+            card = card.max_height(self.config.toast_max_height);
+        }
 
         button(card)
             .on_press(on_press)

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -1,181 +1,42 @@
 use crate::{
-    components::icons::{StaticIcon, icon, icon_button},
+    components::icons::{IconButtonSize, StaticIcon, icon, icon_button},
     config::{NotificationsModuleConfig, ToastPosition},
     menu::MenuSize,
     services::{
         ReadOnlyService, ServiceEvent,
         notifications::{
-            Notification, NotificationsService,
+            Notification, NotificationIcon, NotificationsService,
             dbus::{NotificationDaemon, NotificationEvent},
         },
     },
     theme::AshellTheme,
 };
 use chrono::{DateTime, Local};
-use freedesktop_icons::lookup;
 use iced::{
-    Alignment, Background, Border, Color, Column, Element, Length, Padding, Row, Subscription,
-    Task, Theme,
+    Alignment, Border, Column, Element, Length, Padding, Row, Subscription, Task, Theme,
     widget::{Space, button, column, container, image, row, scrollable, svg, text},
 };
 use itertools::Itertools;
-use linicon_theme::get_icon_theme;
 use log::error;
 use std::{
-    collections::{HashMap, HashSet, VecDeque},
-    path::{Path, PathBuf},
+    collections::{HashSet, VecDeque},
     time::Duration,
 };
 use zbus::Connection;
-use zbus::zvariant::OwnedValue;
 
-const ICON_SIZE: f32 = 20.0;
+const ICON_SIZE: f32 = 36.0;
 
-fn palette_text_style(theme: &Theme) -> text::Style {
-    text::Style {
-        color: Some(theme.palette().text),
-    }
-}
-
-#[derive(Debug, Clone)]
-enum NotificationIcon {
-    Raster(image::Handle),
-    Vector(svg::Handle),
-    Bell,
-}
-
-fn resolve_notification_icon(notification: &Notification) -> NotificationIcon {
-    match resolve_notification_icon_path(
-        &notification.app_name,
-        &notification.app_icon,
-        &notification.hints,
-    ) {
-        Some(path) => {
-            let is_svg = Path::new(&path)
-                .extension()
-                .and_then(|ext| ext.to_str())
-                .is_some_and(|ext| ext.eq_ignore_ascii_case("svg"));
-
-            if is_svg {
-                NotificationIcon::Vector(svg::Handle::from_path(path))
-            } else {
-                NotificationIcon::Raster(image::Handle::from_path(path))
-            }
-        }
-        None => NotificationIcon::Bell,
-    }
-}
-
-fn non_empty_owned_value_string(value: Option<&OwnedValue>) -> Option<String> {
-    value
-        .and_then(|v| v.clone().try_into().ok())
-        .map(|s: String| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-}
-
-fn parse_file_url(value: &str) -> Option<PathBuf> {
-    if !value.starts_with("file://") {
-        return None;
-    }
-
-    let decoded = url::Url::parse(value).ok()?.to_file_path().ok()?;
-    decoded.exists().then_some(decoded)
-}
-
-fn find_icon_path(icon_name: &str) -> Option<PathBuf> {
-    let base_lookup = lookup(icon_name).with_cache();
-
-    match get_icon_theme() {
-        Some(theme) => base_lookup.with_theme(&theme).find().or_else(|| {
-            let fallback_lookup = lookup(icon_name).with_cache();
-            fallback_lookup.find()
-        }),
-        None => base_lookup.find(),
-    }
-}
-
-fn resolve_notification_icon_path(
-    app_name: &str,
-    app_icon: &str,
-    hints: &HashMap<String, OwnedValue>,
-) -> Option<String> {
-    let mut candidates = Vec::new();
-
-    if !app_icon.trim().is_empty() {
-        candidates.push(app_icon.trim().to_string());
-    }
-
-    for key in [
-        "image-path",
-        "image_path",
-        "icon-name",
-        "icon_name",
-        "desktop-entry",
-    ] {
-        if let Some(value) = non_empty_owned_value_string(hints.get(key)) {
-            candidates.push(value);
-        }
-    }
-
-    if !app_name.trim().is_empty() {
-        candidates.push(app_name.trim().to_string());
-    }
-
-    for candidate in candidates {
-        if let Some(path) = parse_file_url(&candidate) {
-            return Some(path.to_string_lossy().into_owned());
-        }
-
-        let candidate_path = PathBuf::from(&candidate);
-        if (candidate.contains('/') || candidate.starts_with('.')) && candidate_path.exists() {
-            return Some(candidate_path.to_string_lossy().into_owned());
-        }
-
-        if let Some(path) = find_icon_path(&candidate) {
-            return Some(path.to_string_lossy().into_owned());
-        }
-
-        if let Some(stripped) = candidate.strip_suffix(".desktop")
-            && let Some(path) = find_icon_path(stripped)
-        {
-            return Some(path.to_string_lossy().into_owned());
-        }
-    }
-
-    None
-}
-
-fn notification_icon_with_frame<'a, M: 'a>(icon_kind: &NotificationIcon) -> Element<'a, M> {
-    let inner: Element<'a, M> = match icon_kind {
-        NotificationIcon::Vector(handle) => svg(handle.clone())
+fn notification_icon<'a, M: 'a>(icon_kind: Option<&NotificationIcon>) -> Element<'a, M> {
+    match icon_kind {
+        Some(NotificationIcon::Svg(handle)) => svg(handle.clone())
             .width(Length::Fixed(ICON_SIZE))
             .height(Length::Fixed(ICON_SIZE))
             .into(),
-        NotificationIcon::Raster(handle) => image(handle.clone())
+        Some(NotificationIcon::Image(handle)) => image(handle.clone())
             .width(Length::Fixed(ICON_SIZE))
             .height(Length::Fixed(ICON_SIZE))
             .into(),
-        NotificationIcon::Bell => icon(StaticIcon::Bell)
-            .size(ICON_SIZE)
-            .style(palette_text_style)
-            .into(),
-    };
-    container(inner)
-        .center_x(Length::Fixed(ICON_SIZE))
-        .center_y(Length::Fixed(ICON_SIZE))
-        .width(Length::Fixed(ICON_SIZE))
-        .height(Length::Fixed(ICON_SIZE))
-        .into()
-}
-
-fn icon_button_style(theme: &Theme, status: button::Status) -> button::Style {
-    button::Style {
-        background: Some(Background::Color(Color::TRANSPARENT)),
-        text_color: match status {
-            button::Status::Hovered => theme.palette().danger,
-            _ => theme.palette().text,
-        },
-        ..Default::default()
+        None => icon(StaticIcon::Bell).size(ICON_SIZE).into(),
     }
 }
 
@@ -273,7 +134,6 @@ pub struct Notifications {
     notifications: VecDeque<Notification>,
     expanded_groups: HashSet<String>,
     toasts: VecDeque<u32>,
-    icons: HashMap<u32, NotificationIcon>,
 }
 
 impl Notifications {
@@ -284,7 +144,6 @@ impl Notifications {
             notifications: VecDeque::new(),
             expanded_groups: HashSet::new(),
             toasts: VecDeque::new(),
-            icons: HashMap::new(),
         }
     }
 
@@ -324,10 +183,6 @@ impl Notifications {
             .filter(|notification| notification.app_name == app_name)
             .map(|notification| notification.id)
             .collect()
-    }
-
-    fn icon_for_notification(&self, id: u32) -> &NotificationIcon {
-        self.icons.get(&id).unwrap_or(&NotificationIcon::Bell)
     }
 
     fn hide_toasts_if_empty(&self, had_toasts: bool) -> Action {
@@ -394,12 +249,9 @@ impl Notifications {
     fn apply_update_event(&mut self, update_event: NotificationEvent) {
         match update_event {
             NotificationEvent::Received(notification) => {
-                self.icons
-                    .insert(notification.id, resolve_notification_icon(&notification));
                 self.notifications.push_front(*notification);
             }
             NotificationEvent::Closed(id) => {
-                self.icons.remove(&id);
                 if let Some(pos) = self.notifications.iter().position(|n| n.id == id) {
                     self.notifications.remove(pos);
                 }
@@ -451,7 +303,6 @@ impl Notifications {
             }
             Message::NotificationsCleared => {
                 let had_toasts = self.clear_toasts();
-                self.icons.clear();
                 self.hide_toasts_if_empty(had_toasts)
             }
             Message::ClearGroup(app_name) => {
@@ -468,9 +319,6 @@ impl Notifications {
             }
             Message::GroupCleared(app_name, group_ids) => {
                 self.expanded_groups.remove(&app_name);
-                for id in &group_ids {
-                    self.icons.remove(id);
-                }
                 let had_toasts = self.remove_toasts(&group_ids);
                 self.hide_toasts_if_empty(had_toasts)
             }
@@ -581,7 +429,12 @@ impl Notifications {
         toast: bool,
     ) -> Element<'a, Message> {
         let timestamp_element = if self.config.show_timestamps {
-            Some(text(self.format_timestamp(notification.timestamp)).size(theme.font_size.sm))
+            Some(
+                container(
+                    text(self.format_timestamp(notification.timestamp)).size(theme.font_size.xs),
+                )
+                .padding([0., theme.space.xxs]),
+            )
         } else {
             None
         };
@@ -597,38 +450,41 @@ impl Notifications {
         };
 
         let notification_id = notification.id;
-        let icon = self.icon_for_notification(notification_id);
 
-        let app_icon_button = button(notification_icon_with_frame(icon))
-            .on_press(Message::CloseNotificationById(notification_id))
-            .style(icon_button_style);
+        let app_icon_button = notification_icon(notification.icon.as_ref());
 
-        let card = container(
-            column!(
-                Row::new()
-                    .push(app_icon_button)
-                    .push(
-                        container(
+        let card = column!(
+            Row::new()
+                .push(
+                    Row::new()
+                        .push(app_icon_button)
+                        .push(column!(
                             text(&notification.app_name)
                                 .size(theme.font_size.md)
-                                .wrapping(text::Wrapping::WordOrGlyph)
-                        )
+                                .wrapping(text::Wrapping::WordOrGlyph),
+                            timestamp_element
+                        ))
                         .width(Length::Fill)
-                    )
-                    .push(timestamp_element)
-                    .spacing(theme.space.xs)
-                    .align_y(Alignment::Center),
-                text(&notification.summary)
-                    .size(theme.font_size.sm)
-                    .wrapping(text::Wrapping::WordOrGlyph),
+                        .spacing(theme.space.xs)
+                        .align_y(Alignment::Center),
+                )
+                .push(
+                    icon_button(theme, StaticIcon::Close)
+                        .style(theme.notification_delete_button_style())
+                        .on_press(Message::CloseNotificationById(notification_id))
+                ),
+            column!(
+                text(&notification.summary).wrapping(text::Wrapping::WordOrGlyph),
                 body_element,
             )
-            .spacing(theme.space.xxs),
+            .spacing(theme.space.xxs)
+            .padding(Padding::new(theme.space.xxs).top(0.))
         )
-        .padding(theme.space.sm);
+        .spacing(theme.space.xxs);
 
         button(card)
             .on_press(on_press)
+            .width(Length::Fill)
             .style(Self::notification_button_style(
                 theme,
                 if toast {
@@ -713,12 +569,10 @@ impl Notifications {
 
     pub fn toast_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
         if self.toasts.is_empty() {
-            return Space::new().width(Length::Fill).height(Length::Fill).into();
+            return Space::new().into();
         }
 
-        let mut toast_column = column!()
-            .spacing(theme.space.sm)
-            .width(Length::Fixed(self.config.toast_width as f32));
+        let mut toast_column = column!().spacing(theme.space.sm);
 
         for &toast_id in &self.toasts {
             if let Some(notification) = self.find_notification(toast_id) {
@@ -739,8 +593,7 @@ impl Notifications {
         };
 
         container(toast_column)
-            .width(Length::Fill)
-            .height(Length::Fill)
+            .width(MenuSize::Medium)
             .padding(theme.space.sm)
             .align_x(h_align)
             .align_y(v_align)
@@ -768,7 +621,9 @@ impl Notifications {
             let is_expanded = self.expanded_groups.contains(&app_name);
 
             let mut iter = group.peekable();
-            let first_id = iter.peek().map(|n| n.id);
+            let first_icon = iter.peek().and_then(|n| n.icon.as_ref());
+            let app_icon = notification_icon(first_icon);
+
             let mut count = 0usize;
             let mut group_notifications = vec![];
 
@@ -783,11 +638,6 @@ impl Notifications {
                 group_notifications.push(self.group_item(first, true, theme));
             }
 
-            let app_icon: Element<'a, Message> = first_id
-                .map(|id| self.icon_for_notification(id))
-                .map(notification_icon_with_frame)
-                .unwrap_or_else(|| icon(StaticIcon::Bell).size(ICON_SIZE).into());
-
             let clear_msg = Message::ClearGroup(app_name.clone());
             let toggle_msg = Message::ToggleGroup(app_name.clone());
 
@@ -797,10 +647,11 @@ impl Notifications {
                     .size(theme.font_size.md)
                     .wrapping(text::Wrapping::WordOrGlyph)
                     .width(Length::Fill),
-                text(format!("{count} new")).size(theme.font_size.sm),
+                text(format!("{count} new")),
                 icon_button(theme, StaticIcon::Delete)
                     .on_press(clear_msg)
-                    .style(theme.notification_group_delete_button_style())
+                    .size(IconButtonSize::Large)
+                    .style(theme.notification_delete_button_style())
             )
             .spacing(theme.space.xs)
             .align_y(Alignment::Center);
@@ -854,7 +705,7 @@ impl Notifications {
                 * line_height
             + 3 * theme.space.sm as u32;
         let spacing = theme.space.sm as u32;
-        let width = self.config.toast_width as u32 + 2 * margin;
+        let width = MenuSize::Medium.size() as u32 + 2 * margin;
         let height = n * card_height + n.saturating_sub(1) * spacing + 2 * margin;
         (width, height)
     }

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -530,7 +530,6 @@ impl Notifications {
         theme: &AshellTheme,
         style: NotificationStyle,
     ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style {
-        let theme = theme.clone();
         move |iced_theme: &Theme, status| {
             let mut button_style = iced::widget::button::Style {
                 text_color: iced_theme.palette().text,
@@ -624,80 +623,56 @@ impl Notifications {
         show_body: bool,
         on_press: Message,
     ) -> Element<'a, Message> {
-        let timestamp_element: Element<'_, Message> = if self.config.show_timestamps {
-            text(self.format_timestamp(notification.timestamp))
-                .size(theme.font_size.sm)
-                // .style(weak_text_style)
-                .into()
+        let timestamp_element = if self.config.show_timestamps {
+            Some(text(self.format_timestamp(notification.timestamp)).size(theme.font_size.sm))
         } else {
-            Space::new().width(Length::Shrink).into()
+            None
         };
 
-        let body_element: Element<'_, Message> = if show_body && !notification.body.is_empty() {
-            text(&notification.body)
-                .size(theme.font_size.sm)
-                .wrapping(text::Wrapping::WordOrGlyph)
-                // .style(strong_text_style)
-                .into()
+        let body_element = if show_body && !notification.body.is_empty() {
+            Some(
+                text(&notification.body)
+                    .size(theme.font_size.sm)
+                    .wrapping(text::Wrapping::WordOrGlyph),
+            )
         } else {
-            Space::new().height(Length::Shrink).into()
+            None
         };
 
         let notification_id = notification.id;
-        let icon_kind = self.icon_for_notification(notification_id);
-        // App icon (no longer closes the notification when clicked)
-        let app_icon_elem = notification_icon_with_frame(icon_kind);
+        let icon = self.icon_for_notification(notification_id);
 
-        let action_button: Element<'_, Message> = if !notification.actions.is_empty() {
-            icon_button(theme, StaticIcon::RightArrow)
-                .size(IconButtonSize::Small)
-                .on_press(Message::NotificationClicked(notification_id))
-                .style(icon_button_style)
-                .into()
-        } else {
-            Space::new().width(Length::Shrink).into()
-        };
-
-        let close_button = icon_button(theme, StaticIcon::Close)
-            .size(IconButtonSize::Small)
+        let app_icon_button = button(notification_icon_with_frame(icon))
             .on_press(Message::CloseNotificationById(notification_id))
             .style(icon_button_style);
 
         let card = container(
             column!(
-                row!(
-                    app_icon_elem,
-                    container(
-                        text(&notification.app_name)
-                            .size(theme.font_size.md)
-                            .wrapping(text::Wrapping::WordOrGlyph) // .style(palette_text_style)
+                Row::new()
+                    .push(app_icon_button)
+                    .push(
+                        container(
+                            text(&notification.app_name)
+                                .size(theme.font_size.md)
+                                .wrapping(text::Wrapping::WordOrGlyph)
+                        )
+                        .width(Length::Fill)
                     )
-                    .width(Length::Fill),
-                    timestamp_element,
-                    action_button,
-                    close_button,
-                )
-                .spacing(theme.space.xs)
-                .align_y(Alignment::Center),
+                    .push(timestamp_element)
+                    .spacing(theme.space.xs)
+                    .align_y(Alignment::Center),
                 text(&notification.summary)
                     .size(theme.font_size.sm)
                     .wrapping(text::Wrapping::WordOrGlyph),
-                // .style(strong_text_style),
                 body_element,
             )
             .spacing(theme.space.xxs),
         )
-        .style(Self::item_container_style(theme))
-        .padding(theme.space.sm)
-        .width(Length::Fill);
+        .padding(theme.space.sm);
 
         button(card)
             .on_press(on_press)
-            .style(Self::notification_button_style(
-                theme,
-                NotificationStyle::Rounded,
-            ))
-            .padding(0)
+            .style(theme.round_button_style())
             .into()
     }
 
@@ -772,15 +747,10 @@ impl Notifications {
                         .width(Length::Fill)
                         .size(theme.font_size.lg)
                 )
-                .push(if !is_empty {
-                    Some(
-                        icon_button(theme, StaticIcon::Delete)
-                            .on_press(Message::ClearNotifications),
-                    )
-                } else {
-                    None
-                }),
-            scrollable(content),
+                .push((!is_empty).then(|| {
+                    icon_button(theme, StaticIcon::Delete).on_press(Message::ClearNotifications)
+                })),
+            container(scrollable(content)).max_height(400.),
         )
         .width(MenuSize::Medium)
         .spacing(theme.space.sm)
@@ -890,7 +860,7 @@ impl Notifications {
     }
 
     fn list_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        Column::from_vec(
+        Column::with_children(
             self.notifications
                 .iter()
                 .map(|notification| {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -798,7 +798,9 @@ impl Notifications {
                     .wrapping(text::Wrapping::WordOrGlyph)
                     .width(Length::Fill),
                 text(format!("{count} new")).size(theme.font_size.sm),
-                icon_button(theme, StaticIcon::Delete).on_press(clear_msg)
+                icon_button(theme, StaticIcon::Delete)
+                    .on_press(clear_msg)
+                    .style(theme.notification_group_delete_button_style())
             )
             .spacing(theme.space.xs)
             .align_y(Alignment::Center);

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use chrono::{DateTime, Local};
 use iced::{
-    Alignment, Border, Column, Element, Length, Padding, Row, Subscription, Task, Theme,
-    widget::{Space, button, column, container, image, row, scrollable, svg, text},
+    Alignment, Border, Column, Element, Length, Padding, Row, Size, Subscription, Task, Theme,
+    widget::{Space, button, column, container, image, row, scrollable, sensor, svg, text},
 };
 use itertools::Itertools;
 use log::error;
@@ -110,6 +110,7 @@ pub enum Message {
     ToggleGroup(String),
     ExpireToast(u32),
     DismissToast(u32),
+    ToastResized(Size),
 }
 
 #[derive(Debug, PartialEq)]
@@ -126,6 +127,7 @@ pub enum Action {
     Task(Task<Message>),
     Show(Task<Message>),
     Hide(Task<Message>),
+    UpdateToastInputRegion(Size),
 }
 
 pub struct Notifications {
@@ -338,6 +340,7 @@ impl Notifications {
                 let task = invoke_and_close_task(connection, id, action_key);
                 self.hide_toasts_if_empty_with_task(had_toasts, task)
             }
+            Message::ToastResized(size) => Action::UpdateToastInputRegion(size),
         }
     }
 
@@ -445,34 +448,37 @@ impl Notifications {
 
         let app_icon_button = notification_icon(notification.icon.as_ref());
 
-        let card = column!(
-            Row::new()
-                .push(
-                    Row::new()
-                        .push(app_icon_button)
-                        .push(column!(
-                            text(&notification.app_name)
-                                .size(theme.font_size.md)
-                                .wrapping(text::Wrapping::WordOrGlyph),
-                            timestamp_element
-                        ))
-                        .width(Length::Fill)
-                        .spacing(theme.space.xs)
-                        .align_y(Alignment::Center),
-                )
-                .push(
-                    icon_button(theme, StaticIcon::Close)
-                        .style(theme.notification_delete_button_style())
-                        .on_press(Message::CloseNotificationById(notification_id))
-                ),
+        let card = container(
             column!(
-                text(&notification.summary).wrapping(text::Wrapping::WordOrGlyph),
-                body_element,
+                Row::new()
+                    .push(
+                        Row::new()
+                            .push(app_icon_button)
+                            .push(column!(
+                                text(&notification.app_name)
+                                    .size(theme.font_size.md)
+                                    .wrapping(text::Wrapping::WordOrGlyph),
+                                timestamp_element
+                            ))
+                            .width(Length::Fill)
+                            .spacing(theme.space.xs)
+                            .align_y(Alignment::Center),
+                    )
+                    .push(
+                        icon_button(theme, StaticIcon::Close)
+                            .style(theme.notification_delete_button_style())
+                            .on_press(Message::CloseNotificationById(notification_id))
+                    ),
+                column!(
+                    text(&notification.summary).wrapping(text::Wrapping::WordOrGlyph),
+                    body_element,
+                )
+                .spacing(theme.space.xxs)
+                .padding(Padding::new(theme.space.xxs).top(0.))
             )
-            .spacing(theme.space.xxs)
-            .padding(Padding::new(theme.space.xxs).top(0.))
+            .spacing(theme.space.xxs),
         )
-        .spacing(theme.space.xxs);
+        .max_height(self.config.toast_height);
 
         button(card)
             .on_press(on_press)
@@ -577,17 +583,23 @@ impl Notifications {
             }
         }
 
-        let (h_align, v_align) = match self.config.toast_position {
-            ToastPosition::TopLeft => (Alignment::Start, Alignment::Start),
-            ToastPosition::TopRight => (Alignment::End, Alignment::Start),
-            ToastPosition::BottomLeft => (Alignment::Start, Alignment::End),
-            ToastPosition::BottomRight => (Alignment::End, Alignment::End),
+        let v_align = match self.config.toast_position {
+            ToastPosition::TopLeft | ToastPosition::TopRight => Alignment::Start,
+            ToastPosition::BottomLeft | ToastPosition::BottomRight => Alignment::End,
         };
 
-        container(toast_column)
-            .width(MenuSize::Medium)
-            .padding(theme.space.sm)
-            .align_x(h_align)
+        // Sensor wraps the padded toast content to report its rendered size.
+        // The outer container fills the full-height surface and aligns vertically.
+        let toast_content = sensor(
+            container(toast_column)
+                .width(MenuSize::Medium)
+                .padding(theme.space.sm),
+        )
+        .on_resize(Message::ToastResized);
+
+        container(toast_content)
+            .width(Length::Fill)
+            .height(Length::Fill)
             .align_y(v_align)
             .into()
     }
@@ -686,18 +698,6 @@ impl Notifications {
         )
         .spacing(theme.space.sm)
         .into()
-    }
-
-    pub fn toast_layer_size(&self, theme: &AshellTheme) -> (u32, u32) {
-        let limit = self.config.toast_limit;
-        let single_height = self.config.toast_height;
-        let spacing = theme.space.sm;
-
-        let n = limit.min(self.toasts.len()) as u32;
-
-        let height = n * single_height + (n - 1) * spacing as u32;
-
-        (MenuSize::Medium.size() as u32, height)
     }
 
     pub fn toast_position(&self) -> ToastPosition {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -541,7 +541,10 @@ impl Notifications {
     ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style {
         let theme = theme.clone();
         move |iced_theme: &Theme, status| {
-            let mut button_style = iced::widget::button::Style::default();
+            let mut button_style = iced::widget::button::Style {
+                text_color: iced_theme.palette().text,
+                ..iced::widget::button::Style::default()
+            };
             match status {
                 iced::widget::button::Status::Hovered => {
                     match style {
@@ -613,10 +616,8 @@ impl Notifications {
         move |app_theme: &Theme| container::Style {
             background: Background::Color(
                 app_theme
-                    .extended_palette()
-                    .secondary
-                    .strong
-                    .color
+                    .palette()
+                    .background
                     .scale_alpha(theme.menu.opacity),
             )
             .into(),
@@ -635,7 +636,7 @@ impl Notifications {
         let timestamp_element: Element<'_, Message> = if self.config.show_timestamps {
             text(self.format_timestamp(notification.timestamp))
                 .size(theme.font_size.sm)
-                .style(weak_text_style)
+                // .style(weak_text_style)
                 .into()
         } else {
             Space::new().width(Length::Shrink).into()
@@ -645,7 +646,7 @@ impl Notifications {
             text(&notification.body)
                 .size(theme.font_size.sm)
                 .wrapping(text::Wrapping::WordOrGlyph)
-                .style(weak_text_style)
+                // .style(strong_text_style)
                 .into()
         } else {
             Space::new().height(Length::Shrink).into()
@@ -678,8 +679,7 @@ impl Notifications {
                     container(
                         text(&notification.app_name)
                             .size(theme.font_size.md)
-                            .wrapping(text::Wrapping::WordOrGlyph)
-                            .style(palette_text_style)
+                            .wrapping(text::Wrapping::WordOrGlyph) // .style(palette_text_style)
                     )
                     .width(Length::Fill),
                     timestamp_element,
@@ -690,8 +690,8 @@ impl Notifications {
                 .align_y(Alignment::Center),
                 text(&notification.summary)
                     .size(theme.font_size.sm)
-                    .wrapping(text::Wrapping::WordOrGlyph)
-                    .style(strong_text_style),
+                    .wrapping(text::Wrapping::WordOrGlyph),
+                // .style(strong_text_style),
                 body_element,
             )
             .spacing(theme.space.xxs),

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::icons::{IconButtonSize, StaticIcon, icon, icon_button},
+    components::icons::{StaticIcon, icon, icon_button},
     config::{NotificationsModuleConfig, ToastPosition},
     menu::MenuSize,
     services::{
@@ -14,7 +14,7 @@ use crate::{
 use chrono::{DateTime, Local};
 use freedesktop_icons::lookup;
 use iced::{
-    Alignment, Background, Border, Color, Element, Length, Subscription, Task, Theme,
+    Alignment, Background, Border, Color, Column, Element, Length, Row, Subscription, Task, Theme,
     widget::{Space, button, column, container, image, row, rule, scrollable, svg, text},
 };
 use linicon_theme::get_icon_theme;
@@ -187,15 +187,6 @@ fn icon_button_style(theme: &Theme, status: button::Status) -> button::Style {
             _ => theme.palette().text,
         },
         ..Default::default()
-    }
-}
-
-fn clear_button_style(radius: f32) -> impl Fn(&Theme, button::Status) -> button::Style {
-    move |iced_theme: &Theme, _status| button::Style {
-        background: Some(Background::Color(Color::TRANSPARENT)),
-        text_color: iced_theme.palette().text,
-        border: Border::default().rounded(radius),
-        ..button::Style::default()
     }
 }
 
@@ -759,12 +750,86 @@ impl Notifications {
         }
     }
 
+    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+        let is_empty = self.notifications.is_empty();
+
+        let content = if is_empty {
+            container(text("No notifications").size(theme.font_size.md))
+                .padding([theme.space.xxl, 0.])
+                .width(Length::Fill)
+                .center_x(Length::Fill)
+                .into()
+        } else if self.config.grouped {
+            self.grouped_notifications(theme)
+        } else {
+            self.list_notifications(theme)
+        };
+
+        column!(
+            Row::new()
+                .push(
+                    text("Notifications")
+                        .width(Length::Fill)
+                        .size(theme.font_size.lg)
+                )
+                .push(if !is_empty {
+                    Some(
+                        icon_button(theme, StaticIcon::Delete)
+                            .on_press(Message::ClearNotifications),
+                    )
+                } else {
+                    None
+                }),
+            scrollable(content),
+        )
+        .width(MenuSize::Medium)
+        .spacing(theme.space.sm)
+        .into()
+    }
+
+    pub fn toast_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+        if self.toasts.is_empty() {
+            return Space::new().width(Length::Fill).height(Length::Fill).into();
+        }
+
+        let mut toast_column = column!()
+            .spacing(theme.space.sm)
+            .width(Length::Fixed(self.config.toast_width as f32));
+
+        for &toast_id in &self.toasts {
+            if let Some(notification) = self.find_notification(toast_id) {
+                toast_column = toast_column.push(self.build_notification_card(
+                    notification,
+                    theme,
+                    true,
+                    Message::DismissToast(notification.id),
+                ));
+            }
+        }
+
+        let (h_align, v_align) = match self.config.toast_position {
+            ToastPosition::TopLeft => (Alignment::Start, Alignment::Start),
+            ToastPosition::TopRight => (Alignment::End, Alignment::Start),
+            ToastPosition::BottomLeft => (Alignment::Start, Alignment::End),
+            ToastPosition::BottomRight => (Alignment::End, Alignment::End),
+        };
+
+        container(toast_column)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .padding(theme.space.sm)
+            .align_x(h_align)
+            .align_y(v_align)
+            .into()
+    }
+
     pub fn subscription(&self) -> Subscription<Message> {
         NotificationsService::subscribe().map(Message::Event)
     }
 
     fn grouped_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
         let mut content = column!().spacing(theme.space.sm);
+
         for (app_name, notifications) in self.grouped_notifications_by_app() {
             let is_expanded = self.expanded_groups.contains(&app_name);
             let app_icon: Element<'a, Message> = notifications
@@ -825,96 +890,21 @@ impl Notifications {
     }
 
     fn list_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let mut notifications_refs: Vec<&Notification> = self.notifications.iter().collect();
-
-        if let Some(max) = self.config.max_notifications {
-            notifications_refs.truncate(max);
-        }
-
-        let mut content = column!().spacing(theme.space.sm);
-        for notification in notifications_refs {
-            content = content.push(self.build_notification_card(
-                notification,
-                theme,
-                self.config.show_bodies,
-                Message::NotificationClicked(notification.id),
-            ));
-        }
-        content.into()
-    }
-
-    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let is_empty = self.notifications.is_empty();
-        let content = if is_empty {
-            container(text("No notifications").size(theme.font_size.md))
-                .width(Length::Fill)
-                .height(Length::Fixed(self.config.empty_state_height))
-                .center_x(Length::Fill)
-                .center_y(Length::Fixed(self.config.empty_state_height))
-                .into()
-        } else if self.config.grouped {
-            self.grouped_notifications(theme)
-        } else {
-            self.list_notifications(theme)
-        };
-        column!(
-            row!(
-                text("Notifications").size(theme.font_size.lg),
-                if !is_empty {
-                    container(
-                        button("Clear")
-                            .style(clear_button_style(theme.radius.md))
-                            .on_press(Message::ClearNotifications),
+        Column::from_vec(
+            self.notifications
+                .iter()
+                .map(|notification| {
+                    self.build_notification_card(
+                        notification,
+                        theme,
+                        self.config.show_bodies,
+                        Message::NotificationClicked(notification.id),
                     )
-                    .width(Length::Fill)
-                    .align_x(Alignment::End)
-                } else {
-                    container(Space::new().width(Length::Fill).height(Length::Shrink))
-                        .width(Length::Fill)
-                        .align_x(Alignment::End)
-                }
-            ),
-            scrollable(content),
+                })
+                .collect::<Vec<Element<'a, Message>>>(),
         )
-        .width(MenuSize::Medium)
         .spacing(theme.space.sm)
         .into()
-    }
-
-    pub fn toast_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        if self.toasts.is_empty() {
-            return Space::new().width(Length::Fill).height(Length::Fill).into();
-        }
-
-        let mut toast_column = column!()
-            .spacing(theme.space.sm)
-            .width(Length::Fixed(self.config.toast_width as f32));
-
-        for &toast_id in &self.toasts {
-            if let Some(notification) = self.find_notification(toast_id) {
-                toast_column = toast_column.push(self.build_notification_card(
-                    notification,
-                    theme,
-                    true,
-                    Message::DismissToast(notification.id),
-                ));
-            }
-        }
-
-        let (h_align, v_align) = match self.config.toast_position {
-            ToastPosition::TopLeft => (Alignment::Start, Alignment::Start),
-            ToastPosition::TopRight => (Alignment::End, Alignment::Start),
-            ToastPosition::BottomLeft => (Alignment::Start, Alignment::End),
-            ToastPosition::BottomRight => (Alignment::End, Alignment::End),
-        };
-
-        container(toast_column)
-            .width(Length::Fill)
-            .height(Length::Fill)
-            .padding(theme.space.sm)
-            .align_x(h_align)
-            .align_y(v_align)
-            .into()
     }
 
     pub fn toast_layer_size(&self, theme: &AshellTheme) -> (u32, u32) {

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,7 +1,7 @@
 use iced::{
     Anchor, KeyboardInteractivity, Layer, LayerShellSettings, OutputId, SurfaceId, Task,
     destroy_layer_surface, new_layer_surface, set_anchor, set_exclusive_zone,
-    set_keyboard_interactivity, set_layer, set_size,
+    set_keyboard_interactivity, set_size,
 };
 use log::debug;
 
@@ -667,7 +667,6 @@ impl Outputs {
                 // update its size and layer ordering.
                 if let Some(toast_id) = shell_info.toast_id {
                     tasks.push(set_size(toast_id, (width, height)));
-                    tasks.push(set_layer(toast_id, Layer::Overlay));
                 } else {
                     let anchor = match position {
                         config::ToastPosition::TopLeft => Anchor::TOP | Anchor::LEFT,
@@ -679,7 +678,7 @@ impl Outputs {
                     let (toast_id, toast_task) = new_layer_surface(LayerShellSettings {
                         namespace: "ashell-toast-layer".to_string(),
                         size: Some((width, height)),
-                        layer: Layer::Top,
+                        layer: Layer::Overlay,
                         keyboard_interactivity: KeyboardInteractivity::None,
                         exclusive_zone: 0,
                         anchor,

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,7 +1,7 @@
 use iced::{
-    Anchor, KeyboardInteractivity, Layer, LayerShellSettings, OutputId, SurfaceId, Task,
-    destroy_layer_surface, new_layer_surface, set_anchor, set_exclusive_zone,
-    set_keyboard_interactivity, set_size,
+    Anchor, InputRegionRect, KeyboardInteractivity, Layer, LayerShellSettings, OutputId, SurfaceId,
+    Task, destroy_layer_surface, new_layer_surface, set_anchor, set_exclusive_zone,
+    set_input_region, set_keyboard_interactivity, set_size,
 };
 use log::debug;
 
@@ -22,6 +22,8 @@ pub struct ShellInfo {
     pub scale_factor: f64,
     /// Optional layer surface used to render toast notifications.
     pub toast_id: Option<SurfaceId>,
+    /// Logical height of this output (for computing toast input regions).
+    pub output_logical_height: Option<u32>,
 }
 
 #[derive(Debug, Clone)]
@@ -65,6 +67,7 @@ impl Outputs {
                     layer,
                     style,
                     scale_factor,
+                    output_logical_height: None,
                 }),
                 None,
             )]),
@@ -220,6 +223,7 @@ impl Outputs {
                     layer,
                     style,
                     scale_factor,
+                    output_logical_height: None,
                 }),
                 Some(output_id),
             ));
@@ -305,6 +309,7 @@ impl Outputs {
                             layer,
                             style,
                             scale_factor,
+                            output_logical_height: None,
                         }),
                         None,
                     ));
@@ -648,50 +653,98 @@ impl Outputs {
 
     /// Show the toast layer(s) for every output.
     ///
-    /// `width` and `height` specify the size of the new surface, and
-    /// `position` determines the corner where it should be anchored.  The
-    /// returned `Task` creates (or updates) the surfaces; callers should supply
-    /// values large enough to encompass all possible toasts, for example using
-    /// `toast_max_visible` from the notifications configuration.
+    /// Creates a full-height surface anchored at `position`. Height is 0 so
+    /// the compositor fills the output height. The surface starts with an
+    /// empty input region (fully click-through); `update_toast_input_region`
+    /// restricts input to just the rendered toast area after layout.
     pub fn show_toast_layer<Message: 'static>(
         &mut self,
         width: u32,
-        height: u32,
         position: config::ToastPosition,
     ) -> Task<Message> {
         let mut tasks = vec![];
 
         for (_, shell_info, _) in &mut self.0 {
-            if let Some(shell_info) = shell_info {
-                // If we already created a toast surface for this output, just
-                // update its size and layer ordering.
-                if let Some(toast_id) = shell_info.toast_id {
-                    tasks.push(set_size(toast_id, (width, height)));
-                } else {
-                    let anchor = match position {
-                        config::ToastPosition::TopLeft => Anchor::TOP | Anchor::LEFT,
-                        config::ToastPosition::TopRight => Anchor::TOP | Anchor::RIGHT,
-                        config::ToastPosition::BottomLeft => Anchor::BOTTOM | Anchor::LEFT,
-                        config::ToastPosition::BottomRight => Anchor::BOTTOM | Anchor::RIGHT,
-                    };
+            if let Some(shell_info) = shell_info
+                && shell_info.toast_id.is_none()
+            {
+                // Anchor both vertical edges so height 0 → full output height.
+                let anchor = match position {
+                    config::ToastPosition::TopLeft => Anchor::TOP | Anchor::BOTTOM | Anchor::LEFT,
+                    config::ToastPosition::TopRight => Anchor::TOP | Anchor::BOTTOM | Anchor::RIGHT,
+                    config::ToastPosition::BottomLeft => {
+                        Anchor::TOP | Anchor::BOTTOM | Anchor::LEFT
+                    }
+                    config::ToastPosition::BottomRight => {
+                        Anchor::TOP | Anchor::BOTTOM | Anchor::RIGHT
+                    }
+                };
 
-                    let (toast_id, toast_task) = new_layer_surface(LayerShellSettings {
-                        namespace: "ashell-toast-layer".to_string(),
-                        size: Some((width, height)),
-                        layer: Layer::Overlay,
-                        keyboard_interactivity: KeyboardInteractivity::None,
-                        exclusive_zone: 0,
-                        anchor,
-                        ..Default::default()
-                    });
+                let (toast_id, toast_task) = new_layer_surface(LayerShellSettings {
+                    namespace: "ashell-toast-layer".to_string(),
+                    size: Some((width, 0)),
+                    layer: Layer::Overlay,
+                    keyboard_interactivity: KeyboardInteractivity::None,
+                    exclusive_zone: 0,
+                    anchor,
+                    ..Default::default()
+                });
 
-                    shell_info.toast_id = Some(toast_id);
-                    tasks.push(toast_task);
-                }
+                shell_info.toast_id = Some(toast_id);
+                tasks.push(toast_task);
+                // Start fully click-through until sensor reports content size.
+                tasks.push(set_input_region(toast_id, Some(vec![])));
             }
         }
 
         Task::batch(tasks)
+    }
+
+    /// Update the input region of the toast surface(s) so only the rendered
+    /// toast content accepts pointer input. Everything else is click-through.
+    pub fn update_toast_input_region<Message: 'static>(
+        &self,
+        content_size: iced::Size,
+        position: config::ToastPosition,
+    ) -> Task<Message> {
+        let content_w = content_size.width.ceil() as i32;
+        let content_h = content_size.height.ceil() as i32;
+        let mut tasks = vec![];
+        for (_, shell_info, _) in &self.0 {
+            if let Some(shell_info) = shell_info
+                && let Some(toast_id) = shell_info.toast_id
+            {
+                let y = match position {
+                    config::ToastPosition::TopLeft | config::ToastPosition::TopRight => 0,
+                    config::ToastPosition::BottomLeft | config::ToastPosition::BottomRight => {
+                        shell_info
+                            .output_logical_height
+                            .map_or(0, |h| (h as i32) - content_h)
+                    }
+                };
+                tasks.push(set_input_region(
+                    toast_id,
+                    Some(vec![InputRegionRect {
+                        x: 0,
+                        y,
+                        width: content_w,
+                        height: content_h,
+                    }]),
+                ));
+            }
+        }
+        Task::batch(tasks)
+    }
+
+    /// Store the logical height for an output (used for bottom-aligned toast input regions).
+    pub fn set_output_logical_height(&mut self, output_id: OutputId, height: u32) {
+        for (_, shell_info, oid) in &mut self.0 {
+            if *oid == Some(output_id)
+                && let Some(info) = shell_info
+            {
+                info.output_logical_height = Some(height);
+            }
+        }
     }
 
     pub fn hide_toast_layer<Message: 'static>(&mut self) -> Task<Message> {

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -669,14 +669,13 @@ impl Outputs {
                     tasks.push(set_size(toast_id, (width, height)));
                     tasks.push(set_layer(toast_id, Layer::Overlay));
                 } else {
-                    
                     let anchor = match position {
                         config::ToastPosition::TopLeft => Anchor::TOP | Anchor::LEFT,
                         config::ToastPosition::TopRight => Anchor::TOP | Anchor::RIGHT,
                         config::ToastPosition::BottomLeft => Anchor::BOTTOM | Anchor::LEFT,
                         config::ToastPosition::BottomRight => Anchor::BOTTOM | Anchor::RIGHT,
                     };
-                    
+
                     let (toast_id, toast_task) = new_layer_surface(LayerShellSettings {
                         namespace: "ashell-toast-layer".to_string(),
                         size: Some((width, height)),
@@ -686,7 +685,7 @@ impl Outputs {
                         anchor,
                         ..Default::default()
                     });
-                    
+
                     shell_info.toast_id = Some(toast_id);
                     tasks.push(toast_task);
                 }

--- a/src/services/notifications/dbus.rs
+++ b/src/services/notifications/dbus.rs
@@ -1,3 +1,4 @@
+use super::NotificationIcon;
 use log::{debug, info, warn};
 use std::collections::HashMap;
 use std::time::SystemTime;
@@ -31,6 +32,8 @@ pub struct Notification {
     pub hints: HashMap<String, OwnedValue>,
     pub expire_timeout: i32,
     pub timestamp: SystemTime,
+    #[serde(skip)]
+    pub icon: Option<NotificationIcon>,
 }
 
 pub struct NotificationDaemon {
@@ -79,6 +82,7 @@ impl NotificationDaemon {
             replaces_id
         };
 
+        let icon = NotificationIcon::resolve(&app_name, &app_icon, &hints);
         let notification = Notification {
             id,
             app_name,
@@ -89,6 +93,7 @@ impl NotificationDaemon {
             hints,
             expire_timeout,
             timestamp: SystemTime::now(),
+            icon,
         };
 
         debug!("New notification: {:?}", notification);

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -2,16 +2,103 @@ use crate::services::{ReadOnlyService, ServiceEvent};
 use iced::Subscription;
 use iced::futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending};
 use iced::stream::channel;
+use iced::widget::{image, svg};
 use log::{error, info};
 use std::any::TypeId;
+use std::collections::HashMap;
+use std::path::PathBuf;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
 use zbus::Connection;
+use zbus::zvariant::OwnedValue;
 
 pub mod dbus;
 
 pub use dbus::Notification;
 use dbus::NotificationEvent;
+
+#[derive(Debug, Clone)]
+pub enum NotificationIcon {
+    Image(image::Handle),
+    Svg(svg::Handle),
+}
+
+impl NotificationIcon {
+    pub fn resolve(
+        app_name: &str,
+        app_icon: &str,
+        hints: &HashMap<String, OwnedValue>,
+    ) -> Option<Self> {
+        icon_candidates(app_name, app_icon, hints)
+            .find_map(resolve_candidate)
+            .map(Self::from_path)
+    }
+
+    fn from_path(path: PathBuf) -> Self {
+        let is_svg = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .is_some_and(|e| e.eq_ignore_ascii_case("svg"));
+        if is_svg {
+            Self::Svg(svg::Handle::from_path(path))
+        } else {
+            Self::Image(image::Handle::from_path(path))
+        }
+    }
+}
+
+const HINT_KEYS: &[&str] = &[
+    "image-path",
+    "image_path",
+    "icon-name",
+    "icon_name",
+    "desktop-entry",
+];
+
+fn icon_candidates<'a>(
+    app_name: &'a str,
+    app_icon: &'a str,
+    hints: &'a HashMap<String, OwnedValue>,
+) -> impl Iterator<Item = String> + 'a {
+    std::iter::once(app_icon.to_string())
+        .chain(
+            HINT_KEYS
+                .iter()
+                .filter_map(|k| hints.get(*k).and_then(|v| v.clone().try_into().ok())),
+        )
+        .chain(std::iter::once(app_name.to_string()))
+        .map(|s: String| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+fn resolve_candidate(candidate: String) -> Option<PathBuf> {
+    if let Ok(url) = url::Url::parse(&candidate)
+        && url.scheme() == "file"
+    {
+        return url.to_file_path().ok().filter(|p| p.exists());
+    }
+
+    if candidate.contains('/') || candidate.starts_with('.') {
+        let path = PathBuf::from(&candidate);
+        if path.exists() {
+            return Some(path);
+        }
+    }
+
+    let name = candidate.strip_suffix(".desktop").unwrap_or(&candidate);
+    freedesktop_lookup(name)
+}
+
+fn freedesktop_lookup(name: &str) -> Option<PathBuf> {
+    let base = freedesktop_icons::lookup(name).with_cache();
+    match linicon_theme::get_icon_theme() {
+        Some(theme) => base
+            .with_theme(&theme)
+            .find()
+            .or_else(|| freedesktop_icons::lookup(name).with_cache().find()),
+        None => base.find(),
+    }
+}
 
 #[derive(Debug, Clone)]
 pub struct NotificationsService {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -661,6 +661,30 @@ impl AshellTheme {
             }
         }
     }
+
+    pub fn notification_group_delete_button_style(
+        &self,
+    ) -> impl Fn(&Theme, Status) -> button::Style {
+        move |theme: &Theme, status: Status| {
+            let mut base = button::Style {
+                background: None,
+                border: Border {
+                    width: 0.0,
+                    radius: self.radius.lg.into(),
+                    color: Color::TRANSPARENT,
+                },
+                text_color: theme.palette().text,
+                ..button::Style::default()
+            };
+            match status {
+                Status::Hovered => {
+                    base.text_color = theme.palette().danger;
+                    base
+                }
+                _ => base,
+            }
+        }
+    }
 }
 
 pub fn backdrop_color(backdrop: f32) -> Color {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -662,9 +662,7 @@ impl AshellTheme {
         }
     }
 
-    pub fn notification_group_delete_button_style(
-        &self,
-    ) -> impl Fn(&Theme, Status) -> button::Style {
+    pub fn notification_delete_button_style(&self) -> impl Fn(&Theme, Status) -> button::Style {
         move |theme: &Theme, status: Status| {
             let mut base = button::Style {
                 background: None,

--- a/website/docs/configuration/modules/notifications.md
+++ b/website/docs/configuration/modules/notifications.md
@@ -6,7 +6,7 @@ sidebar_position: 5
 
 This module displays a notification indicator in the status bar and provides a menu to view and interact with notifications.
 
-The notification indicator shows a bell icon (🔔) when there are no notifications, and a bell with a badge (🔔•) when notifications are present.
+The notification indicator shows a bell icon when there are no notifications, and a bell with a badge when notifications are present.
 
 ## Notification Daemon
 
@@ -17,9 +17,11 @@ Enabling this module makes ashell register itself as the system notification dae
 
 ### Toast popups
 
-By default, ashell shows transient toast popups when notifications arrive. Toasts appear in a configurable corner of the screen, stack vertically up to `toast_max_visible`, and auto-dismiss after the timeout. Clicking a toast invokes the notification's default action (if one exists) and dismisses it.
+By default, ashell shows transient toast popups when notifications arrive. Toasts appear in a configurable corner of the screen, stack vertically up to `toast_limit`, and auto-dismiss after the timeout. Clicking a toast invokes the notification's default action (if one exists) and dismisses it.
 
-The `expire_timeout` hint sent by applications is respected: a value of `-1` falls back to `toast_default_timeout`, `0` means the toast never auto-dismisses, and any positive value (in milliseconds) is used directly.
+The toast surface spans the full output height and uses a Wayland input region so that only the area occupied by actual toast cards accepts pointer input — the rest of the surface is fully click-through.
+
+The `expire_timeout` hint sent by applications is respected: a value of `-1` falls back to `toast_timeout`, `0` means the toast never auto-dismisses, and any positive value (in milliseconds) is used directly.
 
 If you prefer no popups and only the panel indicator, set `toast = false`.
 
@@ -43,21 +45,14 @@ The format string used to display notification timestamps. Uses chrono strftime 
 
 ### show_timestamps
 
-Whether to display timestamps for each notification in the menu. This setting only applies when `grouped` is `false`.
+Whether to display timestamps for each notification in the menu.
 
 **Type:** `boolean`
 **Default:** `true`
 
-### max_notifications
-
-Maximum number of notifications to display in the menu. If not set, all notifications are shown. This setting only applies when `grouped` is `false`.
-
-**Type:** `integer` (optional)
-**Default:** `null`
-
 ### show_bodies
 
-Whether to display the body text of notifications in the menu. This setting only applies when `grouped` is `false`.
+Whether to display the body text of notifications in the menu.
 
 **Type:** `boolean`
 **Default:** `true`
@@ -70,14 +65,10 @@ When enabled, notifications are grouped by app name and each group can be
 expanded or collapsed independently. The group header shows the app name,
 icon, and count of notifications. When collapsed, only the most recent
 notification from each group is previewed. When expanded, all notifications
-in the group are shown. Clicking the app icon clears all notifications for
-that group.
+in the group are shown.
 
 Clicking on a notification in the menu will invoke its default action (if
 one exists) and close it.
-
-Note: in grouped mode, `max_notifications`, `show_timestamps`, and
-`show_bodies` are not applied.
 
 **Type:** `boolean`
 **Default:** `false`
@@ -96,27 +87,26 @@ The corner of the screen where toast notifications appear.
 **Type:** `string` — one of `"top_left"`, `"top_right"`, `"bottom_left"`, `"bottom_right"`
 **Default:** `"top_right"`
 
-### toast_default_timeout
+### toast_timeout
 
 How long (in milliseconds) a toast is shown before auto-dismissing when the application does not specify a timeout (`expire_timeout = -1`).
 
 **Type:** `integer`
 **Default:** `5000`
 
-### toast_max_visible
+### toast_limit
 
 Maximum number of toasts that can be visible at the same time. When this limit is reached, the oldest toast is removed to make room for a new one.
 
 **Type:** `integer`
-**Default:** `3`
+**Default:** `5`
 
-### empty_state_height
+### toast_max_height
 
-Height (in pixels) of the notification menu when there are no notifications. This affects the size of the
-"No notifications" placeholder and can be used to avoid the menu collapsing to a tiny popup.
+Maximum height (in pixels) of each individual toast card. Cards with less content will be shorter; this value caps how tall a single card can grow.
 
-**Type:** `number` (float)
-**Default:** `300.0`
+**Type:** `integer`
+**Default:** `150`
 
 ### Example
 
@@ -124,12 +114,11 @@ Height (in pixels) of the notification menu when there are no notifications. Thi
 [notifications]
 format = "%m/%d %H:%M"
 show_timestamps = true
-max_notifications = 20
 show_bodies = false
 grouped = true
 toast = true
 toast_position = "top_right"
-toast_default_timeout = 4000
-toast_max_visible = 3
-empty_state_height = 350.0
+toast_timeout = 4000
+toast_limit = 5
+toast_max_height = 150
 ```


### PR DESCRIPTION
## Config refactor

Removed some configuration to simplify things:
- max notifications
- toast_width
- toast_summary_line_budget
- toast_body_line_budget
- empty_state_height

Renamed other config

## UI Rework
I changed a little the UI to simplify the code and align with the rest of the application. 

I moved the icon logic to the service and refactored that part.

## Iced Layer changes
Introduced the `input_region`, we can create a full height surface and set the input region only on a specific region. This lets us have a dynamic list of toast and let the user interact with the windows behind the ashel toast surface.

## Missing pieces
- notification timeout progressibar?
- stop timeout on mouseover
- critical level (change the card border color)