### PR TITLE
Add panic handler and auto-retry for PulseAudio thread

### DIFF
--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -2,7 +2,7 @@ use super::{ReadOnlyService, Service, ServiceEvent};
 use crate::utils::remote_value::Remote;
 use iced::{
     Subscription, Task,
-    futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending},
+    futures::{SinkExt, channel::mpsc::Sender},
     stream::channel,
 };
 use itertools::Either;
@@ -34,8 +34,10 @@ use std::{
     rc::Rc,
     sync::Arc,
     thread::{self, JoinHandle},
+    time::Duration,
 };
 use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::time::sleep;
 
 #[derive(Debug, Clone)]
 pub struct Device {
@@ -207,10 +209,11 @@ impl AudioService {
                 None => State::Active(handle),
             },
             State::Error => {
-                error!("Audio service error");
+                error!("Audio service error, retrying in 5 seconds");
 
-                let _ = pending::<u8>().next().await;
-                State::Error
+                sleep(Duration::from_secs(5)).await;
+
+                State::Init
             }
         }
     }
@@ -504,9 +507,20 @@ impl PulseAudioServer {
 
         // Single thread for both listening and commanding — avoids PulseAudio
         // mainloop assertion failures from concurrent connections.
+        let from_server_tx_for_panic = from_server_tx.clone();
         let handle = thread::spawn({
             let from_server_tx = from_server_tx.clone();
             let mut to_server_rx = to_server_rx;
+
+            // Set up panic handler to gracefully handle PulseAudio thread crashes
+            let panic_tx = from_server_tx_for_panic.clone();
+            let old_hook = std::panic::take_hook();
+            std::panic::set_hook(Box::new(move |panic_info| {
+                error!("PulseAudio thread panicked: {}", panic_info);
+                let _ = panic_tx.send(PulseAudioServerEvent::Error);
+                old_hook(panic_info);
+            }));
+
             move || match Self::new() {
                 Ok(mut server) => {
                     let _ = init_tx.send(true);


### PR DESCRIPTION
I accidentally stumbled upon this one. 

I watched a YT video and did a 
```
systemctl --user restart pipewire
systemctl --user restart pipewire-pulse
```
nothijnng was visible (in the ashell terminal output)
but then I moved the volume slider and I got a crash.


Terminal output:
```
❯ ashell
INFO [ashell::config] Decoding config file "/home/roman/.config/ashell/config.toml"
INFO [ashell::config] Config file loaded successfully
WARN [wgpu_hal::vulkan::instance] Unable to find extension: VK_EXT_physical_device_drm
WARN [wgpu_hal::gles::egl] Re-initializing Gles context due to Wayland window
WARN [ashell::services::upower] Failed to get power profile: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
ERROR [ashell] Panic: panicked at /home/roman/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libpulse-binding-2.30.1/src/operation.rs:51:9:
assertion failed: !ptr.is_null() 
 disabled backtrace
fish: Job 1, 'ashell' terminated by signal SIGABRT (Abort)
Failed to show notification: GDBus.Error:org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
```

What I did, like for the Network service as well added a Panic handler that catches PulseAudio thread crashes and logs them and an auto-retry which retries initialization after 5 seconds when it fails. 

now I have something like  

```
❯ cargo r
   Compiling ashell v0.8.0 (/srv/opensource/ashell)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.02s
     Running `target/debug/ashell`
INFO [ashell::config] Decoding config file "/home/roman/.config/ashell/config.toml"
INFO [ashell::config] Config file loaded successfully
WARN [wgpu_hal::vulkan::instance] Unable to find extension: VK_EXT_physical_device_drm
WARN [wgpu_hal::gles::egl] Re-initializing Gles context due to Wayland window
WARN [ashell::services::upower] Failed to get power profile: org.freedesktop.DBus.Error.ServiceUnknown: The name is not activatable
ERROR [ashell::services::audio] PulseAudio thread panicked: panicked at /home/roman/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libpulse-binding-2.30.1/src/operation.rs:51:9:
assertion failed: !ptr.is_null()
ERROR [ashell] Panic: panicked at /home/roman/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/libpulse-binding-2.30.1/src/operation.rs:51:9:
assertion failed: !ptr.is_null() 
 disabled backtrace
ERROR [ashell::services::audio] PulseAudio server error
ERROR [ashell::services::audio] Audio service error, retrying in 5 seconds
^C⏎       

```

But the audio module/service works and doesn't crash the bar. 

@MalpenZibo There is a general question if this is fine, or we should add a max retries and exp backoff? 


PS: put on draft for now, maybe it is better to make more of the services retry-able on error. 
and then some generic helper like  

```
// utils/service.rs
pub async fn retry_on_error<E: std::fmt::Debug>(
    label: &str,
    delay: Duration,
    mut attempt: impl FnMut() -> Result<(), E>,
) -> Result<(), E> {
    loop {
        match attempt() {
            Ok(()) => return Ok(()),
            Err(e) => {
                error!("{} error: {:?}", label, e);
                error!("{}, retrying in {} seconds", label, delay.as_secs());
                sleep(delay).await;
            }
        }
    }
}
```
 would be useful. 
 
 I think higher abstraction will all the various states and different inits is not useful.
