### PR TITLE
ci(release-drafter): fix autolabeler for fork PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches:
       - main
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, edited, synchronize]
 
 permissions:
@@ -23,7 +23,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   label-pr:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request_target'
     name: Label PR
     permissions:
       pull-requests: write


### PR DESCRIPTION
## Summary

- Use `pull_request_target` instead of `pull_request` in the release-drafter workflow so the `GITHUB_TOKEN` has write permissions when labeling PRs from contributor forks
- This fixes the "Resource not accessible by integration" error seen in PR #650

### Why this is safe

The autolabeler only reads PR metadata (branch name, title) to match patterns — it does not check out or execute any code from the PR. `pull_request_target` is the [recommended pattern](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target) for workflows that need write access on fork PRs without running untrusted code.

## Test plan

- [ ] Verify the "Label PR" check passes on this PR itself
- [ ] Verify it also passes on fork PRs (e.g. #650)