### PR TITLE
add typed temperature sensor configuration with auto-detection

### DIFF
--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -136,7 +136,7 @@ alert_threshold = 80
 ```
 
 **Dependencies:**
-- Temperature monitoring reads the kernel `hwmon` sysfs interface directly (no extra package required). The `sensor` label (e.g. `"acpitz temp1"`) must match a hwmon device on your system — run `sensors` (from `lm_sensors`) to find the right name.
+- Temperature monitoring reads the kernel `hwmon` sysfs interface directly (no extra package required). The `sensor` option is either a type keyword (`"Cpu"`, `"Gpu"`, `"Acpi"`, `"Nvme"`) for auto-detection or an exact hwmon label (e.g. `"acpitz temp1"`) — run `sensors` (from `lm_sensors`) to find the right name. The displayed unit follows the locale / unit system, not a per-module option.
 - CPU, memory, disk, and network info use standard kernel interfaces and do not need extra packages.
 
 ## Clock Module (Deprecated)

--- a/src/config.rs
+++ b/src/config.rs
@@ -225,12 +225,22 @@ impl Default for SystemInfoMemory {
 const DEFAULT_TEMP_WARN_CELSIUS: i32 = 60;
 const DEFAULT_TEMP_ALERT_CELSIUS: i32 = 80;
 
+#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub enum TemperatureSensorType {
+    #[default]
+    Cpu,
+    Gpu,
+    Acpi,
+    Nvme,
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct SystemInfoTemperature {
     warn_threshold: Option<i32>,
     alert_threshold: Option<i32>,
-    pub sensor: String,
+    pub sensor_type: TemperatureSensorType,
+    pub sensor: Option<String>,
     pub format: TemperatureFormat,
 }
 
@@ -263,7 +273,8 @@ impl Default for SystemInfoTemperature {
         Self {
             warn_threshold: None,
             alert_threshold: None,
-            sensor: "acpitz temp1".to_string(),
+            sensor_type: TemperatureSensorType::default(),
+            sensor: None,
             format: TemperatureFormat::Celsius,
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -242,12 +242,23 @@ impl Default for SystemInfoMemory {
 const DEFAULT_TEMP_WARN_CELSIUS: i32 = 60;
 const DEFAULT_TEMP_ALERT_CELSIUS: i32 = 80;
 
+#[derive(Deserialize, Clone, Debug, Default, PartialEq, Eq)]
+pub enum TemperatureSensorType {
+    #[default]
+    Cpu,
+    Gpu,
+    Acpi,
+    Nvme,
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct SystemInfoTemperature {
     warn_threshold: Option<i32>,
     alert_threshold: Option<i32>,
-    pub sensor: String,
+    pub sensor_type: TemperatureSensorType,
+    pub sensor: Option<String>,
+    pub format: TemperatureFormat,
 }
 
 impl SystemInfoTemperature {
@@ -279,7 +290,9 @@ impl Default for SystemInfoTemperature {
         Self {
             warn_threshold: None,
             alert_threshold: None,
-            sensor: "acpitz temp1".to_string(),
+            sensor_type: TemperatureSensorType::default(),
+            sensor: None,
+            format: TemperatureFormat::Celsius,
         }
     }
 }
@@ -303,6 +316,13 @@ pub enum CpuFormat {
     #[default]
     Percentage,
     Frequency,
+}
+
+#[derive(Clone, Debug, Deserialize, Default)]
+pub enum TemperatureFormat {
+    #[default]
+    Celsius,
+    Fahrenheit,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,14 +251,26 @@ pub enum TemperatureSensorType {
     Nvme,
 }
 
-#[derive(Deserialize, Clone, Debug)]
+/// A type keyword (auto-detected) or an exact sensor label.
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
+#[serde(untagged)]
+pub enum TemperatureSensor {
+    Type(TemperatureSensorType),
+    Label(String),
+}
+
+impl Default for TemperatureSensor {
+    fn default() -> Self {
+        Self::Type(TemperatureSensorType::default())
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
 #[serde(default)]
 pub struct SystemInfoTemperature {
     warn_threshold: Option<i32>,
     alert_threshold: Option<i32>,
-    pub sensor_type: TemperatureSensorType,
-    pub sensor: Option<String>,
-    pub format: TemperatureFormat,
+    pub sensor: TemperatureSensor,
 }
 
 impl SystemInfoTemperature {
@@ -285,18 +297,6 @@ impl SystemInfoTemperature {
     }
 }
 
-impl Default for SystemInfoTemperature {
-    fn default() -> Self {
-        Self {
-            warn_threshold: None,
-            alert_threshold: None,
-            sensor_type: TemperatureSensorType::default(),
-            sensor: None,
-            format: TemperatureFormat::Celsius,
-        }
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Default)]
 pub enum DiskFormat {
     #[default]
@@ -316,13 +316,6 @@ pub enum CpuFormat {
     #[default]
     Percentage,
     Frequency,
-}
-
-#[derive(Clone, Debug, Deserialize, Default)]
-pub enum TemperatureFormat {
-    #[default]
-    Celsius,
-    Fahrenheit,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -4,7 +4,7 @@ use crate::{
     components::icons::{StaticIcon, icon},
     config::{
         CpuFormat, DiskFormat, MemoryFormat, SystemInfoIndicator, SystemInfoModuleConfig,
-        TemperatureFormat,
+        SystemInfoTemperature, TemperatureFormat, TemperatureSensorType,
     },
     theme::AshellTheme,
     utils,
@@ -15,6 +15,7 @@ use iced::{
     widget::{Column, Row, column, container, row, text},
 };
 use itertools::Itertools;
+use log::{info, warn};
 use std::time::{Duration, Instant};
 use sysinfo::{Components, Disks, Networks, System};
 
@@ -80,13 +81,79 @@ struct SystemInfoData {
     network: Option<NetworkData>,
 }
 
+fn find_first_sensor_label(labels: &[&str], components: &Components) -> Option<String> {
+    labels
+        .iter()
+        .find(|&&label| components.iter().any(|c| c.label() == label))
+        .map(|&label| label.to_string())
+}
+
+fn get_temperature_sensor_label(
+    temperature_config: &SystemInfoTemperature,
+    components: &Components,
+) -> Option<String> {
+    if let Some(sensor) = temperature_config.sensor.as_deref() {
+        if components.iter().any(|c| c.label() == sensor) {
+            info!(
+                "Using manually configured temperature sensor: {} (type {:?})",
+                sensor, temperature_config.sensor_type
+            );
+            Some(sensor.to_string())
+        } else {
+            warn!(
+                "Configured temperature sensor '{}' not found in component list",
+                sensor
+            );
+            None
+        }
+    } else {
+        let sensor_label = match temperature_config.sensor_type {
+            TemperatureSensorType::Cpu => {
+                find_first_sensor_label(&["coretemp Package id 0", "coretemp Core 0"], components)
+                    .or_else(|| {
+                        components
+                            .iter()
+                            .find(|c| c.label().starts_with("k10temp"))
+                            .map(|c| c.label().to_string())
+                    })
+            }
+            TemperatureSensorType::Gpu => components
+                .iter()
+                .find(|c| c.label().starts_with("xe"))
+                .map(|c| c.label().to_string())
+                .or_else(|| find_first_sensor_label(&["amdgpu edge", "nouveau temp1"], components)),
+            TemperatureSensorType::Acpi => {
+                find_first_sensor_label(&["acpitz temp1", "acpitz temp0"], components)
+            }
+            TemperatureSensorType::Nvme => components
+                .iter()
+                .find(|c| c.label().starts_with("nvme"))
+                .map(|c| c.label().to_string()),
+        };
+
+        if let Some(ref label) = sensor_label {
+            info!(
+                "Auto-detected temperature sensor for {:?}: {}",
+                temperature_config.sensor_type, label
+            );
+        } else {
+            warn!(
+                "No temperature sensor found for {:?} type",
+                temperature_config.sensor_type
+            );
+        }
+
+        sensor_label
+    }
+}
+
 fn get_system_info(
     system: &mut System,
     components: &mut Components,
     disks: &mut Disks,
     (networks, last_check): (&mut Networks, Option<Instant>),
-    temperature_sensor: &str,
-    sensor_index: Option<usize>,
+    temperature_config: &SystemInfoTemperature,
+    cached_sensor_label: &mut Option<String>,
 ) -> SystemInfoData {
     system.refresh_memory();
     system.refresh_cpu_all();
@@ -135,15 +202,38 @@ fn get_system_info(
         ),
     };
 
-    let temperature_cel = sensor_index
-        .and_then(|i| components.get(i))
-        .and_then(|c| c.temperature().map(|t| t as i32))
-        .or_else(|| {
+    let temperature_cel = if let Some(sensor) = temperature_config.sensor.as_deref() {
+        components
+            .iter()
+            .find(|c| c.label() == sensor)
+            .and_then(|c| c.temperature().map(|t| t as i32))
+    } else {
+        if cached_sensor_label.is_none() {
+            *cached_sensor_label = get_temperature_sensor_label(temperature_config, components);
+        }
+
+        let mut reading = cached_sensor_label.as_ref().and_then(|label| {
             components
                 .iter()
-                .find(|c| c.label() == temperature_sensor)
+                .find(|c| c.label() == label)
                 .and_then(|c| c.temperature().map(|t| t as i32))
         });
+
+        if reading.is_none() {
+            if let Some(label) = (*cached_sensor_label).take() {
+                warn!("Cached sensor '{}' invalid; re-detecting", label);
+            }
+            *cached_sensor_label = get_temperature_sensor_label(temperature_config, components);
+            reading = cached_sensor_label.as_ref().and_then(|label| {
+                components
+                    .iter()
+                    .find(|c| c.label() == label)
+                    .and_then(|c| c.temperature().map(|t| t as i32))
+            });
+        }
+
+        reading
+    };
 
     let temperature = Temperature {
         celsius: temperature_cel,
@@ -265,7 +355,7 @@ pub struct SystemInfo {
     disks: Disks,
     networks: Networks,
     data: SystemInfoData,
-    cached_sensor_index: Option<usize>,
+    cached_sensor_label: Option<String>,
 }
 
 impl SystemInfo {
@@ -275,18 +365,22 @@ impl SystemInfo {
         let mut disks = Disks::new_with_refreshed_list();
         let mut networks = Networks::new_with_refreshed_list();
 
-        let cached_sensor_index = components
-            .iter()
-            .position(|c| c.label() == config.temperature.sensor);
+        let mut cached_sensor_label = None;
 
         let data = get_system_info(
             &mut system,
             &mut components,
             &mut disks,
             (&mut networks, None),
-            config.temperature.sensor.as_str(),
-            cached_sensor_index,
+            &config.temperature,
+            &mut cached_sensor_label,
         );
+
+        if let Some(label) = cached_sensor_label.as_ref() {
+            info!("Using temperature sensor: {}", label);
+        } else if let Some(sensor) = config.temperature.sensor.as_deref() {
+            info!("Using temperature sensor: {}", sensor);
+        }
 
         Self {
             config,
@@ -295,7 +389,7 @@ impl SystemInfo {
             disks,
             data,
             networks,
-            cached_sensor_index,
+            cached_sensor_label,
         }
     }
 
@@ -310,8 +404,8 @@ impl SystemInfo {
                         &mut self.networks,
                         self.data.network.as_ref().map(|n| n.last_check),
                     ),
-                    &self.config.temperature.sensor,
-                    self.cached_sensor_index,
+                    &self.config.temperature,
+                    &mut self.cached_sensor_label,
                 );
             }
         }

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -2,7 +2,10 @@ use crate::{
     components::MenuSize,
     components::divider,
     components::icons::{StaticIcon, icon},
-    config::{CpuFormat, DiskFormat, MemoryFormat, SystemInfoIndicator, SystemInfoModuleConfig},
+    config::{
+        CpuFormat, DiskFormat, MemoryFormat, SystemInfoIndicator, SystemInfoModuleConfig,
+        SystemInfoTemperature, TemperatureSensorType,
+    },
     i18n::{UnitSystem, unit_system},
     theme::use_theme,
     utils,
@@ -13,6 +16,7 @@ use iced::{
     widget::{Column, Row, column, container, row, text},
 };
 use itertools::Itertools;
+use log::{info, warn};
 use std::time::{Duration, Instant};
 use sysinfo::{Components, Disks, Networks, System};
 
@@ -78,13 +82,125 @@ struct SystemInfoData {
     network: Option<NetworkData>,
 }
 
+fn find_first_sensor_label(labels: &[&str], components: &Components) -> Option<String> {
+    labels
+        .iter()
+        .find(|&&label| components.iter().any(|c| c.label() == label))
+        .map(|&label| label.to_string())
+}
+
+enum SensorMatch<'a> {
+    Exact(&'a [&'a str]),
+    StartsWith(&'a [&'a str]),
+    Contains(&'a [&'a str]),
+}
+
+fn find_sensor(components: &Components, matches: &[SensorMatch]) -> Option<String> {
+    for m in matches {
+        let result = match m {
+            SensorMatch::Exact(labels) => find_first_sensor_label(labels, components),
+            SensorMatch::StartsWith(prefixes) => {
+                let mut result = None;
+                for &prefix in *prefixes {
+                    if let Some(c) = components.iter().find(|c| c.label().starts_with(prefix)) {
+                        result = Some(c.label().to_string());
+                        break;
+                    }
+                }
+                result
+            }
+            SensorMatch::Contains(substrs) => {
+                let mut result = None;
+                for &substr in *substrs {
+                    if let Some(c) = components
+                        .iter()
+                        .find(|c| c.label().to_lowercase().contains(substr))
+                    {
+                        result = Some(c.label().to_string());
+                        break;
+                    }
+                }
+                result
+            }
+        };
+        if result.is_some() {
+            return result;
+        }
+    }
+    None
+}
+
+static CPU_MATCHES: [SensorMatch<'static>; 2] = [
+    SensorMatch::Exact(&[
+        "coretemp Package id 0",
+        "coretemp Core 0",
+        "coretemp Physical id 0",
+    ]),
+    SensorMatch::StartsWith(&["k10temp", "applesmc"]),
+];
+
+static GPU_MATCHES: [SensorMatch<'static>; 3] = [
+    SensorMatch::StartsWith(&["xe"]),
+    SensorMatch::Exact(&["amdgpu edge", "nouveau temp1"]),
+    SensorMatch::Contains(&["nvidia"]),
+];
+
+static ACPI_MATCHES: [SensorMatch<'static>; 1] =
+    [SensorMatch::Exact(&["acpitz temp1", "acpitz temp0"])];
+
+static NVME_MATCHES: [SensorMatch<'static>; 1] = [SensorMatch::StartsWith(&["nvme"])];
+
+fn get_temperature_sensor_label(
+    temperature_config: &SystemInfoTemperature,
+    components: &Components,
+) -> Option<String> {
+    // Try manual sensor first if specified
+    if let Some(sensor) = temperature_config.sensor.as_deref() {
+        if components.iter().any(|c| c.label() == sensor) {
+            info!(
+                "Using manually configured temperature sensor: {} (type {:?})",
+                sensor, temperature_config.sensor_type
+            );
+            return Some(sensor.to_string());
+        } else {
+            warn!(
+                "Configured temperature sensor '{}' not found, falling back to auto-detection for {:?}",
+                sensor, temperature_config.sensor_type
+            );
+        }
+    }
+
+    let matches: &[SensorMatch] = match temperature_config.sensor_type {
+        TemperatureSensorType::Cpu => &CPU_MATCHES,
+        TemperatureSensorType::Gpu => &GPU_MATCHES,
+        TemperatureSensorType::Acpi => &ACPI_MATCHES,
+        TemperatureSensorType::Nvme => &NVME_MATCHES,
+    };
+
+    let sensor_label = find_sensor(components, matches);
+
+    if let Some(ref label) = sensor_label {
+        info!(
+            "Auto-detected temperature sensor for {:?}: {}",
+            temperature_config.sensor_type, label
+        );
+    } else {
+        warn!(
+            "No temperature sensor found for {:?} type",
+            temperature_config.sensor_type
+        );
+    }
+
+    sensor_label
+}
+
 fn get_system_info(
     system: &mut System,
     components: &mut Components,
     disks: &mut Disks,
     (networks, last_check): (&mut Networks, Option<Instant>),
-    temperature_sensor: &str,
-    sensor_index: Option<usize>,
+    temperature_config: &SystemInfoTemperature,
+    cached_sensor_label: &mut Option<String>,
 ) -> SystemInfoData {
     system.refresh_memory();
     system.refresh_cpu_all();
@@ -133,15 +249,33 @@ fn get_system_info(
         ),
     };
 
-    let temperature_cel = sensor_index
-        .and_then(|i| components.get(i))
-        .and_then(|c| c.temperature().map(|t| t as i32))
-        .or_else(|| {
+    let temperature_cel = {
+        if cached_sensor_label.is_none() {
+            *cached_sensor_label = get_temperature_sensor_label(temperature_config, components);
+        }
+
+        let mut reading = cached_sensor_label.as_ref().and_then(|label| {
             components
                 .iter()
-                .find(|c| c.label() == temperature_sensor)
+                .find(|c| c.label() == label)
                 .and_then(|c| c.temperature().map(|t| t as i32))
         });
+
+        if reading.is_none() {
+            if let Some(label) = (*cached_sensor_label).take() {
+                warn!("Cached sensor '{}' invalid; re-detecting", label);
+            }
+            *cached_sensor_label = get_temperature_sensor_label(temperature_config, components);
+            reading = cached_sensor_label.as_ref().and_then(|label| {
+                components
+                    .iter()
+                    .find(|c| c.label() == label)
+                    .and_then(|c| c.temperature().map(|t| t as i32))
+            });
+        }
+
+        reading
+    };
 
     let temperature = Temperature {
         celsius: temperature_cel,
@@ -263,7 +397,7 @@ pub struct SystemInfo {
     disks: Disks,
     networks: Networks,
     data: SystemInfoData,
-    cached_sensor_index: Option<usize>,
+    cached_sensor_label: Option<String>,
 }
 
 impl SystemInfo {
@@ -273,18 +407,22 @@ impl SystemInfo {
         let mut disks = Disks::new_with_refreshed_list();
         let mut networks = Networks::new_with_refreshed_list();
 
-        let cached_sensor_index = components
-            .iter()
-            .position(|c| c.label() == config.temperature.sensor);
+        let mut cached_sensor_label = None;
 
         let data = get_system_info(
             &mut system,
             &mut components,
             &mut disks,
             (&mut networks, None),
-            config.temperature.sensor.as_str(),
-            cached_sensor_index,
+            &config.temperature,
+            &mut cached_sensor_label,
         );
+
+        if let Some(label) = cached_sensor_label.as_ref() {
+            info!("Using temperature sensor: {}", label);
+        } else if let Some(sensor) = config.temperature.sensor.as_deref() {
+            info!("Using temperature sensor: {}", sensor);
+        }
 
         Self {
             config,
@@ -293,7 +431,7 @@ impl SystemInfo {
             disks,
             data,
             networks,
-            cached_sensor_index,
+            cached_sensor_label,
         }
     }
 
@@ -308,8 +446,8 @@ impl SystemInfo {
                         &mut self.networks,
                         self.data.network.as_ref().map(|n| n.last_check),
                     ),
-                    &self.config.temperature.sensor,
-                    self.cached_sensor_index,
+                    &self.config.temperature,
+                    &mut self.cached_sensor_label,
                 );
             }
         }

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -4,7 +4,7 @@ use crate::{
     components::icons::{StaticIcon, icon},
     config::{
         CpuFormat, DiskFormat, MemoryFormat, SystemInfoIndicator, SystemInfoModuleConfig,
-        SystemInfoTemperature, TemperatureSensorType,
+        SystemInfoTemperature, TemperatureSensor, TemperatureSensorType,
     },
     i18n::{UnitSystem, unit_system},
     t,
@@ -152,26 +152,24 @@ static ACPI_MATCHES: [SensorMatch<'static>; 1] =
 static NVME_MATCHES: [SensorMatch<'static>; 1] = [SensorMatch::StartsWith(&["nvme"])];
 
 fn get_temperature_sensor_label(
-    temperature_config: &SystemInfoTemperature,
+    sensor: &TemperatureSensor,
     components: &Components,
 ) -> Option<String> {
-    // Try manual sensor first if specified
-    if let Some(sensor) = temperature_config.sensor.as_deref() {
-        if components.iter().any(|c| c.label() == sensor) {
-            info!(
-                "Using manually configured temperature sensor: {} (type {:?})",
-                sensor, temperature_config.sensor_type
-            );
-            return Some(sensor.to_string());
-        } else {
+    let sensor_type = match sensor {
+        TemperatureSensor::Label(label) => {
+            if components.iter().any(|c| c.label() == label) {
+                info!("Using manually configured temperature sensor: {label}");
+                return Some(label.clone());
+            }
             warn!(
-                "Configured temperature sensor '{}' not found, falling back to auto-detection for {:?}",
-                sensor, temperature_config.sensor_type
+                "Configured temperature sensor '{label}' not found, falling back to Cpu auto-detection"
             );
+            &TemperatureSensorType::Cpu
         }
-    }
+        TemperatureSensor::Type(sensor_type) => sensor_type,
+    };
 
-    let matches: &[SensorMatch] = match temperature_config.sensor_type {
+    let matches: &[SensorMatch] = match sensor_type {
         TemperatureSensorType::Cpu => &CPU_MATCHES,
         TemperatureSensorType::Gpu => &GPU_MATCHES,
         TemperatureSensorType::Acpi => &ACPI_MATCHES,
@@ -181,15 +179,9 @@ fn get_temperature_sensor_label(
     let sensor_label = find_sensor(components, matches);
 
     if let Some(ref label) = sensor_label {
-        info!(
-            "Auto-detected temperature sensor for {:?}: {}",
-            temperature_config.sensor_type, label
-        );
+        info!("Auto-detected temperature sensor for {sensor_type:?}: {label}");
     } else {
-        warn!(
-            "No temperature sensor found for {:?} type",
-            temperature_config.sensor_type
-        );
+        warn!("No temperature sensor found for {sensor_type:?} type");
     }
 
     sensor_label
@@ -254,7 +246,8 @@ fn get_system_info(
 
     let temperature_cel = {
         if cached_sensor_label.is_none() {
-            *cached_sensor_label = get_temperature_sensor_label(temperature_config, components);
+            *cached_sensor_label =
+                get_temperature_sensor_label(&temperature_config.sensor, components);
         }
 
         let mut reading = cached_sensor_label.as_ref().and_then(|label| {
@@ -268,7 +261,8 @@ fn get_system_info(
             if let Some(label) = (*cached_sensor_label).take() {
                 warn!("Cached sensor '{}' invalid; re-detecting", label);
             }
-            *cached_sensor_label = get_temperature_sensor_label(temperature_config, components);
+            *cached_sensor_label =
+                get_temperature_sensor_label(&temperature_config.sensor, components);
             reading = cached_sensor_label.as_ref().and_then(|label| {
                 components
                     .iter()
@@ -445,9 +439,7 @@ impl SystemInfo {
         );
 
         if let Some(label) = cached_sensor_label.as_ref() {
-            info!("Using temperature sensor: {}", label);
-        } else if let Some(sensor) = config.temperature.sensor.as_deref() {
-            info!("Using temperature sensor: {}", sensor);
+            info!("Using temperature sensor: {label}");
         }
 
         Self {

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -50,7 +50,7 @@ alert_threshold = 85
 [system_info.temperature]
 warn_threshold = 60
 alert_threshold = 80
-sensor = "acpitz temp1"
+sensor = "Cpu"             # type keyword or exact label, e.g. "acpitz temp1"
 
 [tempo]
 clock_format = "%a %d %b %R"

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -111,8 +111,17 @@ The Temperature indicator displays the current temperature from the configured s
 
 To enable this indicator, add `Temperature` to the `indicators` configuration.
 
-By default, the temperature sensor used is `acpitz temp1` (ACPI thermal zone).
-You can configure which sensor to use with the `sensor` option in the `[system_info.temperature]` section.
+By default, the temperature sensor is auto-detected based on the `sensor_type` option.
+The default sensor type is `Cpu`, which will look for `k10temp` (AMD) or `coretemp` (Intel) sensors.
+
+You can configure the sensor type with `sensor_type`:
+
+- `"Cpu"` (default) — CPU temperature (coretemp/k10temp)
+- `"Gpu"` — GPU temperature (amdgpu/nouveau)
+- `"Acpi"` — ACPI thermal zone (acpitz)
+- `"Nvme"` — NVMe SSD temperature
+
+Alternatively, you can specify a exact sensor name with the `sensor` option to override auto-detection:
 
 You can also change the display format using the `format` option:
 
@@ -226,6 +235,7 @@ format = "Percentage"
 [system_info.temperature]
 warn_threshold = 60
 alert_threshold = 80
-sensor = "acpitz temp1"
+sensor_type = "Cpu"  # "Cpu", "Gpu", "Acpi", or "Nvme"
+# sensor = "k10temp Tctl"  # optional: override with specific sensor
 format = "Celsius"
 ```

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -111,8 +111,17 @@ The Temperature indicator displays the current temperature from the configured s
 
 To enable this indicator, add `Temperature` to the `indicators` configuration.
 
-By default, the temperature sensor used is `acpitz temp1` (ACPI thermal zone).
-You can configure which sensor to use with the `sensor` option in the `[system_info.temperature]` section.
+By default, the temperature sensor is auto-detected based on the `sensor_type` option.
+The default sensor type is `Cpu`, which will look for `k10temp` (AMD) or `coretemp` (Intel) sensors.
+
+You can configure the sensor type with `sensor_type`:
+
+- `"Cpu"` (default) — CPU temperature (coretemp/k10temp)
+- `"Gpu"` — GPU temperature (amdgpu/nouveau)
+- `"Acpi"` — ACPI thermal zone (acpitz)
+- `"Nvme"` — NVMe SSD temperature
+
+Alternatively, you can specify an exact sensor name with the `sensor` option to override auto-detection:
 
 You can also change the display format using the `format` option:
 
@@ -226,6 +235,7 @@ format = "Percentage"
 [system_info.temperature]
 warn_threshold = 60
 alert_threshold = 80
-sensor = "acpitz temp1"
+sensor_type = "Cpu"  # "Cpu", "Gpu", "Acpi", or "Nvme"
+# sensor = "k10temp Tctl"  # optional: override with specific sensor
 format = "Celsius"
 ```

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -127,22 +127,24 @@ The Temperature indicator displays the current temperature from the configured s
 
 To enable this indicator, add `Temperature` to the `indicators` configuration.
 
-By default, the temperature sensor is auto-detected based on the `sensor_type` option.
-The default sensor type is `Cpu`, which will look for `k10temp` (AMD) or `coretemp` (Intel) sensors.
+The sensor is configured with a single `sensor` option that accepts either a sensor **type** keyword (auto-detected) or an **exact sensor label** (manual override).
 
-You can configure the sensor type with `sensor_type`:
+Sensor type keywords (auto-detected):
 
 - `"Cpu"` (default) — CPU temperature (coretemp/k10temp)
 - `"Gpu"` — GPU temperature (amdgpu/nouveau)
 - `"Acpi"` — ACPI thermal zone (acpitz)
 - `"Nvme"` — NVMe SSD temperature
 
-Alternatively, you can specify an exact sensor name with the `sensor` option to override auto-detection:
+Any other string is treated as an exact sensor label, overriding auto-detection (e.g. `sensor = "k10temp Tctl"`). If the configured label isn't found on your system, ashell falls back to `Cpu` auto-detection.
 
-You can also change the display format using the `format` option:
+```toml
+[system_info.temperature]
+sensor = "Cpu"              # auto-detect by type
+# sensor = "k10temp Tctl"   # or pin an exact sensor label
+```
 
-- `"Celsius"` (default) — shows temperature in Celsius (e.g., `52°C`)
-- `"Fahrenheit"` — shows temperature in Fahrenheit (e.g., `125°F`)
+The temperature **unit** (Celsius or Fahrenheit) follows your locale / unit system (the global `region` option), so there is no separate temperature format option.
 
 To see available sensors on your system, you can check the output of `sensors` command or
 look at the component labels returned by the sysinfo library.
@@ -182,7 +184,7 @@ Higher values reduce CPU usage at the cost of less frequent updates.
 Each indicator type supports a `format` option that controls how its value is displayed in the status bar and menu. The format is configured in the corresponding `[system_info.<type>]` section.
 
 :::info
-Warning and alert color thresholds remain active regardless of the display format. For temperature, thresholds are interpreted in the configured unit — so if you use `"Fahrenheit"`, set your thresholds in Fahrenheit (e.g., `warn_threshold = 140`).
+Warning and alert color thresholds remain active regardless of the display format. For temperature, thresholds are interpreted in the unit determined by your locale / unit system — so if your locale uses Fahrenheit, set your thresholds in Fahrenheit (e.g., `warn_threshold = 140`).
 :::
 
 #### Example
@@ -193,9 +195,6 @@ format = "Frequency"
 
 [system_info.memory]
 format = "Fraction"
-
-[system_info.temperature]
-format = "Fahrenheit"
 
 [system_info.disk]
 format = "Fraction"
@@ -252,7 +251,6 @@ format = "Percentage"
 [system_info.temperature]
 warn_threshold = 60
 alert_threshold = 80
-sensor_type = "Cpu"  # "Cpu", "Gpu", "Acpi", or "Nvme"
-# sensor = "k10temp Tctl"  # optional: override with specific sensor
-format = "Celsius"
+sensor = "Cpu"  # type keyword ("Cpu", "Gpu", "Acpi", "Nvme") or an exact sensor label
+# sensor = "k10temp Tctl"  # example: pin an exact sensor label
 ```


### PR DESCRIPTION

Yeah basically based on 
https://github.com/MalpenZibo/ashell/issues/664
https://github.com/MalpenZibo/ashell/issues/335

these 2 issues where people didn't had the default sensor or the temp was not was was expected, 
I thought I would just start with some heuristic auto-detect for sensors. 

Basically what I did is adding some `sensor_type` 
```
"Cpu" (default) — CPU temperature (coretemp/k10temp)
"Gpu" — GPU temperature (amdgpu/nouveau/xe)
"Acpi" — ACPI thermal zone (acpitz)
"Nvme" — NVMe SSD temperature
```
and in the config you can set nothing, which falls back to `Cpu`
or you set a `sensor_type` or you can override that with the name of the sensor (like we had it before). 

```
[system_info.temperature]
warn_threshold = 60
alert_threshold = 80
sensor_type = "Cpu"  # "Cpu", "Gpu", "Acpi", or "Nvme"
# sensor = "k10temp Tctl"  # optional: override with specific sensor
format = "Celsius"
```

No clue if you want to leave that with a capital letter or lowercase. 

For me it was something that some people were struggling with,
and this underlines the "install and run without a ton of configuring" slogan.

**What I am missing is the `sensor` output of a nvidia-open and closed-source driver.** 

I am not sure, for now if you have a sensor manually configured and it fails (lets say you swap the disk between systems) then it falls back to auto-detect ( we can discuss that, but a warning will be sent to log). 


I get something like (for now I put those into INFO)
```
INFO [ashell::modules::system_info] Auto-detected temperature sensor for Nvme: nvme Composite CT1000T705SSD3
INFO [ashell::modules::system_info] Using temperature sensor: nvme Composite CT1000T705SSD3

INFO [ashell::modules::system_info] Auto-detected temperature sensor for Gpu: amdgpu edge
INFO [ashell::modules::system_info] Using temperature sensor: amdgpu edge

INFO [ashell::modules::system_info] Auto-detected temperature sensor for Cpu: k10temp Tctl
INFO [ashell::modules::system_info] Using temperature sensor: k10temp Tctl

INFO [ashell::modules::system_info] Auto-detected temperature sensor for Acpi: acpitz temp1
INFO [ashell::modules::system_info] Using temperature sensor: acpitz temp1
```