### PR TITLE
New module to view and toggle systemd user services

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -16,6 +16,7 @@ use crate::{
         tempo::Tempo,
         tray::TrayModule,
         updates::Updates,
+        user_services::UserServices,
         window_title::WindowTitle,
         workspaces::Workspaces,
     },
@@ -62,6 +63,7 @@ pub struct App {
     pub settings: Settings,
     pub media_player: MediaPlayer,
     pub notifications: Notifications,
+    pub user_services: UserServices,
     pub visible: bool,
 }
 
@@ -83,6 +85,7 @@ pub enum Message {
     Settings(modules::settings::Message),
     MediaPlayer(modules::media_player::Message),
     Notifications(modules::notifications::Message),
+    UserServices(modules::user_services::Message),
     OutputEvent(OutputEvent),
     CloseAllMenus,
     ResumeFromSleep,
@@ -136,6 +139,7 @@ impl App {
                     settings: Settings::new(config.settings),
                     notifications,
                     media_player: MediaPlayer::new(config.media_player),
+                    user_services: UserServices::new(),
                     visible: true,
                 },
                 task,
@@ -392,6 +396,10 @@ impl App {
                 modules::media_player::Action::None => Task::none(),
                 modules::media_player::Action::Command(task) => task.map(Message::MediaPlayer),
             },
+            Message::UserServices(msg) => match self.user_services.update(msg) {
+                modules::user_services::Action::None => Task::none(),
+                modules::user_services::Action::Command(task) => task.map(Message::UserServices),
+            },
             Message::CloseAllMenus => {
                 if self.outputs.menu_is_open() {
                     self.outputs
@@ -594,6 +602,13 @@ impl App {
                 Some((MenuType::Tempo, button_ui_ref)) => self.menu_wrapper(
                     id,
                     self.tempo.menu_view(&self.theme).map(Message::Tempo),
+                    *button_ui_ref,
+                ),
+                Some((MenuType::UserServices, button_ui_ref)) => self.menu_wrapper(
+                    id,
+                    self.user_services
+                        .menu_view(&self.theme)
+                        .map(Message::UserServices),
                     *button_ui_ref,
                 ),
                 None => Row::new().into(),

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -125,6 +125,7 @@ pub enum StaticIcon {
     Bell,
     BellBadge,
     Delete,
+    Server,
 }
 
 impl StaticIcon {
@@ -237,6 +238,7 @@ impl StaticIcon {
             StaticIcon::Bell => "\u{eaa2}",
             StaticIcon::BellBadge => "\u{eb9a}",
             StaticIcon::Delete => "\u{f01b4}",
+            StaticIcon::Server => "\u{f048b}",
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -904,6 +904,7 @@ pub enum ModuleName {
     MediaPlayer,
     Custom(String),
     Notifications,
+    UserServices,
 }
 
 impl<'de> Deserialize<'de> for ModuleName {
@@ -934,6 +935,7 @@ impl<'de> Deserialize<'de> for ModuleName {
                     "Privacy" => ModuleName::Privacy,
                     "Settings" => ModuleName::Settings,
                     "MediaPlayer" => ModuleName::MediaPlayer,
+                    "UserServices" => ModuleName::UserServices,
                     other => ModuleName::Custom(other.to_string()),
                 })
             }

--- a/src/menu.rs
+++ b/src/menu.rs
@@ -18,6 +18,7 @@ pub enum MenuType {
     MediaPlayer,
     SystemInfo,
     Tempo,
+    UserServices,
 }
 
 #[derive(Clone, Debug)]

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -21,6 +21,7 @@ pub mod system_info;
 pub mod tempo;
 pub mod tray;
 pub mod updates;
+pub mod user_services;
 pub mod window_title;
 pub mod workspaces;
 
@@ -360,6 +361,12 @@ impl App {
                     .map(Message::Notifications),
                 Some(OnModulePress::ToggleMenu(MenuType::Notifications)),
             )),
+            ModuleName::UserServices => Some((
+                self.user_services
+                    .view(&self.theme)
+                    .map(Message::UserServices),
+                Some(OnModulePress::ToggleMenu(MenuType::UserServices)),
+            )),
         }
     }
 
@@ -403,6 +410,9 @@ impl App {
                     .subscription()
                     .map(Message::Notifications),
             ),
+            ModuleName::UserServices => {
+                Some(self.user_services.subscription().map(Message::UserServices))
+            }
         }
     }
 }

--- a/src/modules/user_services.rs
+++ b/src/modules/user_services.rs
@@ -1,0 +1,160 @@
+use crate::{
+    components::icons::{StaticIcon, icon, icon_button},
+    menu::MenuSize,
+    services::{
+        ReadOnlyService, Service, ServiceEvent,
+        user_services::{UserServicesCommand, UserServicesService},
+    },
+    theme::AshellTheme,
+};
+use iced::{
+    Alignment, Element, Length, Padding, Subscription, Task,
+    alignment::Vertical,
+    widget::{Column, button, column, container, row, rule, scrollable, text},
+};
+use std::convert;
+
+#[derive(Debug, Clone)]
+pub enum Message {
+    ToggleUnit(String),
+    Refresh,
+    Event(ServiceEvent<UserServicesService>),
+}
+
+pub enum Action {
+    None,
+    Command(Task<Message>),
+}
+
+pub struct UserServices {
+    service: Option<UserServicesService>,
+}
+
+impl UserServices {
+    pub fn new() -> Self {
+        Self { service: None }
+    }
+
+    pub fn update(&mut self, message: Message) -> Action {
+        match message {
+            Message::ToggleUnit(name) => match self.service.as_mut() {
+                Some(service) => Action::Command(
+                    service
+                        .command(UserServicesCommand::ToggleUnit(name))
+                        .map(Message::Event),
+                ),
+                None => Action::None,
+            },
+            Message::Refresh => match self.service.as_mut() {
+                Some(service) => Action::Command(
+                    service
+                        .command(UserServicesCommand::Refresh)
+                        .map(Message::Event),
+                ),
+                None => Action::None,
+            },
+            Message::Event(event) => match event {
+                ServiceEvent::Init(service) => {
+                    self.service = Some(service);
+                    Action::None
+                }
+                ServiceEvent::Update(update) => {
+                    if let Some(service) = self.service.as_mut() {
+                        service.update(update);
+                    }
+                    Action::None
+                }
+                ServiceEvent::Error(()) => Action::None,
+            },
+        }
+    }
+
+    pub fn view(&self, theme: &AshellTheme) -> Element<'_, Message> {
+        let (active, total) = match &self.service {
+            Some(service) => (service.active_count(), service.units.len()),
+            None => (0, 0),
+        };
+
+        row![
+            icon(StaticIcon::Server),
+            text(format!("{active}/{total}")).size(theme.font_size.sm),
+        ]
+        .align_y(Alignment::Center)
+        .spacing(theme.space.xxs)
+        .into()
+    }
+
+    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+        column![
+            row![
+                text("User Services")
+                    .size(theme.font_size.lg)
+                    .width(Length::Fill),
+                icon_button::<Message>(theme, StaticIcon::Refresh).on_press(Message::Refresh),
+            ]
+            .align_y(Vertical::Center),
+            rule::horizontal(1),
+            match &self.service {
+                None => convert::Into::<Element<'_, _>>::into(
+                    container(text("Connecting...")).padding(theme.space.xs),
+                ),
+                Some(service) if service.units.is_empty() => {
+                    convert::Into::<Element<'_, _>>::into(
+                        container(text("No user services found")).padding(theme.space.xs),
+                    )
+                }
+                Some(service) => container(scrollable(
+                    Column::with_children(
+                        service
+                            .units
+                            .iter()
+                            .map(|unit| self.unit_row(theme, unit))
+                            .collect::<Vec<_>>(),
+                    )
+                    .spacing(theme.space.xxs)
+                    .padding(Padding::default().right(theme.space.md)),
+                ))
+                .max_height(400)
+                .into(),
+            },
+        ]
+        .width(MenuSize::Medium)
+        .spacing(theme.space.xs)
+        .into()
+    }
+
+    fn unit_row<'a>(
+        &'a self,
+        theme: &'a AshellTheme,
+        unit: &'a crate::services::user_services::UnitInfo,
+    ) -> Element<'a, Message> {
+        let status_dot = icon(StaticIcon::Point)
+            .size(theme.font_size.xs)
+            .color(unit.status_color());
+
+        let name = text(unit.display_name()).size(theme.font_size.sm);
+
+        let content = row![status_dot, name]
+            .align_y(Vertical::Center)
+            .spacing(theme.space.xs)
+            .width(Length::Fill);
+
+        if unit.can_toggle() {
+            button(content)
+                .style(theme.ghost_button_style())
+                .padding(theme.space.xs)
+                .on_press(Message::ToggleUnit(unit.name.clone()))
+                .width(Length::Fill)
+                .into()
+        } else {
+            container(content)
+                .padding(theme.space.xs)
+                .width(Length::Fill)
+                .into()
+        }
+    }
+
+    pub fn subscription(&self) -> Subscription<Message> {
+        UserServicesService::subscribe().map(Message::Event)
+    }
+}

--- a/src/modules/user_services.rs
+++ b/src/modules/user_services.rs
@@ -10,7 +10,7 @@ use crate::{
 use iced::{
     Alignment, Element, Length, Padding, Subscription, Task,
     alignment::Vertical,
-    widget::{Column, column, container, row, rule, scrollable, text, toggler},
+    widget::{Column, button, column, container, row, rule, scrollable, text, toggler},
 };
 use std::convert;
 
@@ -82,6 +82,8 @@ impl UserServices {
     }
 
     pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+        let iced_theme = theme.get_theme();
+
         column![
             row![
                 text("User Services")
@@ -106,30 +108,37 @@ impl UserServices {
                             .units
                             .iter()
                             .map(|unit| {
-                                let name = unit.display_name();
-                                let unit_name = unit.name.clone();
-                                let is_active = unit.is_active();
-                                let can_toggle = unit.can_toggle();
+                                let text_color = match unit.active_state.as_str() {
+                                    "active" | "reloading" => Some(iced_theme.palette().success),
+                                    "activating" | "deactivating" => {
+                                        Some(iced_theme.palette().warning)
+                                    }
+                                    "failed" => Some(iced_theme.palette().danger),
+                                    _ => None,
+                                };
 
-                                row!(
-                                    text(name).width(Length::Fill),
-                                    toggler(is_active)
-                                        .on_toggle_maybe(can_toggle.then_some(move |_| {
-                                            Message::ToggleUnit(unit_name.clone())
-                                        },))
-                                        .width(Length::Shrink),
+                                let content = row!(
+                                    text(unit.display_name())
+                                        .color_maybe(text_color)
+                                        .width(Length::Fill),
+                                    toggler(unit.is_active()).width(Length::Shrink),
                                 )
-                                .padding([theme.space.xxs, theme.space.xs])
-                                .into()
+                                .align_y(Vertical::Center);
+
+                                button(content)
+                                    .style(theme.ghost_button_style())
+                                    .padding([theme.space.xxs, theme.space.sm])
+                                    .on_press_maybe(
+                                        unit.can_toggle()
+                                            .then_some(Message::ToggleUnit(unit.name.clone())),
+                                    )
+                                    .width(Length::Fill)
+                                    .into()
                             })
                             .collect::<Vec<_>>(),
                     )
-                    .spacing(theme.space.xs)
-                    .padding(
-                        Padding::default()
-                            .right(theme.space.md)
-                            .left(theme.space.xs),
-                    ),
+                    .spacing(theme.space.xxs)
+                    .padding(Padding::default().right(theme.space.md)),
                 ))
                 .max_height(400)
                 .into(),

--- a/src/modules/user_services.rs
+++ b/src/modules/user_services.rs
@@ -10,7 +10,7 @@ use crate::{
 use iced::{
     Alignment, Element, Length, Padding, Subscription, Task,
     alignment::Vertical,
-    widget::{Column, button, column, container, row, rule, scrollable, text},
+    widget::{Column, column, container, row, rule, scrollable, text, toggler},
 };
 use std::convert;
 
@@ -75,13 +75,10 @@ impl UserServices {
             None => (0, 0),
         };
 
-        row![
-            icon(StaticIcon::Server),
-            text(format!("{active}/{total}")).size(theme.font_size.sm),
-        ]
-        .align_y(Alignment::Center)
-        .spacing(theme.space.xxs)
-        .into()
+        row![icon(StaticIcon::Server), text(format!("{active}/{total}")),]
+            .align_y(Alignment::Center)
+            .spacing(theme.space.xxs)
+            .into()
     }
 
     pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
@@ -108,11 +105,31 @@ impl UserServices {
                         service
                             .units
                             .iter()
-                            .map(|unit| self.unit_row(theme, unit))
+                            .map(|unit| {
+                                let name = unit.display_name();
+                                let unit_name = unit.name.clone();
+                                let is_active = unit.is_active();
+                                let can_toggle = unit.can_toggle();
+
+                                row!(
+                                    text(name).width(Length::Fill),
+                                    toggler(is_active)
+                                        .on_toggle_maybe(can_toggle.then_some(move |_| {
+                                            Message::ToggleUnit(unit_name.clone())
+                                        },))
+                                        .width(Length::Shrink),
+                                )
+                                .padding([theme.space.xxs, theme.space.xs])
+                                .into()
+                            })
                             .collect::<Vec<_>>(),
                     )
-                    .spacing(theme.space.xxs)
-                    .padding(Padding::default().right(theme.space.md)),
+                    .spacing(theme.space.xs)
+                    .padding(
+                        Padding::default()
+                            .right(theme.space.md)
+                            .left(theme.space.xs),
+                    ),
                 ))
                 .max_height(400)
                 .into(),
@@ -121,37 +138,6 @@ impl UserServices {
         .width(MenuSize::Medium)
         .spacing(theme.space.xs)
         .into()
-    }
-
-    fn unit_row<'a>(
-        &'a self,
-        theme: &'a AshellTheme,
-        unit: &'a crate::services::user_services::UnitInfo,
-    ) -> Element<'a, Message> {
-        let status_dot = icon(StaticIcon::Point)
-            .size(theme.font_size.xs)
-            .color(unit.status_color());
-
-        let name = text(unit.display_name()).size(theme.font_size.sm);
-
-        let content = row![status_dot, name]
-            .align_y(Vertical::Center)
-            .spacing(theme.space.xs)
-            .width(Length::Fill);
-
-        if unit.can_toggle() {
-            button(content)
-                .style(theme.ghost_button_style())
-                .padding(theme.space.xs)
-                .on_press(Message::ToggleUnit(unit.name.clone()))
-                .width(Length::Fill)
-                .into()
-        } else {
-            container(content)
-                .padding(theme.space.xs)
-                .width(Length::Fill)
-                .into()
-        }
     }
 
     pub fn subscription(&self) -> Subscription<Message> {

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -13,6 +13,7 @@ pub mod privacy;
 mod throttle;
 pub mod tray;
 pub mod upower;
+pub mod user_services;
 
 #[allow(unused)]
 #[derive(Debug, Clone)]

--- a/src/services/user_services/dbus.rs
+++ b/src/services/user_services/dbus.rs
@@ -1,0 +1,68 @@
+use zbus::zvariant::OwnedObjectPath;
+
+#[zbus::proxy(
+    interface = "org.freedesktop.systemd1.Manager",
+    default_service = "org.freedesktop.systemd1",
+    default_path = "/org/freedesktop/systemd1"
+)]
+pub trait Systemd1Manager {
+    /// ListUnitFiles returns an array of (path, state) pairs.
+    fn list_unit_files(&self) -> zbus::Result<Vec<(String, String)>>;
+
+    /// ListUnits returns an array of
+    /// (name, description, load_state, active_state, sub_state,
+    ///  followed_by, object_path, queued_job_id, job_type, job_object_path).
+    #[allow(clippy::type_complexity)]
+    fn list_units(
+        &self,
+    ) -> zbus::Result<
+        Vec<(
+            String,
+            String,
+            String,
+            String,
+            String,
+            String,
+            OwnedObjectPath,
+            u32,
+            String,
+            OwnedObjectPath,
+        )>,
+    >;
+
+    /// LoadUnit asks systemd to load a unit by name and returns its object path.
+    fn load_unit(&self, name: &str) -> zbus::Result<OwnedObjectPath>;
+
+    /// StartUnit starts a unit with the given mode.
+    fn start_unit(&self, name: &str, mode: &str) -> zbus::Result<OwnedObjectPath>;
+
+    /// StopUnit stops a unit with the given mode.
+    fn stop_unit(&self, name: &str, mode: &str) -> zbus::Result<OwnedObjectPath>;
+
+    /// Subscribe to systemd signals so we receive PropertiesChanged.
+    fn subscribe(&self) -> zbus::Result<()>;
+}
+
+#[zbus::proxy(
+    interface = "org.freedesktop.systemd1.Unit",
+    default_service = "org.freedesktop.systemd1"
+)]
+pub trait Systemd1Unit {
+    #[zbus(property)]
+    fn id(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn description(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn load_state(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn active_state(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn sub_state(&self) -> zbus::Result<String>;
+
+    #[zbus(property)]
+    fn unit_file_state(&self) -> zbus::Result<String>;
+}

--- a/src/services/user_services/mod.rs
+++ b/src/services/user_services/mod.rs
@@ -55,17 +55,6 @@ impl UnitInfo {
         )
     }
 
-    /// Return a color for the status dot.
-    pub fn status_color(&self) -> iced::Color {
-        match self.active_state.as_str() {
-            "active" => iced::Color::from_rgb(0.0, 0.8, 0.0), // green
-            "activating" => iced::Color::from_rgb(1.0, 0.85, 0.0), // yellow
-            "deactivating" => iced::Color::from_rgb(1.0, 0.55, 0.0), // orange
-            "failed" => iced::Color::from_rgb(1.0, 0.0, 0.0), // red
-            _ => iced::Color::from_rgb(0.7, 0.7, 0.7),        // gray (inactive)
-        }
-    }
-
     /// Sort key: (unit_file_state order, name).
     fn state_order(&self) -> u8 {
         match self.unit_file_state.as_str() {

--- a/src/services/user_services/mod.rs
+++ b/src/services/user_services/mod.rs
@@ -1,0 +1,470 @@
+use super::{ReadOnlyService, Service, ServiceEvent};
+use dbus::{Systemd1ManagerProxy, Systemd1UnitProxy};
+use iced::{
+    Subscription,
+    futures::{SinkExt, StreamExt, stream::pending},
+    stream::channel,
+};
+use log::{debug, error, warn};
+use std::{any::TypeId, path::PathBuf};
+use zbus::{MatchRule, MessageStream, message::Type as MessageType, zvariant::OwnedObjectPath};
+
+mod dbus;
+
+const SERVICE_SUFFIX: &str = ".service";
+
+/// Properties we care about in PropertiesChanged signals.
+const INTERESTING_PROPS: &[&str] = &["ActiveState", "SubState", "UnitFileState", "LoadState"];
+
+const UNIT_IFACE: &str = "org.freedesktop.systemd1.Unit";
+
+/// Snapshot of a systemd user service unit.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct UnitInfo {
+    pub name: String,
+    pub description: String,
+    pub load_state: String,
+    pub active_state: String,
+    pub sub_state: String,
+    pub unit_file_state: String,
+    pub object_path: OwnedObjectPath,
+}
+
+impl UnitInfo {
+    /// Unit name with `.service` suffix stripped.
+    pub fn display_name(&self) -> &str {
+        self.name.strip_suffix(SERVICE_SUFFIX).unwrap_or(&self.name)
+    }
+
+    pub fn is_active(&self) -> bool {
+        matches!(
+            self.active_state.as_str(),
+            "active" | "activating" | "reloading"
+        )
+    }
+
+    /// Whether the unit can be toggled (started/stopped) right now.
+    pub fn can_toggle(&self) -> bool {
+        if matches!(self.unit_file_state.as_str(), "alias" | "masked") {
+            return false;
+        }
+        !matches!(
+            self.active_state.as_str(),
+            "activating" | "deactivating" | "reloading"
+        )
+    }
+
+    /// Return a color for the status dot.
+    pub fn status_color(&self) -> iced::Color {
+        match self.active_state.as_str() {
+            "active" => iced::Color::from_rgb(0.0, 0.8, 0.0), // green
+            "activating" => iced::Color::from_rgb(1.0, 0.85, 0.0), // yellow
+            "deactivating" => iced::Color::from_rgb(1.0, 0.55, 0.0), // orange
+            "failed" => iced::Color::from_rgb(1.0, 0.0, 0.0), // red
+            _ => iced::Color::from_rgb(0.7, 0.7, 0.7),        // gray (inactive)
+        }
+    }
+
+    /// Sort key: (unit_file_state order, name).
+    fn state_order(&self) -> u8 {
+        match self.unit_file_state.as_str() {
+            "enabled" => 0,
+            "static" => 1,
+            "disabled" => 2,
+            "generated" => 3,
+            _ => 99,
+        }
+    }
+}
+
+// ── Service types ────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+pub enum UserServicesEvent {
+    UnitsLoaded(Vec<UnitInfo>),
+    UnitChanged(UnitInfo),
+}
+
+pub enum UserServicesCommand {
+    ToggleUnit(String),
+    Refresh,
+}
+
+#[derive(Debug, Clone)]
+pub struct UserServicesService {
+    pub units: Vec<UnitInfo>,
+    conn: zbus::Connection,
+}
+
+impl UserServicesService {
+    pub fn active_count(&self) -> usize {
+        self.units.iter().filter(|u| u.is_active()).count()
+    }
+}
+
+// ── ReadOnlyService ──────────────────────────────────────────────────
+
+impl ReadOnlyService for UserServicesService {
+    type UpdateEvent = UserServicesEvent;
+    type Error = ();
+
+    fn update(&mut self, event: Self::UpdateEvent) {
+        match event {
+            UserServicesEvent::UnitsLoaded(units) => {
+                self.units = units;
+            }
+            UserServicesEvent::UnitChanged(changed) => {
+                if let Some(existing) = self.units.iter_mut().find(|u| u.name == changed.name) {
+                    *existing = changed;
+                }
+            }
+        }
+    }
+
+    fn subscribe() -> Subscription<ServiceEvent<Self>> {
+        Subscription::run_with(TypeId::of::<Self>(), |_| {
+            channel(100, async |mut output| {
+                let mut state = State::Init;
+
+                loop {
+                    state = start_listening(state, &mut output).await;
+                }
+            })
+        })
+    }
+}
+
+// ── Service (mutable commands) ───────────────────────────────────────
+
+impl Service for UserServicesService {
+    type Command = UserServicesCommand;
+
+    fn command(&mut self, command: Self::Command) -> iced::Task<ServiceEvent<Self>> {
+        match command {
+            UserServicesCommand::ToggleUnit(name) => {
+                let conn = self.conn.clone();
+                let is_active = self
+                    .units
+                    .iter()
+                    .find(|u| u.name == name)
+                    .is_some_and(|u| u.is_active());
+
+                iced::Task::perform(
+                    async move {
+                        toggle_unit(&conn, &name, is_active).await;
+                        list_user_units(&conn).await
+                    },
+                    |result| match result {
+                        Ok(units) => ServiceEvent::Update(UserServicesEvent::UnitsLoaded(units)),
+                        Err(_) => ServiceEvent::Error(()),
+                    },
+                )
+            }
+            UserServicesCommand::Refresh => {
+                let conn = self.conn.clone();
+                iced::Task::perform(async move { list_user_units(&conn).await }, |result| {
+                    match result {
+                        Ok(units) => ServiceEvent::Update(UserServicesEvent::UnitsLoaded(units)),
+                        Err(_) => ServiceEvent::Error(()),
+                    }
+                })
+            }
+        }
+    }
+}
+
+// ── State machine ────────────────────────────────────────────────────
+
+enum State {
+    Init,
+    Active(zbus::Connection),
+    Error,
+}
+
+async fn start_listening(
+    state: State,
+    output: &mut iced::futures::channel::mpsc::Sender<ServiceEvent<UserServicesService>>,
+) -> State {
+    match state {
+        State::Init => match zbus::Connection::session().await {
+            Ok(conn) => {
+                // Subscribe so systemd sends us signals.
+                if let Ok(manager) = Systemd1ManagerProxy::new(&conn).await
+                    && let Err(e) = manager.subscribe().await
+                {
+                    warn!("systemd Subscribe failed (signals may not work): {e}");
+                }
+
+                match list_user_units(&conn).await {
+                    Ok(units) => {
+                        let service = UserServicesService {
+                            units: units.clone(),
+                            conn: conn.clone(),
+                        };
+                        let _ = output.send(ServiceEvent::Init(service)).await;
+                        let _ = output
+                            .send(ServiceEvent::Update(UserServicesEvent::UnitsLoaded(units)))
+                            .await;
+
+                        State::Active(conn)
+                    }
+                    Err(err) => {
+                        error!("Failed to list user units: {err}");
+                        let _ = output.send(ServiceEvent::Error(())).await;
+                        State::Error
+                    }
+                }
+            }
+            Err(err) => {
+                error!("Failed to connect to session bus for user_services: {err}");
+                let _ = output.send(ServiceEvent::Error(())).await;
+                State::Error
+            }
+        },
+        State::Active(conn) => match listen_properties_changed(&conn, output).await {
+            Ok(()) => State::Active(conn),
+            Err(err) => {
+                error!("Failed to listen for PropertiesChanged: {err}");
+                State::Error
+            }
+        },
+        State::Error => {
+            let _ = pending::<u8>().next().await;
+            State::Error
+        }
+    }
+}
+
+// ── PropertiesChanged listener ───────────────────────────────────────
+
+async fn listen_properties_changed(
+    conn: &zbus::Connection,
+    output: &mut iced::futures::channel::mpsc::Sender<ServiceEvent<UserServicesService>>,
+) -> anyhow::Result<()> {
+    let rule = MatchRule::builder()
+        .msg_type(MessageType::Signal)
+        .sender("org.freedesktop.systemd1")?
+        .interface("org.freedesktop.DBus.Properties")?
+        .member("PropertiesChanged")?
+        .path_namespace("/org/freedesktop/systemd1/unit")?
+        .build();
+
+    let mut stream = MessageStream::for_match_rule(rule, conn, None).await?;
+
+    while let Some(msg) = stream.next().await {
+        let msg = match msg {
+            Ok(m) => m,
+            Err(e) => {
+                warn!("Error receiving PropertiesChanged message: {e}");
+                continue;
+            }
+        };
+
+        // Parse the signal body: (interface_name, changed_props, invalidated_props)
+        let Ok(body) = msg.body().deserialize::<(
+            String,
+            std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
+            Vec<String>,
+        )>() else {
+            continue;
+        };
+
+        let (iface_name, changed_props, _invalidated) = body;
+
+        // Only care about org.freedesktop.systemd1.Unit interface.
+        if iface_name != UNIT_IFACE {
+            continue;
+        }
+
+        // Check if any interesting property changed.
+        let dominated = changed_props
+            .keys()
+            .any(|k| INTERESTING_PROPS.contains(&k.as_str()));
+
+        if !dominated {
+            continue;
+        }
+
+        // Get the object path from the message header.
+        let header = msg.header();
+        let Some(path) = header.path() else {
+            continue;
+        };
+        let path: OwnedObjectPath = path.to_owned().into();
+
+        // Read unit properties via proxy.
+        if let Ok(info) = read_unit_from_path(conn, &path).await
+            && info.name.ends_with(SERVICE_SUFFIX)
+        {
+            debug!("Unit changed: {} -> {}", info.name, info.active_state);
+            let _ = output
+                .send(ServiceEvent::Update(UserServicesEvent::UnitChanged(info)))
+                .await;
+        }
+    }
+
+    Ok(())
+}
+
+// ── D-Bus helpers ────────────────────────────────────────────────────
+
+/// Read full unit properties from a D-Bus object path.
+async fn read_unit_from_path(
+    conn: &zbus::Connection,
+    path: &OwnedObjectPath,
+) -> anyhow::Result<UnitInfo> {
+    let proxy = Systemd1UnitProxy::builder(conn)
+        .path(path.as_ref())?
+        .build()
+        .await?;
+
+    Ok(UnitInfo {
+        name: proxy.id().await?,
+        description: proxy.description().await?,
+        load_state: proxy.load_state().await?,
+        active_state: proxy.active_state().await?,
+        sub_state: proxy.sub_state().await?,
+        unit_file_state: proxy.unit_file_state().await.unwrap_or_default(),
+        object_path: path.clone(),
+    })
+}
+
+/// Get the user unit directories to scan.
+fn user_unit_dirs() -> Vec<PathBuf> {
+    let Some(home) = std::env::var_os("HOME") else {
+        return Vec::new();
+    };
+    let home = PathBuf::from(home);
+    vec![
+        home.join(".config/systemd/user"),
+        home.join(".local/share/systemd/user"),
+    ]
+}
+
+/// List user-defined service units, replicating the Zig app's algorithm.
+async fn list_user_units(conn: &zbus::Connection) -> anyhow::Result<Vec<UnitInfo>> {
+    let manager = Systemd1ManagerProxy::new(conn).await?;
+    let user_dirs = user_unit_dirs();
+
+    // 1. Scan filesystem for user-defined unit file names.
+    let mut user_unit_names = std::collections::HashSet::new();
+    for dir in &user_dirs {
+        if let Ok(entries) = std::fs::read_dir(dir) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.ends_with(SERVICE_SUFFIX) {
+                    user_unit_names.insert(name.into_owned());
+                }
+            }
+        }
+    }
+
+    // 2. Get unit file states from systemd, filtered to user dirs.
+    let mut uf_states = std::collections::HashMap::new();
+    if let Ok(unit_files) = manager.list_unit_files().await {
+        for (file_path, state) in &unit_files {
+            let Some(basename) = file_path.rsplit('/').next() else {
+                continue;
+            };
+            if !basename.ends_with(SERVICE_SUFFIX) {
+                continue;
+            }
+            let is_user = user_dirs
+                .iter()
+                .any(|dir| file_path.starts_with(dir.to_string_lossy().as_ref()));
+            if !is_user {
+                continue;
+            }
+            uf_states.insert(basename.to_owned(), state.clone());
+        }
+    }
+
+    // 3. Get currently loaded units.
+    let mut loaded = std::collections::HashMap::new();
+    if let Ok(units) = manager.list_units().await {
+        for (name, description, load_state, active_state, sub_state, _, object_path, _, _, _) in
+            &units
+        {
+            if name.ends_with(SERVICE_SUFFIX) {
+                loaded.insert(
+                    name.clone(),
+                    (
+                        description.clone(),
+                        load_state.clone(),
+                        active_state.clone(),
+                        sub_state.clone(),
+                        object_path.clone(),
+                    ),
+                );
+            }
+        }
+    }
+
+    // 4. Merge: for each user unit file, build a UnitInfo.
+    let mut result = Vec::with_capacity(uf_states.len());
+    for (name, uf_state) in &uf_states {
+        if let Some((description, load_state, active_state, sub_state, object_path)) =
+            loaded.get(name)
+        {
+            // Unit is currently loaded — use runtime state.
+            result.push(UnitInfo {
+                name: name.clone(),
+                description: description.clone(),
+                load_state: load_state.clone(),
+                active_state: active_state.clone(),
+                sub_state: sub_state.clone(),
+                unit_file_state: uf_state.clone(),
+                object_path: object_path.clone(),
+            });
+        } else {
+            // Not currently loaded — try LoadUnit to get an object path.
+            let object_path = manager
+                .load_unit(name)
+                .await
+                .unwrap_or_else(|_| OwnedObjectPath::default());
+
+            result.push(UnitInfo {
+                name: name.clone(),
+                description: name.clone(),
+                load_state: "not-found".to_owned(),
+                active_state: "inactive".to_owned(),
+                sub_state: "dead".to_owned(),
+                unit_file_state: uf_state.clone(),
+                object_path,
+            });
+        }
+    }
+
+    // 5. Sort by (state order, name).
+    result.sort_by(|a, b| {
+        a.state_order()
+            .cmp(&b.state_order())
+            .then_with(|| a.name.cmp(&b.name))
+    });
+
+    debug!("Found {} user service units", result.len());
+
+    Ok(result)
+}
+
+/// Toggle a unit: start if inactive, stop if active.
+async fn toggle_unit(conn: &zbus::Connection, name: &str, is_active: bool) {
+    let Ok(manager) = Systemd1ManagerProxy::new(conn).await else {
+        error!("Failed to create systemd manager proxy for toggle");
+        return;
+    };
+
+    let result = if is_active {
+        debug!("Stopping unit: {name}");
+        manager.stop_unit(name, "replace").await
+    } else {
+        debug!("Starting unit: {name}");
+        manager.start_unit(name, "replace").await
+    };
+
+    if let Err(e) = result {
+        error!("Failed to toggle unit {name}: {e}");
+    }
+}

--- a/src/services/user_services/mod.rs
+++ b/src/services/user_services/mod.rs
@@ -6,7 +6,7 @@ use iced::{
     stream::channel,
 };
 use log::{debug, error, warn};
-use std::{any::TypeId, path::PathBuf};
+use std::{any::TypeId, collections::HashSet, path::PathBuf};
 use zbus::{MatchRule, MessageStream, message::Type as MessageType, zvariant::OwnedObjectPath};
 
 mod dbus;
@@ -178,7 +178,7 @@ impl Service for UserServicesService {
 
 enum State {
     Init,
-    Active(zbus::Connection),
+    Active(zbus::Connection, HashSet<OwnedObjectPath>),
     Error,
 }
 
@@ -198,6 +198,9 @@ async fn start_listening(
 
                 match list_user_units(&conn).await {
                     Ok(units) => {
+                        let tracked_paths: HashSet<OwnedObjectPath> =
+                            units.iter().map(|u| u.object_path.clone()).collect();
+
                         let service = UserServicesService {
                             units: units.clone(),
                             conn: conn.clone(),
@@ -207,7 +210,7 @@ async fn start_listening(
                             .send(ServiceEvent::Update(UserServicesEvent::UnitsLoaded(units)))
                             .await;
 
-                        State::Active(conn)
+                        State::Active(conn, tracked_paths)
                     }
                     Err(err) => {
                         error!("Failed to list user units: {err}");
@@ -222,13 +225,15 @@ async fn start_listening(
                 State::Error
             }
         },
-        State::Active(conn) => match listen_properties_changed(&conn, output).await {
-            Ok(()) => State::Active(conn),
-            Err(err) => {
-                error!("Failed to listen for PropertiesChanged: {err}");
-                State::Error
+        State::Active(conn, tracked_paths) => {
+            match listen_properties_changed(&conn, &tracked_paths, output).await {
+                Ok(()) => State::Active(conn, tracked_paths),
+                Err(err) => {
+                    error!("Failed to listen for PropertiesChanged: {err}");
+                    State::Error
+                }
             }
-        },
+        }
         State::Error => {
             let _ = pending::<u8>().next().await;
             State::Error
@@ -240,6 +245,7 @@ async fn start_listening(
 
 async fn listen_properties_changed(
     conn: &zbus::Connection,
+    tracked_paths: &HashSet<OwnedObjectPath>,
     output: &mut iced::futures::channel::mpsc::Sender<ServiceEvent<UserServicesService>>,
 ) -> anyhow::Result<()> {
     let rule = MatchRule::builder()
@@ -250,57 +256,64 @@ async fn listen_properties_changed(
         .path_namespace("/org/freedesktop/systemd1/unit")?
         .build();
 
-    let mut stream = MessageStream::for_match_rule(rule, conn, None).await?;
+    let stream = MessageStream::for_match_rule(rule, conn, None).await?;
+    let mut chunks = stream.ready_chunks(10);
 
-    while let Some(msg) = stream.next().await {
-        let msg = match msg {
-            Ok(m) => m,
-            Err(e) => {
-                warn!("Error receiving PropertiesChanged message: {e}");
+    while let Some(chunk) = chunks.next().await {
+        // Collect unique tracked object paths from this batch of signals.
+        let mut paths_to_update = HashSet::new();
+
+        for msg in chunk.into_iter().flatten() {
+            // Parse the signal body: (interface_name, changed_props, invalidated_props)
+            let Ok(body) = msg.body().deserialize::<(
+                String,
+                std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
+                Vec<String>,
+            )>() else {
+                continue;
+            };
+
+            let (iface_name, changed_props, _invalidated) = body;
+
+            // Only care about org.freedesktop.systemd1.Unit interface.
+            if iface_name != UNIT_IFACE {
                 continue;
             }
-        };
 
-        // Parse the signal body: (interface_name, changed_props, invalidated_props)
-        let Ok(body) = msg.body().deserialize::<(
-            String,
-            std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
-            Vec<String>,
-        )>() else {
-            continue;
-        };
+            // Check if any interesting property changed.
+            let dominated = changed_props
+                .keys()
+                .any(|k| INTERESTING_PROPS.contains(&k.as_str()));
 
-        let (iface_name, changed_props, _invalidated) = body;
+            if !dominated {
+                continue;
+            }
 
-        // Only care about org.freedesktop.systemd1.Unit interface.
-        if iface_name != UNIT_IFACE {
-            continue;
+            // Get the object path from the message header.
+            let header = msg.header();
+            let Some(path) = header.path() else {
+                continue;
+            };
+            let path: OwnedObjectPath = path.to_owned().into();
+
+            // Filter: only process signals for units we are tracking.
+            if !tracked_paths.contains(&path) {
+                continue;
+            }
+
+            paths_to_update.insert(path);
         }
 
-        // Check if any interesting property changed.
-        let dominated = changed_props
-            .keys()
-            .any(|k| INTERESTING_PROPS.contains(&k.as_str()));
-
-        if !dominated {
-            continue;
-        }
-
-        // Get the object path from the message header.
-        let header = msg.header();
-        let Some(path) = header.path() else {
-            continue;
-        };
-        let path: OwnedObjectPath = path.to_owned().into();
-
-        // Read unit properties via proxy.
-        if let Ok(info) = read_unit_from_path(conn, &path).await
-            && info.name.ends_with(SERVICE_SUFFIX)
-        {
-            debug!("Unit changed: {} -> {}", info.name, info.active_state);
-            let _ = output
-                .send(ServiceEvent::Update(UserServicesEvent::UnitChanged(info)))
-                .await;
+        // One D-Bus read per unique tracked unit in this batch.
+        for path in paths_to_update {
+            if let Ok(info) = read_unit_from_path(conn, &path).await
+                && info.name.ends_with(SERVICE_SUFFIX)
+            {
+                debug!("Unit changed: {} -> {}", info.name, info.active_state);
+                let _ = output
+                    .send(ServiceEvent::Update(UserServicesEvent::UnitChanged(info)))
+                    .await;
+            }
         }
     }
 

--- a/src/widgets/menu_wrapper.rs
+++ b/src/widgets/menu_wrapper.rs
@@ -172,13 +172,19 @@ where
 
     fn mouse_interaction(
         &self,
-        _: &Tree,
-        _: Layout<'_>,
-        _: mouse::Cursor,
-        _: &Rectangle,
-        _: &Renderer,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
     ) -> mouse::Interaction {
-        mouse::Interaction::default()
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout.children().next().unwrap(),
+            cursor,
+            viewport,
+            renderer,
+        )
     }
 
     fn draw(


### PR DESCRIPTION
This module lists user units (with some filtering to keep the "interesting" ones) and allows seeing their status and toggling starting/stopping them.

> [!Note]
> I am not a Rust developer (but still a seasoned software engineer...) and heavily used an LLM to create this module. I am not really able to judge on the Rust itself, but tried to stick to the project's best practices.
>
> I tried to avoid "generic" changes, but one seemed required to control the cursor appearance in commit d98b530ff5f61ea8466a1150aca0f676cadfbfd8 *fix: delegate mouse_interaction in MenuWrapper to child content*