### PR TITLE
POC - explore animations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,7 @@ dependencies = [
  "freedesktop-icons",
  "hex_color",
  "hyprland",
+ "iced_anim",
  "iced_layershell",
  "inotify",
  "itertools 0.14.0",
@@ -1281,6 +1282,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
 name = "gl_generator"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1643,6 +1654,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "iced_anim"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7e0f5f848b041abf2907eda96a4c21cbd5c3aee4ade434bd650d898f39e95b"
+dependencies = [
+ "iced_core",
+]
+
+[[package]]
 name = "iced_core"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,8 +1730,8 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell"
-version = "0.1.1"
-source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.2#13656c2bddee49a66d2d5f7ba0591e4574ab4101"
+version = "0.1.3"
+source = "git+https://github.com/MalpenZibo/iced_layershell?branch=fix%2Fanimation-next-frame-redraw#de35866791e51de3f0578f7150aa362914855cbb"
 dependencies = [
  "calloop",
  "calloop-wayland-source",
@@ -1722,6 +1742,7 @@ dependencies = [
  "iced_renderer",
  "iced_runtime",
  "iced_widget",
+ "image",
  "log",
  "raw-window-handle",
  "smithay-client-toolkit",
@@ -1928,8 +1949,14 @@ checksum = "e6506c6c10786659413faa717ceebcb8f70731c0a60cbae39795fdf114519c1a"
 dependencies = [
  "bytemuck",
  "byteorder-lite",
+ "color_quant",
+ "gif 0.14.2",
+ "image-webp",
  "moxcms",
  "num-traits",
+ "png 0.18.1",
+ "zune-core 0.5.1",
+ "zune-jpeg 0.5.15",
 ]
 
 [[package]]
@@ -2939,6 +2966,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.10.0",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "polling"
 version = "3.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3337,7 +3377,7 @@ version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8928798c0a55e03c9ca6c4c6846f76377427d2c1e1f7e6de3c06ae57942df43"
 dependencies = [
- "gif",
+ "gif 0.13.3",
  "image-webp",
  "log",
  "pico-args",
@@ -3345,7 +3385,7 @@ dependencies = [
  "svgtypes",
  "tiny-skia",
  "usvg",
- "zune-jpeg",
+ "zune-jpeg 0.4.21",
 ]
 
 [[package]]
@@ -4078,7 +4118,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "log",
- "png",
+ "png 0.17.16",
  "tiny-skia-path",
 ]
 
@@ -5711,12 +5751,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
 name = "zune-jpeg"
 version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
- "zune-core",
+ "zune-core 0.4.12",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core 0.5.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
-iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.2", features = [
+iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", branch = "fix/animation-next-frame-redraw", features = [
   "tokio",
   "advanced",
   "wgpu",
@@ -36,6 +36,7 @@ iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_
   "svg",
   "canvas",
 ] }
+iced_anim = "0.3"
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "serde",

--- a/src/components/animated_size.rs
+++ b/src/components/animated_size.rs
@@ -1,0 +1,266 @@
+use iced::{
+    Animation, Length, Rectangle, Size, Vector,
+    animation::Easing,
+    core::{
+        Clipboard, Layout, Shell, Widget, event, layout, mouse, overlay, renderer,
+        widget::{Operation, Tree, tree},
+    },
+};
+use std::time::{Duration, Instant};
+
+type Element<'a, Message, Theme, Renderer> = iced::core::Element<'a, Message, Theme, Renderer>;
+
+struct State {
+    width_anim: Animation<f32>,
+    last_child_width: f32,
+    initialized: bool,
+}
+
+impl State {
+    fn new(duration: Duration, easing: Easing) -> Self {
+        Self {
+            width_anim: Animation::new(0.0).duration(duration).easing(easing),
+            last_child_width: 0.0,
+            initialized: false,
+        }
+    }
+}
+
+/// A widget that automatically animates width changes of its content.
+///
+/// Wrap any element in `AnimatedSize` and it will smoothly transition
+/// when the content's natural width changes. No messages, subscriptions,
+/// or manual state management needed.
+///
+/// # Example
+/// ```ignore
+/// animated_size(text("Hello"))
+///     .duration(Duration::from_millis(400))
+/// ```
+pub struct AnimatedSize<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+where
+    Renderer: iced::core::Renderer,
+{
+    content: Element<'a, Message, Theme, Renderer>,
+    duration: Duration,
+    easing: Easing,
+}
+
+impl<'a, Message, Theme, Renderer> AnimatedSize<'a, Message, Theme, Renderer>
+where
+    Renderer: iced::core::Renderer,
+{
+    /// Sets the animation duration.
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    /// Sets the easing function.
+    pub fn easing(mut self, easing: Easing) -> Self {
+        self.easing = easing;
+        self
+    }
+}
+
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for AnimatedSize<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+    Theme: 'a,
+    Renderer: iced::core::Renderer + 'a,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new(self.duration, self.easing))
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_ref(&self.content));
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size::new(Length::Shrink, Length::Shrink)
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        // Layout child with unconstrained width to get its natural size
+        let child_node =
+            self.content
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits);
+        let child_width = child_node.size().width;
+        let child_height = child_node.size().height;
+
+        let state = tree.state.downcast_mut::<State>();
+
+        if !state.initialized {
+            // First layout: set initial width without animation
+            state.width_anim = Animation::new(child_width)
+                .duration(self.duration)
+                .easing(self.easing);
+            state.last_child_width = child_width;
+            state.initialized = true;
+        } else if (child_width - state.last_child_width).abs() > 0.5 {
+            // Child size changed: start animation from current position to new size
+            state.last_child_width = child_width;
+            state.width_anim.go_mut(child_width, Instant::now());
+        }
+
+        let now = Instant::now();
+        let display_width = if state.width_anim.is_animating(now) {
+            state.width_anim.interpolate_with(|v| v, now)
+        } else {
+            child_width
+        };
+
+        // Our node wraps the child but reports the animated width
+        layout::Node::with_children(Size::new(display_width, child_height), vec![child_node])
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &event::Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        // Forward events to child
+        self.content.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+
+        // Drive animation on RedrawRequested
+        if let event::Event::Window(iced::core::window::Event::RedrawRequested(_now)) = event {
+            let state = tree.state.downcast_mut::<State>();
+            if state.width_anim.is_animating(Instant::now()) {
+                shell.request_redraw();
+                shell.invalidate_layout();
+            }
+        }
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+
+        // Clip to our animated bounds
+        renderer.with_layer(bounds, |renderer| {
+            self.content.as_widget().draw(
+                &tree.children[0],
+                renderer,
+                theme,
+                style,
+                layout.children().next().unwrap(),
+                cursor,
+                viewport,
+            );
+        });
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.content.as_widget_mut().operate(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+            operation,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout.children().next().unwrap(),
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout.children().next()?,
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<AnimatedSize<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+    Theme: 'a,
+    Renderer: iced::core::Renderer + 'a,
+{
+    fn from(widget: AnimatedSize<'a, Message, Theme, Renderer>) -> Self {
+        Self::new(widget)
+    }
+}
+
+/// Wraps content in a widget that automatically animates width changes.
+pub fn animated_size<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> AnimatedSize<'a, Message, Theme, Renderer>
+where
+    Renderer: iced::core::Renderer,
+{
+    AnimatedSize {
+        content: content.into(),
+        duration: Duration::from_millis(400),
+        easing: Easing::EaseOutCubic,
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod animated_size;
 pub mod button;
 mod centerbox;
 mod format_indicator;
@@ -12,6 +13,7 @@ mod quick_setting_button;
 mod slider_control;
 mod sub_menu_wrapper;
 
+pub use animated_size::*;
 pub use button::*;
 pub use centerbox::*;
 pub use format_indicator::*;

--- a/src/modules/window_title.rs
+++ b/src/modules/window_title.rs
@@ -1,4 +1,7 @@
+use std::time::Duration;
+
 use crate::{
+    components::animated_size,
     config::{WindowTitleConfig, WindowTitleMode},
     services::{ReadOnlyService, ServiceEvent, compositor::CompositorService},
     theme::AshellTheme,
@@ -91,12 +94,16 @@ impl WindowTitle {
     }
 
     pub fn view(&'_ self, theme: &AshellTheme, title: String) -> Element<'_, Message> {
-        container(
-            text(title)
-                .size(theme.font_size.sm)
-                .wrapping(text::Wrapping::None),
+        animated_size(
+            container(
+                text(title)
+                    .size(theme.font_size.sm)
+                    .wrapping(text::Wrapping::None),
+            )
+            .clip(true),
         )
-        .clip(true)
+        .easing(iced::animation::Easing::EaseIn)
+        .duration(Duration::from_millis(100))
         .into()
     }
 

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -11,6 +11,7 @@ use iced::{
     Element, Length, Subscription, SurfaceId, alignment,
     widget::{MouseArea, Row, button, container, text},
 };
+use iced_anim::{AnimationBuilder, transition::Easing};
 use itertools::Itertools;
 use std::collections::HashMap;
 
@@ -442,14 +443,15 @@ impl Workspaces {
                                 }
                             });
 
-                            Some(
-                                button(
-                                    container(text(w.name.as_str()).size(theme.font_size.xs))
-                                        .align_x(alignment::Horizontal::Center)
-                                        .align_y(alignment::Vertical::Center),
-                                )
-                                .style(theme.workspace_button_style(empty, color))
-                                .padding(if w.id < 0 {
+                            {
+                                let target_width = match (w.id < 0, &w.displayed) {
+                                    (true, _) => None,
+                                    (_, Displayed::Active) => Some(theme.space.xl),
+                                    (_, Displayed::Visible) => Some(theme.space.lg),
+                                    (_, Displayed::Hidden) => Some(theme.space.md),
+                                };
+                                let name = w.name.clone();
+                                let padding = if w.id < 0 {
                                     match w.displayed {
                                         Displayed::Active => [0.0, theme.space.md],
                                         Displayed::Visible => [0.0, theme.space.sm],
@@ -457,21 +459,45 @@ impl Workspaces {
                                     }
                                 } else {
                                     [0.0, 0.0]
-                                })
-                                .on_press(if w.id > 0 {
+                                };
+                                let on_press = if w.id > 0 {
                                     Message::ChangeWorkspace(w.id)
                                 } else {
                                     Message::ToggleSpecialWorkspace(w.id)
+                                };
+                                let height = theme.space.md;
+                                let font_size = theme.font_size.xs;
+
+                                Some(match target_width {
+                                    Some(tw) => AnimationBuilder::new(tw, move |w| {
+                                        button(
+                                            container(text(name.clone()).size(font_size))
+                                                .align_x(alignment::Horizontal::Center)
+                                                .align_y(alignment::Vertical::Center),
+                                        )
+                                        .style(theme.workspace_button_style(empty, color))
+                                        .padding(padding)
+                                        .on_press(on_press.clone())
+                                        .width(Length::Fixed(w))
+                                        .height(height)
+                                        .into()
+                                    })
+                                    .animates_layout(true)
+                                    .animation(Easing::EASE.quick())
+                                    .into(),
+                                    None => button(
+                                        container(text(w.name.as_str()).size(theme.font_size.xs))
+                                            .align_x(alignment::Horizontal::Center)
+                                            .align_y(alignment::Vertical::Center),
+                                    )
+                                    .style(theme.workspace_button_style(empty, color))
+                                    .padding(padding)
+                                    .on_press(on_press)
+                                    .width(Length::Shrink)
+                                    .height(height)
+                                    .into(),
                                 })
-                                .width(match (w.id < 0, &w.displayed) {
-                                    (true, _) => Length::Shrink,
-                                    (_, Displayed::Active) => Length::Fixed(theme.space.xl),
-                                    (_, Displayed::Visible) => Length::Fixed(theme.space.lg),
-                                    (_, Displayed::Hidden) => Length::Fixed(theme.space.md),
-                                })
-                                .height(theme.space.md)
-                                .into(),
-                            )
+                            }
                         } else {
                             None
                         }


### PR DESCRIPTION
- Fixed an `iced_layershell` bug that prevents the animation redraw cycle
- Add `iced_anim` as dep (not 100% sure about this decision)

- Add a simple width animation on workspace buttons
- Add a (not so) simple animation to the window title