### PR TITLE
fix: recover wgpu surface on NVIDIA + Niri (frozen bar)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,8 +1720,8 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell"
-version = "0.1.4"
-source = "git+https://github.com/MalpenZibo/iced_layershell?branch=fix%2Fsurface-recovery-and-igpu-default#155bd0073ee888927d4957a56c0f8d4d55bd7f00"
+version = "0.1.5"
+source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.5#6828748159092435edb684ef4f9206306513cc8e"
 dependencies = [
  "calloop",
  "calloop-wayland-source",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -808,7 +808,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2588,7 +2588,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3448,7 +3448,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3505,7 +3505,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3864,8 +3864,7 @@ dependencies = [
 [[package]]
 name = "softbuffer"
 version = "0.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
+source = "git+https://github.com/MalpenZibo/softbuffer?branch=wayland-argb#8791db4844f58036bd25934f8133e11c31877933"
 dependencies = [
  "bytemuck",
  "fastrand",
@@ -4051,7 +4050,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4990,7 +4989,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1720,8 +1720,8 @@ dependencies = [
 
 [[package]]
 name = "iced_layershell"
-version = "0.1.3"
-source = "git+https://github.com/MalpenZibo/iced_layershell?tag=v0.1.3#6fee0bf32c6a12343dc22c5f73c90cef235ab608"
+version = "0.1.4"
+source = "git+https://github.com/MalpenZibo/iced_layershell?branch=fix%2Fsurface-recovery-and-igpu-default#25f7a8c85610f77b6a8335c72c62c57221bc9792"
 dependencies = [
  "calloop",
  "calloop-wayland-source",
@@ -3152,7 +3152,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3448,7 +3448,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3505,7 +3505,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4045,7 +4045,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4983,7 +4983,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1721,7 +1721,7 @@ dependencies = [
 [[package]]
 name = "iced_layershell"
 version = "0.1.4"
-source = "git+https://github.com/MalpenZibo/iced_layershell?branch=fix%2Fsurface-recovery-and-igpu-default#25f7a8c85610f77b6a8335c72c62c57221bc9792"
+source = "git+https://github.com/MalpenZibo/iced_layershell?branch=fix%2Fsurface-recovery-and-igpu-default#155bd0073ee888927d4957a56c0f8d4d55bd7f00"
 dependencies = [
  "calloop",
  "calloop-wayland-source",
@@ -3152,7 +3152,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3448,7 +3448,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3505,7 +3505,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3868,7 +3868,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
+ "fastrand",
  "js-sys",
+ "memmap2",
  "ndk",
  "objc2",
  "objc2-core-foundation",
@@ -3877,8 +3879,12 @@ dependencies = [
  "objc2-quartz-core",
  "raw-window-handle",
  "redox_syscall",
+ "rustix",
  "tracing",
  "wasm-bindgen",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-sys",
  "web-sys",
  "windows-sys 0.61.2",
 ]
@@ -4045,7 +4051,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4772,6 +4778,7 @@ checksum = "1e6dbfc3ac5ef974c92a2235805cc0114033018ae1290a72e474aa8b28cbbdfd"
 dependencies = [
  "dlib",
  "log",
+ "once_cell",
  "pkg-config",
 ]
 
@@ -4983,7 +4990,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
-iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", branch = "fix/surface-recovery-and-igpu-default", features = [
+iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.5", features = [
   "tokio",
   "advanced",
   "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,13 @@ wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client"] }
 wayland-protocols-wlr = { version = "0.3", features = ["client"] }
 
+[patch.crates-io]
+# Patched softbuffer that uses wl_shm Argb8888 so the tiny-skia fallback
+# renderer honors alpha on Wayland (upstream hardcodes Xrgb8888, which
+# makes translucent backgrounds render opaque). Pinned to a branch off
+# v0.4.8 to match the release iced_tiny_skia 0.14 depends on.
+softbuffer = { git = "https://github.com/MalpenZibo/softbuffer", branch = "wayland-argb" }
+
 [build-dependencies]
 allsorts = "0.16"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_
   "tokio",
   "advanced",
   "wgpu",
+  "tiny-skia",
   "image",
   "svg",
   "canvas",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ depends = ["libwayland-client0", "libpipewire-0.3-0t64", "libpulse0"]
 depends = ["libwayland-client", "pipewire-libs", "pulseaudio-libs"]
 
 [dependencies]
-iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", tag = "v0.1.3", features = [
+iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_layershell", branch = "fix/surface-recovery-and-igpu-default", features = [
   "tokio",
   "advanced",
   "wgpu",


### PR DESCRIPTION
## Summary

- Bumps `iced_layershell` from `v0.1.3` to `v0.1.5`. The new release includes [iced_layershell#19](https://github.com/MalpenZibo/iced_layershell/pull/19): wgpu surface recovery on `SurfaceError::Outdated`/`Lost` (fixes the instantly-frozen bar on NVIDIA + Niri reported in #471), an iGPU-preferring default (`WGPU_POWER_PREF=low`) so hybrid laptops don't wake the dGPU for a status bar, and a `tiny-skia` feature that forwards `iced_renderer/wayland` to softbuffer.
- Enables iced_layershell's `tiny-skia` feature so `iced_renderer::Compositor` resolves to `fallback::Compositor<iced_wgpu, iced_tiny_skia>`. wgpu stays Primary; on setups where wgpu can't initialize at all (e.g. NVIDIA + Niri + `WGPU_BACKEND=gl`, where `wgpu-hal` rejects the only EGL config NVIDIA offers), the fallback drops through to CPU rendering instead of bringing the bar down with `GraphicsAdapterNotFound`. This mirrors iced's own default renderer layout.
- Adds a `[patch.crates-io]` override on `softbuffer` pointing at a one-commit branch off v0.4.8 that swaps `wl_shm::Format::Xrgb8888` for `Argb8888`, so the tiny-skia fallback honours alpha. Upstream softbuffer hardcodes Xrgb8888 with no format negotiation; the Wayland spec guarantees Argb8888 availability, byte layout is identical, and iced_tiny_skia already writes premultiplied alpha. Tracked to be dropped when upstream supports format selection.

Fixes #471.

## Test plan

- [x] `make check` (fmt + cargo check + clippy `-D warnings`) passes
- [x] Verify on NVIDIA + Niri that the bar no longer freezes on startup and stays responsive across surface reconfigurations (Vulkan path via iced_layershell v0.1.5)
- [ ] Verify that `WGPU_BACKEND=gl` no longer crashes the bar; expect it to launch via the tiny-skia CPU fallback with transparency preserved
- [x] `ICED_BACKEND=tiny-skia ./target/release/ashell` on a healthy setup to smoke-test the fallback path end-to-end (forces CPU rendering; theme transparency should still render correctly thanks to the softbuffer patch)
- [x] Sanity check on Hyprland / Niri + Mesa that nothing regresses — wgpu Primary wins on healthy setups; binary size grows modestly due to iced_tiny_skia + softbuffer pull-in