### PR TITLE
Use canonicalize path for watching config file

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1122,7 +1122,7 @@ pub fn subscription(path: &Path) -> Subscription<Message> {
     let path = path.to_path_buf();
 
     Subscription::run_with(path, |path| {
-        let path = path.clone();
+        let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
         channel(100, async move |mut output| {
             match (path.parent(), path.file_name(), Inotify::init()) {
                 (Some(folder), Some(file_name), Ok(inotify)) => {


### PR DESCRIPTION
This fixes an issue with reloading the configuration if the config file was a symlink to another file.