### PR TITLE
docs: add Matrix community channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@
     <a href="https://malpenzibo.github.io/ashell/docs/intro">Getting Started</a> | <a href="https://malpenzibo.github.io/ashell/docs/configuration">Configuration</a> | <a href="https://malpenzibo.github.io/ashell/dev-guide/">Developer&nbsp;Guide</a>
 </p>
 
-## 🚀 Getting Started
-
-Refer to the [Getting Started](https://malpenzibo.github.io/ashell/docs/intro)
-page on website
-
 ## ✨ Features
 
 - Automatic Hyprland/Niri compositor detection

--- a/README.md
+++ b/README.md
@@ -1,15 +1,18 @@
-<div align="center">
+<h1 align="center">
   <a href="https://malpenzibo.github.io/ashell/">
     <img src="https://raw.githubusercontent.com/MalpenZibo/ashell/main/website/static/img/logo_header_dark.svg" alt="ashell" height="140"/>
   </a>
-</div>
+</h1>
+<p align="center">A ready to go Wayland status bar for Hyprland and Niri.</p>
+<p align="center">
+    <a href="https://matrix.to/#/#ashell:matrix.org"><img alt="Matrix" src="https://img.shields.io/badge/matrix-%23ashell-blue?logo=matrix"></a>
+    <a href="https://github.com/MalpenZibo/ashell/blob/main/LICENSE"><img alt="GitHub License" src="https://img.shields.io/github/license/MalpenZibo/ashell"></a>
+    <a href="https://github.com/MalpenZibo/ashell/releases"><img alt="GitHub Release" src="https://img.shields.io/github/v/release/MalpenZibo/ashell?logo=github"></a>
+</p>
 
-## What is ashell?
-
-ashell is a ready to go Wayland status bar for Hyprland and Niri.
-
-Feel free to fork this project and customize it for your needs or just open an
-issue to request a particular feature.
+<p align="center">
+    <a href="https://malpenzibo.github.io/ashell/docs/intro">Getting Started</a> | <a href="https://malpenzibo.github.io/ashell/docs/configuration">Configuration</a> | <a href="https://malpenzibo.github.io/ashell/dev-guide/">Developer&nbsp;Guide</a>
+</p>
 
 ## 🚀 Getting Started
 
@@ -64,11 +67,6 @@ ashell comes with a default configuration that should work out of the box.
 If you want to customize it you can refer to
 the [Configuration](https://malpenzibo.github.io/ashell/docs/configuration)
 page for more details.
-
-## 💬 Community
-
-Join the conversation on [Matrix](https://matrix.to/#/#ashell:matrix.org) or open an
-[issue](https://github.com/MalpenZibo/ashell/issues) on GitHub.
 
 ## 📖 Developer Guide
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ If you want to customize it you can refer to
 the [Configuration](https://malpenzibo.github.io/ashell/docs/configuration)
 page for more details.
 
+## 💬 Community
+
+Join the conversation on [Matrix](https://matrix.to/#/#ashell:matrix.org) or open an
+[issue](https://github.com/MalpenZibo/ashell/issues) on GitHub.
+
 ## 📖 Developer Guide
 
 If you want to contribute or understand the codebase, check out the

--- a/README.md
+++ b/README.md
@@ -68,6 +68,11 @@ If you want to customize it you can refer to
 the [Configuration](https://malpenzibo.github.io/ashell/docs/configuration)
 page for more details.
 
+## 💬 Community
+
+Join the conversation on [Matrix](https://matrix.to/#/#ashell:matrix.org) or open an
+[issue](https://github.com/MalpenZibo/ashell/issues) on GitHub.
+
 ## 📖 Developer Guide
 
 If you want to contribute or understand the codebase, check out the

--- a/docs/src/contributing/ai-assisted-contributions.md
+++ b/docs/src/contributing/ai-assisted-contributions.md
@@ -20,7 +20,7 @@ Regardless of the tools used, **you are responsible for the code you submit**. R
 
 ### Discuss Before Implementing
 
-Before working on a feature or large change, **talk to the maintainers first**. Open an issue or comment on an existing one to discuss:
+Before working on a feature or large change, **talk to the maintainers first**. Reach out on [Matrix](https://matrix.to/#/#ashell:matrix.org), open an issue, or comment on an existing one to discuss:
 
 - Does this fit the project?
 - What architectural decisions make sense?

--- a/docs/src/contributing/workflow.md
+++ b/docs/src/contributing/workflow.md
@@ -64,4 +64,5 @@ For the full AI contribution guide including workflow recommendations, common pi
 
 ## Communication
 
+- For real-time discussion and community support, join us on [Matrix](https://matrix.to/#/#ashell:matrix.org).
 - Primary communication is through GitHub issues and PR comments.

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -134,6 +134,10 @@ const config: Config = {
           title: "Community",
           items: [
             {
+              label: "Matrix Chat",
+              href: "https://matrix.to/#/#ashell:matrix.org",
+            },
+            {
               label: "Issues",
               href: "https://github.com/MalpenZibo/ashell/issues",
             },


### PR DESCRIPTION
## Summary

- Add the Matrix channel ([#ashell:matrix.org](https://matrix.to/#/#ashell:matrix.org)) to all relevant locations:
  - **README.md** — new "Community" section between Configuration and Developer Guide
  - **Website footer** — added Matrix Chat to the existing Community section
  - **Developer guide** (`docs/src/contributing/workflow.md`) — expanded Communication section
  - **AI contribution guide** (`docs/src/contributing/ai-assisted-contributions.md`) — mention Matrix as a way to reach maintainers

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify website footer shows the Matrix Chat link (`cd website && npm start`)
- [ ] Verify dev guide builds correctly (`cd docs && mdbook build`)