### PR TITLE
docs: update for iced_layershell migration and add notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ page on website
 - Clock with calendar, weather, timezone cycling, and format cycling (Tempo)
 - Privacy indicators (microphone, camera, and screenshare usage)
 - Media Player with album art and track info
+- Notification manager with toast popups, grouping, and urgency support
 - Settings panel
   - Power menu (shutdown, suspend, hibernate, reboot, logout, lock)
   - Battery and peripheral battery information

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -39,7 +39,7 @@
 - [Modules Overview](modules/overview.md)
 - [Anatomy of a Module](modules/anatomy-of-a-module.md)
 - [Module Registry and Routing](modules/module-registry.md)
-- [Walkthrough: The Clock Module](modules/clock-walkthrough.md)
+- [Walkthrough: The Clock Module (Historical)](modules/clock-walkthrough.md)
 - [Deep Dive: The Settings Module](modules/settings-module.md)
 - [Writing a New Module](modules/writing-a-new-module.md)
 

--- a/docs/src/architecture/known-limitations.md
+++ b/docs/src/architecture/known-limitations.md
@@ -2,20 +2,6 @@
 
 This chapter documents known architectural limitations and design tradeoffs. Understanding these helps contributors make informed decisions and avoid re-discovering known issues.
 
-## The iced Fork Dependency
-
-**Issue**: ashell depends on a fork of a fork of iced (upstream → Pop!_OS/cosmic → MalpenZibo). This creates maintenance burden:
-
-- Upstream iced improvements must be manually cherry-picked.
-- The fork diverges over time, making rebases increasingly difficult.
-- Contributors can't easily use upstream iced documentation or examples without checking for differences.
-
-**Why it exists**: Upstream iced doesn't support Wayland layer shell surfaces. The Pop!_OS fork adds SCTK integration, and MalpenZibo's fork adds further fixes needed by ashell.
-
-**Status**: The maintainer has explored alternatives (including an experimental GUI library called "guido"), but there are no concrete plans to migrate away from the iced fork. The fork is updated periodically to track upstream changes.
-
-**Related**: [GitHub Issue #450 (Roadmap)](https://github.com/MalpenZibo/ashell/issues/450)
-
 ## Menu Surface Architecture
 
 **Issue**: Context menus currently use a fullscreen transparent overlay surface. This has several drawbacks:
@@ -24,7 +10,7 @@ This chapter documents known architectural limitations and design tradeoffs. Und
 - **Layering bugs**: The overlay doesn't correctly layer popups on top of other windows in all cases
 - **Conflicts**: Can interfere with other layer surfaces on the Background layer
 
-**Correct approach**: Use `zwlr_layer_surface_v1::get_popup` to create proper `xdg_popup` surfaces. However, the SCTK library has this method but the iced fork doesn't expose it.
+**Correct approach**: Use `zwlr_layer_surface_v1::get_popup` to create proper `xdg_popup` surfaces. However, iced_layershell does not currently expose this.
 
 **Workaround**: The current fullscreen overlay approach was also chosen because iced has a HiDPI scaling regression where newly created surfaces initially render blurry.
 

--- a/docs/src/architecture/overview.md
+++ b/docs/src/architecture/overview.md
@@ -22,11 +22,12 @@ ashell is structured in three layers:
 ┌───────▼──────────┐    ┌─────────────▼────────────┐
 │   Modules (UI)   │    │   Services (Backend)     │
 │                  │    │                          │
-│  clock, tempo,   │    │  compositor, audio,      │
+│  tempo,          │    │  compositor, audio,      │
 │  workspaces,     │    │  bluetooth, network,     │
 │  settings,       │◄───│  mpris, tray, upower,    │
 │  system_info,    │    │  brightness, privacy,    │
-│  tray, media,    │    │  logind, idle_inhibitor  │
+│  notifications,  │    │  notifications, logind,  │
+│  tray, media,    │    │  idle_inhibitor          │
 │  privacy, etc.   │    │                          │
 └──────────────────┘    └──────────────────────────┘
 ```
@@ -41,28 +42,20 @@ ashell is structured in three layers:
 
 - **Rust-native**: No FFI bindings to GTK/Qt, keeping the stack uniform.
 - **Elm Architecture**: Predictable state management with unidirectional data flow.
-- **Wayland layer shell support**: Available through a fork (see below).
+- **Wayland layer shell support**: Available through [iced_layershell](https://github.com/MalpenZibo/iced_layershell).
 - **GPU-accelerated rendering**: Via wgpu.
 
-### The iced Fork Chain
+### iced_layershell
 
-ashell does **not** use upstream iced directly. Instead, it uses a chain of forks:
+ashell uses upstream iced 0.14 with [iced_layershell](https://github.com/MalpenZibo/iced_layershell), a Wayland layer shell backend built on Smithay Client Toolkit (SCTK). This provides layer surface management, multi-surface support, and input handling without forking iced.
 
-```
-upstream iced
-    └── Pop!_OS / cosmic-iced (adds Wayland layer shell support via SCTK)
-            └── MalpenZibo/iced (ashell's fork: fixes, features, Wayland tweaks)
-```
-
-The Pop!_OS fork adds SCTK (Smithay Client Toolkit) integration for Wayland layer surfaces, which is essential for a status bar. MalpenZibo's fork on top of that includes additional fixes and features specific to ashell's needs.
-
-This fork dependency is tracked in `Cargo.toml` as a git dependency with a pinned revision:
+In `Cargo.toml` the dependency is aliased as `iced` for convenience:
 
 ```toml
-iced = { git = "https://github.com/MalpenZibo/iced", rev = "...", features = [...] }
+iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.3", features = [...] }
 ```
 
-> **Note**: The fork dependency is a known maintenance burden. See [Known Limitations](known-limitations.md) for more context and the long-term plans.
+> **History**: ashell previously depended on a Pop!_OS/cosmic-iced fork chain. The migration to iced_layershell (v0.8.0+) eliminated that fork dependency.
 
 ## Design Principles
 

--- a/docs/src/build-system/cargo-and-dependencies.md
+++ b/docs/src/build-system/cargo-and-dependencies.md
@@ -8,15 +8,12 @@ ashell's dependencies are managed in `Cargo.toml`. This chapter covers the key d
 
 | Crate | Version | Purpose |
 |-------|---------|---------|
-| `iced` | Git (MalpenZibo fork) | GUI framework with Wayland layer shell support |
+| `iced` (iced_layershell) | Git | GUI framework with Wayland layer shell support via [iced_layershell](https://github.com/MalpenZibo/iced_layershell) |
 
-The iced dependency uses many features:
+The dependency is aliased as `iced` in `Cargo.toml` (`package = "iced_layershell"`). It uses these features:
 - `tokio` — Async runtime integration
-- `multi-window` — Multiple layer surfaces (bar + menu per monitor)
 - `advanced` — Custom widget support
 - `wgpu` — GPU-accelerated rendering
-- `winit` — Window system integration
-- `wayland` — Wayland protocol support
 - `image`, `svg`, `canvas` — Graphics capabilities
 
 ### Async Runtime

--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -31,15 +31,14 @@ If you don't use Nix, install the [prerequisites](prerequisites.md) for your dis
 
 ### rust-analyzer
 
-ashell uses a custom fork of iced (see [Architecture Overview](../architecture/overview.md)). This means `rust-analyzer` resolves iced types from the git dependency. Go-to-definition works, but it will navigate into `~/.cargo/git/` rather than a local checkout.
+ashell uses [iced_layershell](https://github.com/MalpenZibo/iced_layershell) as a git dependency (see [Architecture Overview](../architecture/overview.md)). `rust-analyzer` works normally — go-to-definition will navigate into `~/.cargo/git/`.
 
-If you need to edit or deeply explore the iced fork, clone it locally:
+If you need to develop against a local checkout of iced_layershell, add a `[patch]` section to `Cargo.toml` (don't commit this):
 
-```bash
-git clone https://github.com/MalpenZibo/iced.git
+```toml
+[patch."https://github.com/MalpenZibo/iced_layershell"]
+iced_layershell = { path = "../iced_layershell" }
 ```
-
-Then temporarily override the dependency in `Cargo.toml` using a `[patch]` section (don't commit this).
 
 ## Running ashell
 

--- a/docs/src/modules/clock-walkthrough.md
+++ b/docs/src/modules/clock-walkthrough.md
@@ -1,8 +1,8 @@
-# Walkthrough: The Clock Module
+# Walkthrough: The Clock Module (Historical)
 
-The Clock module (`src/modules/clock.rs`) is the simplest module in ashell at just 60 lines. It's an ideal example for understanding the module pattern.
+> **Note**: The Clock module has been removed from the codebase. This walkthrough is preserved as a teaching example of the module pattern. For current patterns, see [Anatomy of a Module](anatomy-of-a-module.md).
 
-> **Note**: The Clock module is deprecated in favor of the more feature-rich [Tempo](../reference/glossary.md) module. It remains in the codebase for backwards compatibility but logs a deprecation warning.
+The Clock module was the simplest module in ashell at just 60 lines. It's an ideal example for understanding the module pattern.
 
 ## Complete Source (annotated)
 

--- a/docs/src/modules/module-registry.md
+++ b/docs/src/modules/module-registry.md
@@ -11,8 +11,8 @@ fn get_module_view(&self, id: Id, module_name: &ModuleName)
     -> Option<(Element<Message>, Option<OnModulePress>)>
 {
     match module_name {
-        ModuleName::Clock => Some((
-            self.clock.view(&self.theme).map(Message::Clock),
+        ModuleName::Privacy => Some((
+            self.privacy.view(&self.theme).map(Message::Privacy),
             None,  // No interaction
         )),
         ModuleName::Settings => Some((
@@ -63,7 +63,7 @@ Maps each module to its subscriptions:
 ```rust
 fn get_module_subscription(&self, module_name: &ModuleName) -> Option<Subscription<Message>> {
     match module_name {
-        ModuleName::Clock => Some(self.clock.subscription().map(Message::Clock)),
+        ModuleName::Privacy => Some(self.privacy.subscription().map(Message::Privacy)),
         ModuleName::Settings => Some(self.settings.subscription().map(Message::Settings)),
         // ...
     }

--- a/docs/src/modules/overview.md
+++ b/docs/src/modules/overview.md
@@ -12,8 +12,8 @@ Modules are the UI building blocks of ashell. Each module is a self-contained co
 | KeyboardLayout | `"KeyboardLayout"` | Keyboard layout indicator (click to cycle) | No |
 | KeyboardSubmap | `"KeyboardSubmap"` | Hyprland submap display | No |
 | Tray | `"Tray"` | System tray icons | Yes (per-app) |
-| Clock | `"Clock"` | Simple time display (**deprecated**) | No |
 | Tempo | `"Tempo"` | Advanced clock with calendar, weather, timezones | Yes |
+| Notifications | `"Notifications"` | Desktop notification daemon with toasts | Yes |
 | Privacy | `"Privacy"` | Microphone/camera/screenshare indicators | No |
 | Settings | `"Settings"` | Settings panel (audio, network, bluetooth, etc.) | Yes |
 | MediaPlayer | `"MediaPlayer"` | MPRIS media player control | Yes |

--- a/website/docs/configuration/modules/index.md
+++ b/website/docs/configuration/modules/index.md
@@ -87,6 +87,11 @@ Provides privacy-related features, such as toggling microphone and camera access
 
 Displays media player controls and information about the currently playing media.
 
+### Notifications
+
+Desktop notification daemon with toast popups and a notification center menu.
+See the [Notifications docs](./notifications.md) for full configuration details.
+
 ### Settings
 
 Provides access to system settings like audio, network, Bluetooth, battery,


### PR DESCRIPTION
## Summary

- **iced_layershell migration**: Replace all references to the old pop-os/cosmic iced fork chain with iced_layershell across the developer guide (architecture overview, known limitations, cargo dependencies, development environment)
- **Remove resolved limitation**: The "iced Fork Dependency" section in known-limitations.md is no longer relevant and has been removed
- **Add Notifications module**: Added to modules overview table, website module index, and README features list — the module was fully implemented but missing from these indexes
- **Clock module cleanup**: Removed from modules table (code was already deleted), marked the walkthrough as historical, updated code examples in module-registry.md

### Files changed (10)

| File | Change |
|------|--------|
| `docs/src/architecture/overview.md` | Replace fork chain section with iced_layershell |
| `docs/src/architecture/known-limitations.md` | Remove fork dependency section |
| `docs/src/build-system/cargo-and-dependencies.md` | Update iced entry and feature list |
| `docs/src/getting-started/development-environment.md` | Update rust-analyzer section |
| `docs/src/modules/overview.md` | Add Notifications, remove Clock |
| `docs/src/modules/clock-walkthrough.md` | Mark as historical |
| `docs/src/modules/module-registry.md` | Replace Clock examples with Privacy |
| `docs/src/SUMMARY.md` | Update walkthrough title |
| `website/docs/configuration/modules/index.md` | Add Notifications section |
| `README.md` | Add notification manager to features |

## Test plan

- [x] `mdbook build` succeeds
- [x] `npm run build` (website) succeeds
- [x] No stale fork references remain (grep verified)