### PR TITLE
correct timezone index boundary check

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -126,7 +126,7 @@ impl Tempo {
             Message::SetTimezone(index) => {
                 if !self.config.timezones.is_empty() {
                     let len = self.config.timezones.len();
-                    if index <= len {
+                    if index < len {
                         self.current_timezone_index = index;
                     }
                 }


### PR DESCRIPTION
The check `index <= len` would allow `index == len`, which is out of bounds and would panic when the index is later used to access `timezones[index]`.
Currently the UI only emits valid indices (0 to len-1) via `.enumerate()`. 
Nevertheless, we should fix that. 