### PR TITLE
Fix/media player cover

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,7 +1720,8 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell"
-version = "0.1.2"
+version = "0.1.3"
+source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.3#6fee0bf32c6a12343dc22c5f73c90cef235ab608"
 dependencies = [
  "calloop",
  "calloop-wayland-source",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1281,6 +1281,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5df2ba84018d80c213569363bdcd0c64e6933c67fe4c1d60ecf822971a3c35e"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,8 +1720,7 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell"
-version = "0.1.1"
-source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.2#13656c2bddee49a66d2d5f7ba0591e4574ab4101"
+version = "0.1.2"
 dependencies = [
  "calloop",
  "calloop-wayland-source",
@@ -1722,6 +1731,7 @@ dependencies = [
  "iced_renderer",
  "iced_runtime",
  "iced_widget",
+ "image",
  "log",
  "raw-window-handle",
  "smithay-client-toolkit",
@@ -1928,8 +1938,14 @@ checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif 0.14.1",
+ "image-webp",
  "moxcms",
  "num-traits",
+ "png 0.18.1",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -2939,6 +2955,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,7 +3366,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
- "gif",
+ "gif 0.13.3",
  "image-webp",
  "log",
  "pico-args",
@@ -3345,7 +3374,7 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -4078,7 +4107,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5711,12 +5740,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-jpeg"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
-iced = { package = "iced_layershell", path = "../iced_layershell", features = [
+iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.3", features = [
   "tokio",
   "advanced",
   "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
-iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.2", features = [
+iced = { package = "iced_layershell", path = "../iced_layershell", features = [
   "tokio",
   "advanced",
   "wgpu",

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -146,7 +146,7 @@ impl MediaPlayer {
                             let inner: Element<'_, _> = service
                                 .get_cover(url)
                                 .map(|handle| {
-                                    image(handle.clone())
+                                    image(handle)
                                         .filter_method(image::FilterMethod::Linear)
                                         .into()
                                 })

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -16,7 +16,6 @@ use iced::{
     alignment::Vertical,
     widget::{column, container, image, row, rule, slider, space, text},
 };
-use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -36,7 +35,6 @@ pub enum Action {
 pub struct MediaPlayer {
     config: MediaPlayerModuleConfig,
     service: Option<MprisPlayerService>,
-    covers: HashMap<String, image::Handle>,
 }
 
 impl MediaPlayer {
@@ -44,7 +42,6 @@ impl MediaPlayer {
         Self {
             config,
             service: None,
-            covers: HashMap::new(),
         }
     }
 
@@ -67,7 +64,6 @@ impl MediaPlayer {
                     if let Some(service) = self.service.as_mut() {
                         service.update(d);
                     }
-                    self.sync_cover_handles();
                     Action::None
                 }
                 ServiceEvent::Error(_) => Action::None,
@@ -147,11 +143,10 @@ impl MediaPlayer {
                         .as_ref()
                         .and_then(|m| m.art_url.as_ref())
                         .map(|url| {
-                            let inner: Element<'_, _> = self
-                                .covers
-                                .get(url)
+                            let inner: Element<'_, _> = service
+                                .get_cover(url)
                                 .map(|handle| {
-                                    image(handle)
+                                    image(handle.clone())
                                         .filter_method(image::FilterMethod::Linear)
                                         .into()
                                 })
@@ -258,30 +253,5 @@ impl MediaPlayer {
 
     pub fn subscription(&self) -> Subscription<Message> {
         MprisPlayerService::subscribe().map(Message::Event)
-    }
-
-    fn sync_cover_handles(&mut self) {
-        let Some(service) = &self.service else {
-            return;
-        };
-
-        let desired_urls: HashSet<String> = service
-            .players()
-            .iter()
-            .filter_map(|player| player.metadata.as_ref()?.art_url.clone())
-            .collect();
-        self.covers.retain(|url, _| desired_urls.contains(url));
-        let unloaded_urls: HashSet<String> = desired_urls
-            .difference(&self.covers.keys().cloned().collect())
-            .cloned()
-            .collect();
-
-        for url in unloaded_urls {
-            let Some(cover) = service.get_cover(&url) else {
-                continue;
-            };
-            self.covers
-                .insert(url.clone(), image::Handle::from_bytes(cover.clone()));
-        }
     }
 }

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -11,6 +11,7 @@ use iced::{
         stream::{AbortHandle, Abortable, Aborted, FuturesUnordered, SelectAll, pending},
     },
     stream::channel,
+    widget::image,
 };
 use log::{debug, error, info};
 use std::{
@@ -102,7 +103,7 @@ impl From<HashMap<String, OwnedValue>> for MprisPlayerMetadata {
 pub struct MprisPlayerService {
     data: Vec<MprisPlayerData>,
     conn: zbus::Connection,
-    covers: HashMap<String, Bytes>,
+    covers: HashMap<String, image::Handle>,
 }
 
 impl MprisPlayerService {
@@ -110,7 +111,7 @@ impl MprisPlayerService {
         &self.data
     }
 
-    pub fn get_cover(&self, url: &str) -> Option<&Bytes> {
+    pub fn get_cover(&self, url: &str) -> Option<&image::Handle> {
         self.covers.get(url)
     }
 }
@@ -163,7 +164,7 @@ impl ReadOnlyService for MprisPlayerService {
                 self.covers.retain(|url, _| desired_urls.contains(url));
             }
             Event::CoverFetched(url, bytes) => {
-                self.covers.insert(url, bytes);
+                self.covers.insert(url, image::Handle::from_bytes(bytes));
             }
         }
     }


### PR DESCRIPTION
FIXED!!

<img width="970" height="620" alt="image" src="https://github.com/user-attachments/assets/140d9f07-1469-47f7-a973-a042590300d7" />

So... what happened? `iced_graphics` declares the `image` crate with `default-features = false`, which means no codec, which means `Handle::from_bytes` simply fails.

Adding the image crate to `ashell` resolves the issue and, as a side-effect, fixes all the tray icons that rely on `Handle::from_bytes`.

The "correct" solution was to add the image crate to `iced_layershell` with only the codec that we need. I also removed that sync mechanism for the cover because I don't get the meaning of having duplicated stuff between the service and the module.