### PR TITLE
refactor(theme): access AshellTheme via thread_local global

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -208,7 +208,7 @@ impl App {
     }
 
     pub fn theme(&self) -> Theme {
-        use_theme(|t| t.get_theme().clone())
+        use_theme(|t| t.iced_theme.clone())
     }
 
     pub fn scale_factor(&self) -> f64 {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,6 @@
 use crate::{
     HEIGHT,
-    components::menu::MenuType,
-    components::{ButtonUIRef, Centerbox},
+    components::{ButtonUIRef, Centerbox, menu::MenuType},
     config::{self, AppearanceStyle, Config, Modules, Position},
     get_log_spec,
     ipc::IpcCommand,
@@ -24,7 +23,7 @@ use crate::{
     osd::{self, Osd, OsdKind},
     outputs::{HasOutput, Outputs},
     services::ReadOnlyService,
-    theme::{AshellTheme, backdrop_color, darken_color},
+    theme::{AshellTheme, backdrop_color, darken_color, init_theme, use_theme},
 };
 use flexi_logger::LoggerHandle;
 use iced::{
@@ -50,7 +49,6 @@ pub struct GeneralConfig {
 
 pub struct App {
     config_path: PathBuf,
-    pub theme: AshellTheme,
     logger: LoggerHandle,
     pub general_config: GeneralConfig,
     pub outputs: Outputs,
@@ -119,10 +117,11 @@ impl App {
 
             let notifications = Notifications::new(config.notifications);
 
+            init_theme(AshellTheme::new(config.position, &config.appearance));
+
             (
                 App {
                     config_path,
-                    theme: AshellTheme::new(config.position, &config.appearance),
                     logger,
                     general_config: GeneralConfig {
                         outputs: config.outputs,
@@ -159,7 +158,7 @@ impl App {
             layer: config.layer,
             enable_esc_key: config.enable_esc_key,
         };
-        self.theme = AshellTheme::new(config.position, &config.appearance);
+        init_theme(AshellTheme::new(config.position, &config.appearance));
         let custom = config
             .custom_modules
             .into_iter()
@@ -209,11 +208,11 @@ impl App {
     }
 
     pub fn theme(&self) -> Theme {
-        self.theme.get_theme().clone()
+        use_theme(|t| t.get_theme().clone())
     }
 
     pub fn scale_factor(&self) -> f64 {
-        self.theme.scale_factor
+        use_theme(|t| t.scale_factor)
     }
 
     /// Build OSD display info (kind, normalised value, muted) for the given
@@ -274,10 +273,12 @@ impl App {
                     "Current outputs: {:?}, new outputs: {:?}",
                     self.general_config.outputs, config.outputs
                 );
+                let (bar_position, bar_style, scale_factor) =
+                    use_theme(|t| (t.bar_position, t.bar_style, t.scale_factor));
                 if self.general_config.outputs != config.outputs
-                    || self.theme.bar_position != config.position
-                    || self.theme.bar_style != config.appearance.style
-                    || self.theme.scale_factor != config.appearance.scale_factor
+                    || bar_position != config.position
+                    || bar_style != config.appearance.style
+                    || scale_factor != config.appearance.scale_factor
                     || self.general_config.layer != config.layer
                 {
                     warn!("Outputs changed, syncing");
@@ -427,24 +428,28 @@ impl App {
                         self.outputs.set_output_logical_height(info.id, h as u32);
                     }
 
+                    let (bar_style, bar_position, scale_factor) =
+                        use_theme(|t| (t.bar_style, t.bar_position, t.scale_factor));
                     self.outputs.add(
-                        self.theme.bar_style,
+                        bar_style,
                         &self.general_config.outputs,
-                        self.theme.bar_position,
+                        bar_position,
                         self.general_config.layer,
                         name,
                         info.id,
-                        self.theme.scale_factor,
+                        scale_factor,
                     )
                 }
                 OutputEvent::Removed(output_id) => {
                     info!("Output destroyed");
+                    let (bar_style, bar_position, scale_factor) =
+                        use_theme(|t| (t.bar_style, t.bar_position, t.scale_factor));
                     self.outputs.remove(
-                        self.theme.bar_style,
-                        self.theme.bar_position,
+                        bar_style,
+                        bar_position,
                         self.general_config.layer,
                         output_id,
-                        self.theme.scale_factor,
+                        scale_factor,
                     )
                 }
                 OutputEvent::InfoChanged(_) => Task::none(),
@@ -461,13 +466,17 @@ impl App {
                     Task::none()
                 }
             }
-            Message::ResumeFromSleep => self.outputs.sync(
-                self.theme.bar_style,
-                &self.general_config.outputs,
-                self.theme.bar_position,
-                self.general_config.layer,
-                self.theme.scale_factor,
-            ),
+            Message::ResumeFromSleep => {
+                let (bar_style, bar_position, scale_factor) =
+                    use_theme(|t| (t.bar_style, t.bar_position, t.scale_factor));
+                self.outputs.sync(
+                    bar_style,
+                    &self.general_config.outputs,
+                    bar_position,
+                    self.general_config.layer,
+                    scale_factor,
+                )
+            }
             Message::Notifications(message) => match self.notifications.update(message) {
                 modules::notifications::Action::None => Task::none(),
                 modules::notifications::Action::Task(task) => task.map(Message::Notifications),
@@ -528,13 +537,14 @@ impl App {
             Message::None => Task::none(),
             Message::ToggleVisibility => {
                 self.visible = !self.visible;
+                let (bar_style, scale_factor) = use_theme(|t| (t.bar_style, t.scale_factor));
                 let height = if self.visible {
                     (crate::HEIGHT
-                        - match self.theme.bar_style {
+                        - match bar_style {
                             AppearanceStyle::Solid | AppearanceStyle::Gradient => 8.,
                             AppearanceStyle::Islands => 0.,
                         })
-                        * self.theme.scale_factor
+                        * scale_factor
                 } else {
                     0.0
                 };
@@ -560,37 +570,39 @@ impl App {
                     return Row::new().into();
                 }
 
-                let [left, center, right] = self.modules_section(id, &self.theme);
+                let [left, center, right] = self.modules_section(id);
 
+                let (space, bar_style, bar_position, opacity, menu) =
+                    use_theme(|t| (t.space, t.bar_style, t.bar_position, t.opacity, t.menu));
                 let centerbox = Centerbox::new([left, center, right])
-                    .spacing(self.theme.space.xxs)
+                    .spacing(space.xxs)
                     .width(Length::Fill)
                     .align_items(Alignment::Center)
-                    .height(if self.theme.bar_style == AppearanceStyle::Islands {
+                    .height(if bar_style == AppearanceStyle::Islands {
                         HEIGHT
                     } else {
-                        HEIGHT - self.theme.space.xs as f64
+                        HEIGHT - space.xs as f64
                     } as f32)
-                    .padding(if self.theme.bar_style == AppearanceStyle::Islands {
-                        [self.theme.space.xxs, self.theme.space.xxs]
+                    .padding(if bar_style == AppearanceStyle::Islands {
+                        [space.xxs, space.xxs]
                     } else {
                         [0.0, 0.0]
                     });
 
-                let status_bar = container(centerbox).style(|t: &Theme| container::Style {
-                    background: match self.theme.bar_style {
+                let menu_is_open = self.outputs.menu_is_open();
+                let status_bar = container(centerbox).style(move |t: &Theme| container::Style {
+                    background: match bar_style {
                         AppearanceStyle::Gradient => Some({
-                            let start_color =
-                                t.palette().background.scale_alpha(self.theme.opacity);
+                            let start_color = t.palette().background.scale_alpha(opacity);
 
-                            let start_color = if self.outputs.menu_is_open() {
-                                darken_color(start_color, self.theme.menu.backdrop)
+                            let start_color = if menu_is_open {
+                                darken_color(start_color, menu.backdrop)
                             } else {
                                 start_color
                             };
 
-                            let end_color = if self.outputs.menu_is_open() {
-                                backdrop_color(self.theme.menu.backdrop)
+                            let end_color = if menu_is_open {
+                                backdrop_color(menu.backdrop)
                             } else {
                                 Color::TRANSPARENT
                             };
@@ -599,14 +611,14 @@ impl App {
                                 Linear::new(Radians(PI))
                                     .add_stop(
                                         0.0,
-                                        match self.theme.bar_position {
+                                        match bar_position {
                                             Position::Top => start_color,
                                             Position::Bottom => end_color,
                                         },
                                     )
                                     .add_stop(
                                         1.0,
-                                        match self.theme.bar_position {
+                                        match bar_position {
                                             Position::Top => end_color,
                                             Position::Bottom => start_color,
                                         },
@@ -615,17 +627,17 @@ impl App {
                             .into()
                         }),
                         AppearanceStyle::Solid => Some({
-                            let bg = t.palette().background.scale_alpha(self.theme.opacity);
-                            if self.outputs.menu_is_open() {
-                                darken_color(bg, self.theme.menu.backdrop)
+                            let bg = t.palette().background.scale_alpha(opacity);
+                            if menu_is_open {
+                                darken_color(bg, menu.backdrop)
                             } else {
                                 bg
                             }
                             .into()
                         }),
                         AppearanceStyle::Islands => {
-                            if self.outputs.menu_is_open() {
-                                Some(backdrop_color(self.theme.menu.backdrop).into())
+                            if menu_is_open {
+                                Some(backdrop_color(menu.backdrop).into())
                             } else {
                                 None
                             }
@@ -649,59 +661,46 @@ impl App {
                         if let Some(updates) = self.updates.as_ref() {
                             self.menu_wrapper(
                                 id,
-                                updates.menu_view(id, &self.theme).map(Message::Updates),
+                                updates.menu_view(id).map(Message::Updates),
                                 ui_ref,
                             )
                         } else {
                             Row::new().into()
                         }
                     }
-                    MenuType::Tray(name) => self.menu_wrapper(
-                        id,
-                        self.tray.menu_view(&self.theme, name).map(Message::Tray),
-                        ui_ref,
-                    ),
+                    MenuType::Tray(name) => {
+                        self.menu_wrapper(id, self.tray.menu_view(name).map(Message::Tray), ui_ref)
+                    }
                     MenuType::Notifications => self.menu_wrapper(
                         id,
-                        self.notifications
-                            .menu_view(&self.theme)
-                            .map(Message::Notifications),
+                        self.notifications.menu_view().map(Message::Notifications),
                         ui_ref,
                     ),
                     MenuType::Settings => self.menu_wrapper(
                         id,
                         self.settings
-                            .menu_view(id, &self.theme, self.theme.bar_position)
+                            .menu_view(id, use_theme(|t| t.bar_position))
                             .map(Message::Settings),
                         ui_ref,
                     ),
                     MenuType::MediaPlayer => self.menu_wrapper(
                         id,
-                        self.media_player
-                            .menu_view(&self.theme)
-                            .map(Message::MediaPlayer),
+                        self.media_player.menu_view().map(Message::MediaPlayer),
                         ui_ref,
                     ),
                     MenuType::SystemInfo => self.menu_wrapper(
                         id,
-                        self.system_info
-                            .menu_view(&self.theme)
-                            .map(Message::SystemInfo),
+                        self.system_info.menu_view().map(Message::SystemInfo),
                         ui_ref,
                     ),
-                    MenuType::Tempo => self.menu_wrapper(
-                        id,
-                        self.tempo.menu_view(&self.theme).map(Message::Tempo),
-                        ui_ref,
-                    ),
+                    MenuType::Tempo => {
+                        self.menu_wrapper(id, self.tempo.menu_view().map(Message::Tempo), ui_ref)
+                    }
                 }
             }
             Some(HasOutput::Menu(None)) => Row::new().into(),
-            Some(HasOutput::Toast) => self
-                .notifications
-                .toast_view(&self.theme)
-                .map(Message::Notifications),
-            Some(HasOutput::Osd) => self.osd.view(&self.theme).map(Message::Osd),
+            Some(HasOutput::Toast) => self.notifications.toast_view().map(Message::Notifications),
+            Some(HasOutput::Osd) => self.osd.view().map(Message::Osd),
             None => Row::new().into(),
         }
     }

--- a/src/components/button.rs
+++ b/src/components/button.rs
@@ -1,4 +1,4 @@
-use crate::{components::icons::IconKind, theme::AshellTheme};
+use crate::{components::icons::IconKind, theme::use_theme};
 use iced::{
     Alignment, Element, Length,
     widget::{button as button_fn, container, row, text},
@@ -63,7 +63,6 @@ pub(crate) enum OnPress<'a, Message> {
 }
 
 pub struct StyledButton<'a, Message> {
-    theme: &'a AshellTheme,
     label: Element<'a, Message>,
     icon: Option<(IconKind, IconPosition)>,
     kind: ButtonKind,
@@ -123,12 +122,18 @@ impl<'a, Message: 'static + Clone> StyledButton<'a, Message> {
 
 impl<'a, Message: 'static + Clone> From<StyledButton<'a, Message>> for Element<'a, Message> {
     fn from(value: StyledButton<'a, Message>) -> Self {
-        let theme = value.theme;
+        let (space, font_size, button_style) = use_theme(|theme| {
+            (
+                theme.space,
+                theme.font_size,
+                theme.button_style(value.kind, value.hierarchy),
+            )
+        });
 
         let (padding, icon_size) = match value.size {
-            ButtonSize::Small => ([theme.space.xxs, theme.space.sm], theme.font_size.sm),
-            ButtonSize::Medium => ([theme.space.xs, theme.space.md], theme.font_size.md),
-            ButtonSize::Large => ([theme.space.sm, theme.space.xl], theme.font_size.lg),
+            ButtonSize::Small => ([space.xxs, space.sm], font_size.sm),
+            ButtonSize::Medium => ([space.xs, space.md], font_size.md),
+            ButtonSize::Large => ([space.sm, space.xl], font_size.lg),
         };
 
         let (icon_element, icon_position) = match value.icon {
@@ -139,13 +144,13 @@ impl<'a, Message: 'static + Clone> From<StyledButton<'a, Message>> for Element<'
         let content = match (icon_element, icon_position) {
             (Some(icon_el), Some(IconPosition::Before)) => container(
                 row![icon_el, value.label]
-                    .spacing(theme.space.xs)
+                    .spacing(space.xs)
                     .align_y(Alignment::Center),
             )
             .into(),
             (Some(icon_el), Some(IconPosition::After)) => container(
                 row![container(value.label).width(Length::Fill), icon_el,]
-                    .spacing(theme.space.xs)
+                    .spacing(space.xs)
                     .align_y(Alignment::Center),
             )
             .into(),
@@ -154,7 +159,7 @@ impl<'a, Message: 'static + Clone> From<StyledButton<'a, Message>> for Element<'
 
         let mut btn = button_fn(content)
             .padding(padding)
-            .style(theme.button_style(value.kind, value.hierarchy))
+            .style(button_style)
             .height(value.height.unwrap_or(Length::Shrink));
 
         if let Some(width) = value.width {
@@ -172,11 +177,9 @@ impl<'a, Message: 'static + Clone> From<StyledButton<'a, Message>> for Element<'
 }
 
 pub fn styled_button<'a, Message: 'static + Clone>(
-    theme: &'a AshellTheme,
     content: impl IntoButtonContent<'a, Message>,
 ) -> StyledButton<'a, Message> {
     StyledButton {
-        theme,
         label: content.into_content(),
         icon: None,
         kind: ButtonKind::default(),

--- a/src/components/format_indicator.rs
+++ b/src/components/format_indicator.rs
@@ -46,14 +46,14 @@ impl<'a, Msg: 'static + Clone> FormatIndicator<'a, Msg> {
 
 impl<'a, Msg: 'static + Clone> From<FormatIndicator<'a, Msg>> for Element<'a, Msg> {
     fn from(fi: FormatIndicator<'a, Msg>) -> Self {
-        let space_xxs = use_theme(|theme| theme.space.xxs);
+        let space = use_theme(|theme| theme.space);
 
         let content = match fi.format {
             SettingsFormat::Icon => fi.icon.to_text().into(),
             SettingsFormat::Percentage | SettingsFormat::Time => fi.label_element,
             SettingsFormat::IconAndPercentage | SettingsFormat::IconAndTime => {
                 row![fi.icon.to_text(), fi.label_element]
-                    .spacing(space_xxs)
+                    .spacing(space.xxs)
                     .align_y(Alignment::Center)
                     .into()
             }

--- a/src/components/format_indicator.rs
+++ b/src/components/format_indicator.rs
@@ -1,5 +1,5 @@
 use crate::{
-    components::icons::IconKind, config::SettingsFormat, theme::AshellTheme, utils::IndicatorState,
+    components::icons::IconKind, config::SettingsFormat, theme::use_theme, utils::IndicatorState,
 };
 use iced::{
     Alignment, Element, Theme,
@@ -8,7 +8,6 @@ use iced::{
 };
 
 pub struct FormatIndicator<'a, Msg> {
-    theme: &'a AshellTheme,
     format: SettingsFormat,
     icon: IconKind,
     label_element: Element<'a, Msg>,
@@ -18,14 +17,12 @@ pub struct FormatIndicator<'a, Msg> {
 }
 
 pub fn format_indicator<'a, Msg: 'static + Clone>(
-    theme: &'a AshellTheme,
     format: SettingsFormat,
     icon: impl Into<IconKind>,
     label_element: Element<'a, Msg>,
     state: IndicatorState,
 ) -> FormatIndicator<'a, Msg> {
     FormatIndicator {
-        theme,
         format,
         icon: icon.into(),
         label_element,
@@ -49,22 +46,25 @@ impl<'a, Msg: 'static + Clone> FormatIndicator<'a, Msg> {
 
 impl<'a, Msg: 'static + Clone> From<FormatIndicator<'a, Msg>> for Element<'a, Msg> {
     fn from(fi: FormatIndicator<'a, Msg>) -> Self {
+        let space_xxs = use_theme(|theme| theme.space.xxs);
+
         let content = match fi.format {
             SettingsFormat::Icon => fi.icon.to_text().into(),
             SettingsFormat::Percentage | SettingsFormat::Time => fi.label_element,
             SettingsFormat::IconAndPercentage | SettingsFormat::IconAndTime => {
                 row![fi.icon.to_text(), fi.label_element]
-                    .spacing(fi.theme.space.xxs)
+                    .spacing(space_xxs)
                     .align_y(Alignment::Center)
                     .into()
             }
         };
 
-        let colored = match fi.state {
+        let state = fi.state;
+        let colored = match state {
             IndicatorState::Normal => content,
             _ => container(content)
                 .style(move |theme: &Theme| container::Style {
-                    text_color: Some(match fi.state {
+                    text_color: Some(match state {
                         IndicatorState::Success => theme.palette().success,
                         IndicatorState::Warning => theme.palette().warning,
                         IndicatorState::Danger => theme.palette().danger,

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -1,6 +1,6 @@
 use crate::{
     components::button::{ButtonHierarchy, ButtonKind, ButtonSize, OnPress},
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Color, Element, Font, Length, Theme,
@@ -368,7 +368,6 @@ pub fn icon_mono<'a>(icon: impl Icon) -> Text<'a> {
 pub type StyleFn<'a, Theme> = Box<dyn for<'b> Fn(&'b Theme, Status) -> Style + 'a>;
 
 pub struct IconButton<'a, I: Icon, Message> {
-    theme: &'a AshellTheme,
     icon: I,
     on_press: Option<OnPress<'a, Message>>,
     kind: ButtonKind,
@@ -433,17 +432,18 @@ impl<'a, I: Icon, Message: 'static + Clone> From<IconButton<'a, I, Message>>
 {
     #[inline]
     fn from(value: IconButton<'a, I, Message>) -> Self {
+        let (theme_font_size, radius) = use_theme(|theme| (theme.font_size, theme.radius.xl));
+
         let (container_size, font_size) = match value.size {
-            ButtonSize::Small => (24., value.theme.font_size.xs),
-            ButtonSize::Medium => (32., value.theme.font_size.xs),
-            ButtonSize::Large => (38., value.theme.font_size.sm),
+            ButtonSize::Small => (24., theme_font_size.xs),
+            ButtonSize::Medium => (32., theme_font_size.xs),
+            ButtonSize::Large => (38., theme_font_size.sm),
         };
 
-        let radius = value.theme.radius.xl;
         let style: StyleFn<'a, Theme> = match value.style_override {
             Some(s) => s,
             None => {
-                let base = value.theme.button_style(value.kind, value.hierarchy);
+                let base = use_theme(|theme| theme.button_style(value.kind, value.hierarchy));
                 Box::new(move |theme: &Theme, status: Status| {
                     let mut s = base(theme, status);
                     s.border.radius = radius.into();
@@ -476,12 +476,10 @@ impl<'a, I: Icon, Message: 'static + Clone> From<IconButton<'a, I, Message>>
 }
 
 pub fn icon_button<'a, Message: 'static + Clone>(
-    theme: &'a AshellTheme,
     icon: impl Into<IconKind>,
 ) -> IconButton<'a, IconKind, Message> {
     let icon = icon.into();
     IconButton {
-        theme,
         icon,
         on_press: None,
         kind: ButtonKind::Solid,

--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -432,7 +432,7 @@ impl<'a, I: Icon, Message: 'static + Clone> From<IconButton<'a, I, Message>>
 {
     #[inline]
     fn from(value: IconButton<'a, I, Message>) -> Self {
-        let (theme_font_size, radius) = use_theme(|theme| (theme.font_size, theme.radius.xl));
+        let (theme_font_size, radius) = use_theme(|theme| (theme.font_size, theme.radius));
 
         let (container_size, font_size) = match value.size {
             ButtonSize::Small => (24., theme_font_size.xs),
@@ -446,7 +446,7 @@ impl<'a, I: Icon, Message: 'static + Clone> From<IconButton<'a, I, Message>>
                 let base = use_theme(|theme| theme.button_style(value.kind, value.hierarchy));
                 Box::new(move |theme: &Theme, status: Status| {
                     let mut s = base(theme, status);
-                    s.border.radius = radius.into();
+                    s.border.radius = radius.xl.into();
                     s
                 })
             }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -1,7 +1,7 @@
 use crate::app::{self, App};
 use crate::components::{self, ButtonUIRef};
 use crate::config::{AppearanceStyle, Position};
-use crate::theme::backdrop_color;
+use crate::theme::{backdrop_color, use_theme};
 use iced::alignment::Vertical;
 use iced::widget::container::Style;
 use iced::{
@@ -167,27 +167,33 @@ impl App {
         content: Element<'a, app::Message>,
         button_ui_ref: ButtonUIRef,
     ) -> Element<'a, app::Message> {
+        let (space_md, menu_opacity, radius_lg, bar_style, bar_position, menu_backdrop) =
+            use_theme(|t| {
+                (
+                    t.space.md,
+                    t.menu.opacity,
+                    t.radius.lg,
+                    t.bar_style,
+                    t.bar_position,
+                    t.menu.backdrop,
+                )
+            });
+
         components::MenuWrapper::new(
             button_ui_ref.position.x,
             container(content)
-                .padding(self.theme.space.md)
+                .padding(space_md)
                 .style(move |theme: &Theme| Style {
-                    background: Some(
-                        theme
-                            .palette()
-                            .background
-                            .scale_alpha(self.theme.menu.opacity)
-                            .into(),
-                    ),
+                    background: Some(theme.palette().background.scale_alpha(menu_opacity).into()),
                     border: Border {
                         color: theme
                             .extended_palette()
                             .background
                             .weakest
                             .color
-                            .scale_alpha(self.theme.menu.opacity),
+                            .scale_alpha(menu_opacity),
                         width: 1.,
-                        radius: self.theme.radius.lg.into(),
+                        radius: radius_lg.into(),
                     },
                     ..Default::default()
                 })
@@ -195,28 +201,28 @@ impl App {
                 .into(),
         )
         .padding({
-            let v_padding = match self.theme.bar_style {
+            let v_padding = match bar_style {
                 AppearanceStyle::Solid | AppearanceStyle::Gradient => 2,
                 AppearanceStyle::Islands => 0,
             };
 
             Padding::new(0.)
-                .top(if self.theme.bar_position == Position::Top {
+                .top(if bar_position == Position::Top {
                     v_padding
                 } else {
                     0
                 })
-                .bottom(if self.theme.bar_position == Position::Bottom {
+                .bottom(if bar_position == Position::Bottom {
                     v_padding
                 } else {
                     0
                 })
         })
-        .align_y(match self.theme.bar_position {
+        .align_y(match bar_position {
             Position::Top => Vertical::Top,
             Position::Bottom => Vertical::Bottom,
         })
-        .backdrop(backdrop_color(self.theme.menu.backdrop))
+        .backdrop(backdrop_color(menu_backdrop))
         .on_click_outside(app::Message::CloseMenu(id))
         .into()
     }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -167,12 +167,12 @@ impl App {
         content: Element<'a, app::Message>,
         button_ui_ref: ButtonUIRef,
     ) -> Element<'a, app::Message> {
-        let (space_md, menu_opacity, radius_lg, bar_style, bar_position, menu_backdrop) =
+        let (space, menu_opacity, radius, bar_style, bar_position, menu_backdrop) =
             use_theme(|t| {
                 (
-                    t.space.md,
+                    t.space,
                     t.menu.opacity,
-                    t.radius.lg,
+                    t.radius,
                     t.bar_style,
                     t.bar_position,
                     t.menu.backdrop,
@@ -182,7 +182,7 @@ impl App {
         components::MenuWrapper::new(
             button_ui_ref.position.x,
             container(content)
-                .padding(space_md)
+                .padding(space.md)
                 .style(move |theme: &Theme| Style {
                     background: Some(theme.palette().background.scale_alpha(menu_opacity).into()),
                     border: Border {
@@ -193,7 +193,7 @@ impl App {
                             .color
                             .scale_alpha(menu_opacity),
                         width: 1.,
-                        radius: radius_lg.into(),
+                        radius: radius.lg.into(),
                     },
                     ..Default::default()
                 })

--- a/src/components/module_group.rs
+++ b/src/components/module_group.rs
@@ -1,28 +1,22 @@
-use crate::{config::AppearanceStyle, theme::AshellTheme};
+use crate::{config::AppearanceStyle, theme::use_theme};
 use iced::{Border, Color, Element, widget::container};
 
 /// Wraps content with the appropriate bar style container.
 ///
 /// - `Solid | Gradient` → pass through as-is
 /// - `Islands` → wrap in a container with background color + rounded border
-pub fn module_group<'a, Msg: 'static>(
-    theme: &'a AshellTheme,
-    content: Element<'a, Msg>,
-) -> Element<'a, Msg> {
-    match theme.bar_style {
+pub fn module_group<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<'a, Msg> {
+    let (bar_style, opacity, radius_lg) =
+        use_theme(|theme| (theme.bar_style, theme.opacity, theme.radius.lg));
+
+    match bar_style {
         AppearanceStyle::Solid | AppearanceStyle::Gradient => content,
         AppearanceStyle::Islands => container(content)
             .style(move |iced_theme: &iced::Theme| container::Style {
-                background: Some(
-                    iced_theme
-                        .palette()
-                        .background
-                        .scale_alpha(theme.opacity)
-                        .into(),
-                ),
+                background: Some(iced_theme.palette().background.scale_alpha(opacity).into()),
                 border: Border {
                     width: 0.0,
-                    radius: theme.radius.lg.into(),
+                    radius: radius_lg.into(),
                     color: Color::TRANSPARENT,
                 },
                 ..container::Style::default()

--- a/src/components/module_group.rs
+++ b/src/components/module_group.rs
@@ -6,8 +6,8 @@ use iced::{Border, Color, Element, widget::container};
 /// - `Solid | Gradient` → pass through as-is
 /// - `Islands` → wrap in a container with background color + rounded border
 pub fn module_group<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<'a, Msg> {
-    let (bar_style, opacity, radius_lg) =
-        use_theme(|theme| (theme.bar_style, theme.opacity, theme.radius.lg));
+    let (bar_style, opacity, radius) =
+        use_theme(|theme| (theme.bar_style, theme.opacity, theme.radius));
 
     match bar_style {
         AppearanceStyle::Solid | AppearanceStyle::Gradient => content,
@@ -16,7 +16,7 @@ pub fn module_group<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<'a, 
                 background: Some(iced_theme.palette().background.scale_alpha(opacity).into()),
                 border: Border {
                     width: 0.0,
-                    radius: radius_lg.into(),
+                    radius: radius.lg.into(),
                     color: Color::TRANSPARENT,
                 },
                 ..container::Style::default()

--- a/src/components/module_item.rs
+++ b/src/components/module_item.rs
@@ -56,8 +56,8 @@ impl<'a, Msg: 'static + Clone> ModuleItem<'a, Msg> {
 
 impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
     fn from(item: ModuleItem<'a, Msg>) -> Self {
-        let (space_xs, module_button_style) =
-            use_theme(|theme| (theme.space.xs, theme.module_button_style()));
+        let (space, module_button_style) =
+            use_theme(|theme| (theme.space, theme.module_button_style()));
 
         let has_action = item.on_press.is_some() || item.on_press_with_position.is_some();
 
@@ -68,7 +68,7 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
                     .height(Length::Fill)
                     .clip(true),
             )
-            .padding([2.0, space_xs])
+            .padding([2.0, space.xs])
             .height(Length::Fill)
             .style(module_button_style);
 
@@ -91,7 +91,7 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
             button.into()
         } else {
             container(item.content)
-                .padding([2.0, space_xs])
+                .padding([2.0, space.xs])
                 .height(Length::Fill)
                 .align_y(Alignment::Center)
                 .clip(true)

--- a/src/components/module_item.rs
+++ b/src/components/module_item.rs
@@ -1,4 +1,4 @@
-use crate::{components::position_button, theme::AshellTheme};
+use crate::{components::position_button, theme::use_theme};
 use iced::{Alignment, Element, Length, widget::container};
 
 use super::ButtonUIRef;
@@ -8,7 +8,6 @@ use super::ButtonUIRef;
 ///
 /// When no press handler is set, renders as a plain container.
 pub struct ModuleItem<'a, Msg> {
-    theme: &'a AshellTheme,
     content: Element<'a, Msg>,
     on_press: Option<Msg>,
     on_press_with_position: Option<Box<dyn Fn(ButtonUIRef) -> Msg + 'a>>,
@@ -17,12 +16,8 @@ pub struct ModuleItem<'a, Msg> {
     on_scroll_down: Option<Msg>,
 }
 
-pub fn module_item<'a, Msg: 'static + Clone>(
-    theme: &'a AshellTheme,
-    content: Element<'a, Msg>,
-) -> ModuleItem<'a, Msg> {
+pub fn module_item<'a, Msg: 'static + Clone>(content: Element<'a, Msg>) -> ModuleItem<'a, Msg> {
     ModuleItem {
-        theme,
         content,
         on_press: None,
         on_press_with_position: None,
@@ -61,6 +56,9 @@ impl<'a, Msg: 'static + Clone> ModuleItem<'a, Msg> {
 
 impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
     fn from(item: ModuleItem<'a, Msg>) -> Self {
+        let (space_xs, module_button_style) =
+            use_theme(|theme| (theme.space.xs, theme.module_button_style()));
+
         let has_action = item.on_press.is_some() || item.on_press_with_position.is_some();
 
         if has_action {
@@ -70,9 +68,9 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
                     .height(Length::Fill)
                     .clip(true),
             )
-            .padding([2.0, item.theme.space.xs])
+            .padding([2.0, space_xs])
             .height(Length::Fill)
-            .style(item.theme.module_button_style());
+            .style(module_button_style);
 
             if let Some(handler) = item.on_press_with_position {
                 button = button.on_press_with_position(handler);
@@ -93,7 +91,7 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
             button.into()
         } else {
             container(item.content)
-                .padding([2.0, item.theme.space.xs])
+                .padding([2.0, space_xs])
                 .height(Length::Fill)
                 .align_y(Alignment::Center)
                 .clip(true)

--- a/src/components/password_dialog.rs
+++ b/src/components/password_dialog.rs
@@ -1,7 +1,7 @@
 use super::icons::{StaticIcon, icon, icon_button};
 use crate::{
     components::{ButtonHierarchy, ButtonKind, styled_button},
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Alignment, Element, Length, SurfaceId,
@@ -18,12 +18,14 @@ pub enum Message {
 
 pub fn view<'a>(
     id: SurfaceId,
-    theme: &'a AshellTheme,
     wifi_ssid: &str,
     current_password: &str,
     show_password: bool,
     warning_only: bool,
 ) -> Element<'a, Message> {
+    let (space, font_size, text_input_style) =
+        use_theme(|theme| (theme.space, theme.font_size, theme.text_input_style()));
+
     let title = if warning_only {
         "Open network"
     } else {
@@ -47,10 +49,10 @@ Do you want to connect anyway?",
             } else {
                 StaticIcon::WifiLock4
             })
-            .size(theme.font_size.xxl),
-            text(title).size(theme.font_size.xl),
+            .size(font_size.xxl),
+            text(title).size(font_size.xl),
         )
-        .spacing(theme.space.md)
+        .spacing(space.md)
         .align_y(Alignment::Center),
         text(description),
     )
@@ -59,34 +61,31 @@ Do you want to connect anyway?",
             row!(
                 text_input("", current_password)
                     .secure(!show_password)
-                    .size(theme.font_size.md)
-                    .padding([theme.space.xs, theme.space.md])
-                    .style(theme.text_input_style())
+                    .size(font_size.md)
+                    .padding([space.xs, space.md])
+                    .style(text_input_style)
                     .on_input(Message::PasswordChanged)
                     .on_submit(Message::DialogConfirmed(id))
                     .width(Length::Fill),
-                icon_button(
-                    theme,
-                    if show_password {
-                        StaticIcon::EyeOpened
-                    } else {
-                        StaticIcon::EyeClosed
-                    },
-                )
+                icon_button(if show_password {
+                    StaticIcon::EyeOpened
+                } else {
+                    StaticIcon::EyeClosed
+                })
                 .on_press(Message::TogglePasswordVisibility),
             )
-            .spacing(theme.space.sm)
+            .spacing(space.sm)
             .align_y(Alignment::Center),
         ),
     )
     .push(
         row!(
             space::horizontal(),
-            styled_button(theme, "Cancel")
+            styled_button("Cancel")
                 .kind(ButtonKind::Outline)
                 .height(Length::Fixed(50.))
                 .on_press(Message::DialogCancelled(id)),
-            styled_button(theme, "Confirm")
+            styled_button("Confirm")
                 .kind(ButtonKind::Solid)
                 .hierarchy(ButtonHierarchy::Primary)
                 .height(Length::Fixed(50.))
@@ -96,10 +95,10 @@ Do you want to connect anyway?",
                     Some(Message::DialogConfirmed(id))
                 })
         )
-        .spacing(theme.space.xs)
+        .spacing(space.xs)
         .width(Length::Fill),
     )
-    .spacing(theme.space.md)
-    .padding(theme.space.md)
+    .spacing(space.md)
+    .padding(space.md)
     .into()
 }

--- a/src/components/quick_setting_button.rs
+++ b/src/components/quick_setting_button.rs
@@ -4,7 +4,7 @@ use crate::{
         icons::{IconKind, StaticIcon, icon_button},
     },
     modules::settings::SubMenu,
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Alignment, Element, Length, Padding,
@@ -13,7 +13,6 @@ use iced::{
 
 #[allow(clippy::too_many_arguments)]
 pub fn quick_setting_button<'a, Msg: Clone + 'static>(
-    theme: &'a AshellTheme,
     icon: impl Into<IconKind>,
     title: String,
     subtitle: Option<String>,
@@ -22,22 +21,29 @@ pub fn quick_setting_button<'a, Msg: Clone + 'static>(
     on_right_press: Option<Msg>,
     with_submenu: Option<(SubMenu, Option<SubMenu>, Msg)>,
 ) -> Element<'a, Msg> {
+    let (space, font_size, submenu_btn_style, settings_btn_style) = use_theme(|theme| {
+        (
+            theme.space,
+            theme.font_size,
+            theme.quick_settings_submenu_button_style(active),
+            theme.quick_settings_button_style(active),
+        )
+    });
+
     let main_content = row!(
-        icon.into().to_text().size(theme.font_size.lg),
+        icon.into().to_text().size(font_size.lg),
         container(
             Column::with_capacity(2)
-                .push(text(title).size(theme.font_size.sm))
-                .push(subtitle.map(|s| {
-                    text(s)
-                        .wrapping(text::Wrapping::None)
-                        .size(theme.font_size.xs)
-                }))
-                .spacing(theme.space.xxs)
+                .push(text(title).size(font_size.sm))
+                .push(
+                    subtitle.map(|s| { text(s).wrapping(text::Wrapping::None).size(font_size.xs) })
+                )
+                .spacing(space.xxs)
         )
         .clip(true)
     )
-    .spacing(theme.space.xs)
-    .padding(Padding::ZERO.left(theme.space.xxs))
+    .spacing(space.xs)
+    .padding(Padding::ZERO.left(space.xxs))
     .width(Length::Fill)
     .align_y(Alignment::Center);
 
@@ -45,25 +51,22 @@ pub fn quick_setting_button<'a, Msg: Clone + 'static>(
         Row::with_capacity(2)
             .push(main_content)
             .push(with_submenu.map(|(menu_type, submenu, msg)| {
-                icon_button(
-                    theme,
-                    if Some(menu_type) == submenu {
-                        StaticIcon::Close
-                    } else {
-                        StaticIcon::RightChevron
-                    },
-                )
+                icon_button(if Some(menu_type) == submenu {
+                    StaticIcon::Close
+                } else {
+                    StaticIcon::RightChevron
+                })
                 .on_press(msg)
                 .size(ButtonSize::Small)
-                .style(theme.quick_settings_submenu_button_style(active))
+                .style(submenu_btn_style)
             }))
-            .spacing(theme.space.xxs)
+            .spacing(space.xxs)
             .align_y(Alignment::Center)
             .height(Length::Fill),
     )
-    .padding([theme.space.xxs, theme.space.xs])
+    .padding([space.xxs, space.xs])
     .on_press(on_press)
-    .style(theme.quick_settings_button_style(active))
+    .style(settings_btn_style)
     .width(Length::Fill)
     .height(Length::Fixed(50.));
 

--- a/src/components/slider_control.rs
+++ b/src/components/slider_control.rs
@@ -2,7 +2,7 @@ use std::ops::RangeInclusive;
 
 use crate::{
     components::icons::{IconKind, StaticIcon, icon_button},
-    theme::AshellTheme,
+    theme::use_theme,
     utils::remote_value,
 };
 use iced::{
@@ -12,7 +12,6 @@ use iced::{
 };
 
 pub struct SliderControl<'a, Msg> {
-    theme: &'a AshellTheme,
     icon: IconKind,
     range: RangeInclusive<u32>,
     value: u32,
@@ -24,7 +23,6 @@ pub struct SliderControl<'a, Msg> {
 }
 
 pub fn slider_control<'a, Msg: 'static + Clone>(
-    theme: &'a AshellTheme,
     icon: impl Into<IconKind>,
     range: RangeInclusive<u32>,
     value: u32,
@@ -32,7 +30,6 @@ pub fn slider_control<'a, Msg: 'static + Clone>(
     on_scroll: impl Fn(ScrollDelta) -> Msg + 'a,
 ) -> SliderControl<'a, Msg> {
     SliderControl {
-        theme,
         icon: icon.into(),
         range,
         value,
@@ -63,8 +60,10 @@ impl<'a, Msg: 'static + Clone> SliderControl<'a, Msg> {
 
 impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg> {
     fn from(ctrl: SliderControl<'a, Msg>) -> Self {
+        let space_xs = use_theme(|theme| theme.space.xs);
+
         let icon_element: Element<'a, Msg> = if let Some(msg) = ctrl.on_icon_press {
-            let btn = icon_button(ctrl.theme, ctrl.icon.clone()).on_press(msg);
+            let btn = icon_button(ctrl.icon.clone()).on_press(msg);
             if let Some(right_msg) = ctrl.on_icon_right_press {
                 MouseArea::new(btn).on_right_press(right_msg).into()
             } else {
@@ -93,7 +92,7 @@ impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg>
             } else {
                 StaticIcon::RightArrow
             };
-            icon_button(ctrl.theme, trailing_icon).on_press(msg).into()
+            icon_button(trailing_icon).on_press(msg).into()
         });
 
         Row::with_capacity(3)
@@ -101,7 +100,7 @@ impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg>
             .push(slider_element)
             .push(trailing)
             .align_y(Alignment::Center)
-            .spacing(ctrl.theme.space.xs)
+            .spacing(space_xs)
             .into()
     }
 }

--- a/src/components/slider_control.rs
+++ b/src/components/slider_control.rs
@@ -60,7 +60,7 @@ impl<'a, Msg: 'static + Clone> SliderControl<'a, Msg> {
 
 impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg> {
     fn from(ctrl: SliderControl<'a, Msg>) -> Self {
-        let space_xs = use_theme(|theme| theme.space.xs);
+        let space = use_theme(|theme| theme.space);
 
         let icon_element: Element<'a, Msg> = if let Some(msg) = ctrl.on_icon_press {
             let btn = icon_button(ctrl.icon.clone()).on_press(msg);
@@ -100,7 +100,7 @@ impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg>
             .push(slider_element)
             .push(trailing)
             .align_y(Alignment::Center)
-            .spacing(space_xs)
+            .spacing(space.xs)
             .into()
     }
 }

--- a/src/components/sub_menu_wrapper.rs
+++ b/src/components/sub_menu_wrapper.rs
@@ -2,8 +2,7 @@ use crate::theme::use_theme;
 use iced::{Background, Border, Element, Length, Theme, widget::container};
 
 pub fn sub_menu_wrapper<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<'a, Msg> {
-    let (opacity, radius_lg, padding_md) =
-        use_theme(|theme| (theme.opacity, theme.radius.lg, theme.space.md));
+    let (opacity, radius, space) = use_theme(|theme| (theme.opacity, theme.radius, theme.space));
 
     container(content)
         .style(move |theme: &Theme| container::Style {
@@ -16,10 +15,10 @@ pub fn sub_menu_wrapper<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<
                     .scale_alpha(opacity),
             )
             .into(),
-            border: Border::default().rounded(radius_lg),
+            border: Border::default().rounded(radius.lg),
             ..container::Style::default()
         })
-        .padding(padding_md)
+        .padding(space.md)
         .width(Length::Fill)
         .into()
 }

--- a/src/components/sub_menu_wrapper.rs
+++ b/src/components/sub_menu_wrapper.rs
@@ -1,10 +1,10 @@
-use crate::theme::AshellTheme;
+use crate::theme::use_theme;
 use iced::{Background, Border, Element, Length, Theme, widget::container};
 
-pub fn sub_menu_wrapper<'a, Msg: 'static>(
-    ashell_theme: &'a AshellTheme,
-    content: Element<'a, Msg>,
-) -> Element<'a, Msg> {
+pub fn sub_menu_wrapper<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<'a, Msg> {
+    let (opacity, radius_lg, padding_md) =
+        use_theme(|theme| (theme.opacity, theme.radius.lg, theme.space.md));
+
     container(content)
         .style(move |theme: &Theme| container::Style {
             background: Background::Color(
@@ -13,13 +13,13 @@ pub fn sub_menu_wrapper<'a, Msg: 'static>(
                     .background
                     .weak
                     .color
-                    .scale_alpha(ashell_theme.opacity),
+                    .scale_alpha(opacity),
             )
             .into(),
-            border: Border::default().rounded(ashell_theme.radius.lg),
+            border: Border::default().rounded(radius_lg),
             ..container::Style::default()
         })
-        .padding(ashell_theme.space.md)
+        .padding(padding_md)
         .width(Length::Fill)
         .into()
 }

--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::icons::{DynamicIcon, StaticIcon, icon},
     config::CustomModuleDef,
-    theme::AshellTheme,
+    theme::use_theme,
     utils::launcher::execute_command,
 };
 use iced::widget::canvas;
@@ -95,7 +95,8 @@ impl Custom {
         }
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme) -> Element<'_, Message> {
+    pub fn view(&'_ self) -> Element<'_, Message> {
+        let space_xs = use_theme(|theme| theme.space.xs);
         match self.config.r#type {
             crate::config::CustomModuleType::Text => self
                 .data
@@ -137,8 +138,8 @@ impl Custom {
 
                 let icon_with_alert = if show_alert {
                     let alert_canvas = canvas(AlertIndicator)
-                        .width(Length::Fixed(theme.space.xs)) // Size of the dot
-                        .height(Length::Fixed(theme.space.xs));
+                        .width(Length::Fixed(space_xs)) // Size of the dot
+                        .height(Length::Fixed(space_xs));
 
                     // Container to position the dot at the top-right
                     let alert_indicator_container = container(alert_canvas)
@@ -164,9 +165,7 @@ impl Custom {
                 });
 
                 if let Some(text_element) = maybe_text_element {
-                    row![icon_with_alert, text_element]
-                        .spacing(theme.space.xs)
-                        .into()
+                    row![icon_with_alert, text_element].spacing(space_xs).into()
                 } else {
                     icon_with_alert
                 }

--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -96,7 +96,7 @@ impl Custom {
     }
 
     pub fn view(&'_ self) -> Element<'_, Message> {
-        let space_xs = use_theme(|theme| theme.space.xs);
+        let space = use_theme(|theme| theme.space);
         match self.config.r#type {
             crate::config::CustomModuleType::Text => self
                 .data
@@ -138,8 +138,8 @@ impl Custom {
 
                 let icon_with_alert = if show_alert {
                     let alert_canvas = canvas(AlertIndicator)
-                        .width(Length::Fixed(space_xs)) // Size of the dot
-                        .height(Length::Fixed(space_xs));
+                        .width(Length::Fixed(space.xs)) // Size of the dot
+                        .height(Length::Fixed(space.xs));
 
                     // Container to position the dot at the top-right
                     let alert_indicator_container = container(alert_canvas)
@@ -165,7 +165,7 @@ impl Custom {
                 });
 
                 if let Some(text_element) = maybe_text_element {
-                    row![icon_with_alert, text_element].spacing(space_xs).into()
+                    row![icon_with_alert, text_element].spacing(space.xs).into()
                 } else {
                     icon_with_alert
                 }

--- a/src/modules/keyboard_layout.rs
+++ b/src/modules/keyboard_layout.rs
@@ -4,7 +4,6 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         compositor::{CompositorCommand, CompositorService},
     },
-    theme::AshellTheme,
 };
 use iced::{Element, Subscription, Task, widget::text};
 
@@ -57,7 +56,7 @@ impl KeyboardLayout {
         }
     }
 
-    pub fn view(&self, _: &AshellTheme) -> Option<Element<'_, Message>> {
+    pub fn view(&self) -> Option<Element<'_, Message>> {
         let service = self.service.as_ref()?;
         let active_layout = &service.keyboard_layout;
 

--- a/src/modules/keyboard_submap.rs
+++ b/src/modules/keyboard_submap.rs
@@ -1,7 +1,4 @@
-use crate::{
-    services::{ReadOnlyService, ServiceEvent, compositor::CompositorService},
-    theme::AshellTheme,
-};
+use crate::services::{ReadOnlyService, ServiceEvent, compositor::CompositorService};
 use iced::{Element, Subscription, widget::text};
 
 #[derive(Debug, Clone)]
@@ -33,7 +30,7 @@ impl KeyboardSubmap {
         }
     }
 
-    pub fn view(&self, _: &AshellTheme) -> Option<Element<'_, Message>> {
+    pub fn view(&self) -> Option<Element<'_, Message>> {
         let submap = self.service.as_ref()?.submap.as_ref()?;
 
         if !submap.is_empty() {

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -77,8 +77,8 @@ impl MediaPlayer {
     }
 
     pub fn menu_view<'a>(&'a self) -> Element<'a, Message> {
-        let (space, font_size, opacity, radius_lg) =
-            use_theme(|theme| (theme.space, theme.font_size, theme.opacity, theme.radius.lg));
+        let (space, font_size, opacity, radius) =
+            use_theme(|theme| (theme.space, theme.font_size, theme.opacity, theme.radius));
         container(match &self.service {
             None => Into::<Element<'a, Message>>::into(text("Not connected to MPRIS service")),
             Some(service) => column!(
@@ -196,7 +196,7 @@ impl MediaPlayer {
                                     .scale_alpha(opacity),
                             )
                             .into(),
-                            border: Border::default().rounded(radius_lg),
+                            border: Border::default().rounded(radius.lg),
                             ..container::Style::default()
                         })
                         .padding(space.md)
@@ -232,7 +232,7 @@ impl MediaPlayer {
     }
 
     pub fn view(&'_ self) -> Option<Element<'_, Message>> {
-        let (space_xs, font_size_sm) = use_theme(|theme| (theme.space.xs, theme.font_size.sm));
+        let (space, font_size) = use_theme(|theme| (theme.space, theme.font_size));
         self.service.as_ref().and_then(|s| {
             s.players().first().map(|player| {
                 let title =
@@ -240,7 +240,7 @@ impl MediaPlayer {
                         container(
                             text(self.get_title(player))
                                 .wrapping(text::Wrapping::None)
-                                .size(font_size_sm),
+                                .size(font_size.sm),
                         )
                         .clip(true)
                     });
@@ -248,7 +248,7 @@ impl MediaPlayer {
                 row![icon(StaticIcon::MusicNote)]
                     .push(title)
                     .align_y(Vertical::Center)
-                    .spacing(space_xs)
+                    .spacing(space.xs)
                     .into()
             })
         })

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -9,7 +9,7 @@ use crate::{
             MprisPlayerCommand, MprisPlayerData, MprisPlayerService, PlaybackStatus, PlayerCommand,
         },
     },
-    theme::AshellTheme,
+    theme::use_theme,
     utils::truncate_text,
 };
 use iced::{
@@ -76,11 +76,13 @@ impl MediaPlayer {
         }
     }
 
-    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn menu_view<'a>(&'a self) -> Element<'a, Message> {
+        let (space, font_size, opacity, radius_lg) =
+            use_theme(|theme| (theme.space, theme.font_size, theme.opacity, theme.radius.lg));
         container(match &self.service {
             None => Into::<Element<'a, Message>>::into(text("Not connected to MPRIS service")),
             Some(service) => column!(
-                text("Players").size(theme.font_size.lg),
+                text("Players").size(font_size.lg),
                 divider(),
                 column(service.players().iter().map(|d| {
                     const LEFT_COLUMN_WIDTH: Length = Length::FillPortion(3);
@@ -101,14 +103,14 @@ impl MediaPlayer {
                         .width(Length::Fill);
                     let artists = text(truncate_text(&artists, self.config.max_title_length))
                         .wrapping(text::Wrapping::WordOrGlyph)
-                        .size(theme.font_size.sm)
+                        .size(font_size.sm)
                         .width(Length::Fill);
                     let album = text(truncate_text(&album, self.config.max_title_length))
                         .wrapping(text::Wrapping::WordOrGlyph)
-                        .size(theme.font_size.sm)
+                        .size(font_size.sm)
                         .width(Length::Fill);
                     let description = column![title, artists, album]
-                        .spacing(theme.space.xxs)
+                        .spacing(space.xxs)
                         .width(LEFT_COLUMN_WIDTH);
 
                     let play_pause_icon = match d.state {
@@ -118,18 +120,18 @@ impl MediaPlayer {
 
                     let buttons = container(
                         row![
-                            icon_button(theme, StaticIcon::SkipPrevious)
+                            icon_button(StaticIcon::SkipPrevious)
                                 .on_press(Message::Prev(d.service.clone()))
                                 .size(ButtonSize::Large),
-                            icon_button(theme, play_pause_icon)
+                            icon_button(play_pause_icon)
                                 .on_press(Message::PlayPause(d.service.clone()))
                                 .size(ButtonSize::Large),
-                            icon_button(theme, StaticIcon::SkipNext)
+                            icon_button(StaticIcon::SkipNext)
                                 .on_press(Message::Next(d.service.clone()))
                                 .size(ButtonSize::Large),
                         ]
                         .align_y(Vertical::Center)
-                        .spacing(theme.space.xs),
+                        .spacing(space.xs),
                     )
                     .center_x(RIGHT_COLUMN_WIDTH);
                     let volume_slider: Option<Element<'_, _>> = d.volume.map(|v| {
@@ -157,30 +159,29 @@ impl MediaPlayer {
                     let metadata = |description, cover| -> Element<'_, _> {
                         row![description]
                             .push(cover)
-                            .spacing(theme.space.md)
+                            .spacing(space.md)
                             .align_y(Vertical::Center)
                             .into()
                     };
                     let content: Element<'_, _> = match (volume_slider, cover) {
                         (None, None) => row![description, buttons]
-                            .spacing(theme.space.md)
+                            .spacing(space.md)
                             .align_y(Vertical::Center)
                             .into(),
                         (Some(v), cover) => {
-                            let controls = row![v, buttons]
-                                .spacing(theme.space.md)
-                                .align_y(Vertical::Center);
+                            let controls =
+                                row![v, buttons].spacing(space.md).align_y(Vertical::Center);
                             column![metadata(description, cover), controls]
-                                .spacing(theme.space.md)
+                                .spacing(space.md)
                                 .into()
                         }
                         (None, cover) => {
                             let controls =
                                 row![space::horizontal().width(LEFT_COLUMN_WIDTH), buttons]
-                                    .spacing(theme.space.md)
+                                    .spacing(space.md)
                                     .align_y(Vertical::Center);
                             column![metadata(description, cover), controls]
-                                .spacing(theme.space.md)
+                                .spacing(space.md)
                                 .into()
                         }
                     };
@@ -192,19 +193,19 @@ impl MediaPlayer {
                                     .background
                                     .weak
                                     .color
-                                    .scale_alpha(theme.opacity),
+                                    .scale_alpha(opacity),
                             )
                             .into(),
-                            border: Border::default().rounded(theme.radius.lg),
+                            border: Border::default().rounded(radius_lg),
                             ..container::Style::default()
                         })
-                        .padding(theme.space.md)
+                        .padding(space.md)
                         .width(Length::Fill)
                         .into()
                 }))
-                .spacing(theme.space.md)
+                .spacing(space.md)
             )
-            .spacing(theme.space.xs)
+            .spacing(space.xs)
             .into(),
         })
         .width(MenuSize::Large)
@@ -230,7 +231,8 @@ impl MediaPlayer {
         }
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme) -> Option<Element<'_, Message>> {
+    pub fn view(&'_ self) -> Option<Element<'_, Message>> {
+        let (space_xs, font_size_sm) = use_theme(|theme| (theme.space.xs, theme.font_size.sm));
         self.service.as_ref().and_then(|s| {
             s.players().first().map(|player| {
                 let title =
@@ -238,7 +240,7 @@ impl MediaPlayer {
                         container(
                             text(self.get_title(player))
                                 .wrapping(text::Wrapping::None)
-                                .size(theme.font_size.sm),
+                                .size(font_size_sm),
                         )
                         .clip(true)
                     });
@@ -246,7 +248,7 @@ impl MediaPlayer {
                 row![icon(StaticIcon::MusicNote)]
                     .push(title)
                     .align_y(Vertical::Center)
-                    .spacing(theme.space.xs)
+                    .spacing(space_xs)
                     .into()
             })
         })

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -3,7 +3,7 @@ use crate::{
     components::menu::MenuType,
     components::{module_group, module_item},
     config::{ModuleDef, ModuleName},
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{Alignment, Element, Length, Subscription, SurfaceId, widget::Row};
 
@@ -34,11 +34,8 @@ pub enum OnModulePress {
 }
 
 impl App {
-    pub fn modules_section<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-    ) -> [Element<'a, Message>; 3] {
+    pub fn modules_section<'a>(&'a self, id: SurfaceId) -> [Element<'a, Message>; 3] {
+        let space_xxs = use_theme(|t| t.space.xxs);
         [
             &self.general_config.modules.left,
             &self.general_config.modules.center,
@@ -48,13 +45,13 @@ impl App {
             let mut row = Row::with_capacity(modules_def.len())
                 .height(Length::Shrink)
                 .align_y(Alignment::Center)
-                .spacing(self.theme.space.xxs);
+                .spacing(space_xxs);
 
             for module_def in modules_def {
                 row = row.push(match module_def {
                     // life parsing of string to module
-                    ModuleDef::Single(module) => self.single_module_wrapper(id, theme, module),
-                    ModuleDef::Group(group) => self.group_module_wrapper(id, theme, group),
+                    ModuleDef::Single(module) => self.single_module_wrapper(id, module),
+                    ModuleDef::Group(group) => self.group_module_wrapper(id, group),
                 });
             }
 
@@ -81,13 +78,12 @@ impl App {
     fn build_module_item<'a>(
         &'a self,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         content: Element<'a, Message>,
         action: Option<OnModulePress>,
     ) -> Element<'a, Message> {
         match action {
             Some(action) => {
-                let mut item = module_item(theme, content);
+                let mut item = module_item(content);
                 match action {
                     OnModulePress::Action(msg) => {
                         item = item.on_press(*msg);
@@ -119,26 +115,22 @@ impl App {
                 }
                 item.into()
             }
-            None => module_item(theme, content).into(),
+            None => module_item(content).into(),
         }
     }
 
     fn single_module_wrapper<'a>(
         &'a self,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         module_name: &'a ModuleName,
     ) -> Option<Element<'a, Message>> {
         self.get_module_view(id, module_name)
-            .map(|(content, action)| {
-                module_group(theme, self.build_module_item(id, theme, content, action))
-            })
+            .map(|(content, action)| module_group(self.build_module_item(id, content, action)))
     }
 
     fn group_module_wrapper<'a>(
         &'a self,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         group: &'a [ModuleName],
     ) -> Option<Element<'a, Message>> {
         let modules: Vec<_> = group
@@ -152,10 +144,10 @@ impl App {
             let items = Row::with_children(
                 modules
                     .into_iter()
-                    .map(|(content, action)| self.build_module_item(id, theme, content, action))
+                    .map(|(content, action)| self.build_module_item(id, content, action))
                     .collect::<Vec<_>>(),
             );
-            Some(module_group(theme, items.into()))
+            Some(module_group(items.into()))
         }
     }
 
@@ -176,37 +168,33 @@ impl App {
                     }
                 };
                 (
-                    custom
-                        .view(&self.theme)
-                        .map(|msg| Message::Custom(name.clone(), msg)),
+                    custom.view().map(|msg| Message::Custom(name.clone(), msg)),
                     action,
                 )
             }),
             ModuleName::Updates => self.updates.as_ref().map(|updates| {
                 (
-                    updates.view(&self.theme).map(Message::Updates),
+                    updates.view().map(Message::Updates),
                     Some(OnModulePress::ToggleMenu(MenuType::Updates)),
                 )
             }),
             ModuleName::Workspaces => Some((
                 self.workspaces
-                    .view(id, &self.theme, &self.outputs)
+                    .view(id, &self.outputs)
                     .map(Message::Workspaces),
                 None,
             )),
             ModuleName::WindowTitle => self.window_title.get_value().map(|title| {
                 (
-                    self.window_title
-                        .view(&self.theme, title)
-                        .map(Message::WindowTitle),
+                    self.window_title.view(title).map(Message::WindowTitle),
                     None,
                 )
             }),
             ModuleName::SystemInfo => Some((
-                self.system_info.view(&self.theme).map(Message::SystemInfo),
+                self.system_info.view().map(Message::SystemInfo),
                 Some(OnModulePress::ToggleMenu(MenuType::SystemInfo)),
             )),
-            ModuleName::KeyboardLayout => self.keyboard_layout.view(&self.theme).map(|view| {
+            ModuleName::KeyboardLayout => self.keyboard_layout.view().map(|view| {
                 (
                     view.map(Message::KeyboardLayout),
                     Some(OnModulePress::Action(Box::new(Message::KeyboardLayout(
@@ -216,14 +204,14 @@ impl App {
             }),
             ModuleName::KeyboardSubmap => self
                 .keyboard_submap
-                .view(&self.theme)
+                .view()
                 .map(|view| (view.map(Message::KeyboardSubmap), None)),
             ModuleName::Tray => self
                 .tray
-                .view(id, &self.theme)
+                .view(id)
                 .map(|view| (view.map(Message::Tray), None)),
             ModuleName::Tempo => Some((
-                self.tempo.view(&self.theme).map(Message::Tempo),
+                self.tempo.view().map(Message::Tempo),
                 Some(OnModulePress::ToggleMenuWithExtra {
                     menu_type: MenuType::Tempo,
                     on_right_press: Some(Box::new(Message::Tempo(tempo::Message::CycleFormat))),
@@ -237,22 +225,20 @@ impl App {
             )),
             ModuleName::Privacy => self
                 .privacy
-                .view(&self.theme)
+                .view()
                 .map(|view| (view.map(Message::Privacy), None)),
-            ModuleName::MediaPlayer => self.media_player.view(&self.theme).map(|view| {
+            ModuleName::MediaPlayer => self.media_player.view().map(|view| {
                 (
                     view.map(Message::MediaPlayer),
                     Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
                 )
             }),
             ModuleName::Settings => Some((
-                self.settings.view(&self.theme).map(Message::Settings),
+                self.settings.view().map(Message::Settings),
                 Some(OnModulePress::ToggleMenu(MenuType::Settings)),
             )),
             ModuleName::Notifications => Some((
-                self.notifications
-                    .view(&self.theme)
-                    .map(Message::Notifications),
+                self.notifications.view().map(Message::Notifications),
                 Some(OnModulePress::ToggleMenu(MenuType::Notifications)),
             )),
         }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -35,7 +35,7 @@ pub enum OnModulePress {
 
 impl App {
     pub fn modules_section<'a>(&'a self, id: SurfaceId) -> [Element<'a, Message>; 3] {
-        let space_xxs = use_theme(|t| t.space.xxs);
+        let space = use_theme(|t| t.space);
         [
             &self.general_config.modules.left,
             &self.general_config.modules.center,
@@ -45,7 +45,7 @@ impl App {
             let mut row = Row::with_capacity(modules_def.len())
                 .height(Length::Shrink)
                 .align_y(Alignment::Center)
-                .spacing(space_xxs);
+                .spacing(space.xxs);
 
             for module_def in modules_def {
                 row = row.push(match module_def {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -9,7 +9,7 @@ use crate::{
             dbus::{NotificationDaemon, NotificationEvent},
         },
     },
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use chrono::{DateTime, Local};
 use iced::{
@@ -377,29 +377,30 @@ impl Notifications {
     }
 
     fn notification_button_style(
-        theme: &AshellTheme,
         style: NotificationStyle,
         urgency: Urgency,
-    ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style {
+    ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style + use<> {
+        let (radius_lg, radius_sm, menu_opacity) =
+            use_theme(|t| (t.radius.lg, t.radius.sm, t.menu.opacity));
         move |iced_theme: &Theme, status| {
             let mut border = match style {
                 NotificationStyle::Toast => Border::default()
                     .width(1)
                     .color(iced_theme.extended_palette().background.weakest.color)
-                    .rounded(theme.radius.lg),
-                NotificationStyle::Standalone => Border::default().rounded(theme.radius.lg),
+                    .rounded(radius_lg),
+                NotificationStyle::Standalone => Border::default().rounded(radius_lg),
                 NotificationStyle::GroupHeader => Border::default().rounded(iced::border::Radius {
-                    top_left: theme.radius.lg,
-                    top_right: theme.radius.lg,
-                    bottom_left: theme.radius.sm,
-                    bottom_right: theme.radius.sm,
+                    top_left: radius_lg,
+                    top_right: radius_lg,
+                    bottom_left: radius_sm,
+                    bottom_right: radius_sm,
                 }),
-                NotificationStyle::GroupItem => Border::default().rounded(theme.radius.sm),
+                NotificationStyle::GroupItem => Border::default().rounded(radius_sm),
                 NotificationStyle::GroupLast => Border::default().rounded(iced::border::Radius {
                     top_left: 0.0,
                     top_right: 0.0,
-                    bottom_left: theme.radius.lg,
-                    bottom_right: theme.radius.lg,
+                    bottom_left: radius_lg,
+                    bottom_right: radius_lg,
                 }),
             };
 
@@ -422,7 +423,7 @@ impl Notifications {
                                 .background
                                 .weak
                                 .color
-                                .scale_alpha(theme.menu.opacity)
+                                .scale_alpha(menu_opacity)
                                 .into(),
                         );
                     } else {
@@ -432,7 +433,7 @@ impl Notifications {
                                 .background
                                 .strong
                                 .color
-                                .scale_alpha(theme.menu.opacity)
+                                .scale_alpha(menu_opacity)
                                 .into(),
                         );
                     }
@@ -452,16 +453,14 @@ impl Notifications {
     fn notification_card<'a>(
         &'a self,
         notification: &'a Notification,
-        theme: &'a AshellTheme,
         on_press: Message,
         toast: bool,
     ) -> Element<'a, Message> {
+        let (space, font_size) = use_theme(|t| (t.space, t.font_size));
         let timestamp_element = if self.config.show_timestamps {
             Some(
-                container(
-                    text(self.format_timestamp(notification.timestamp)).size(theme.font_size.xs),
-                )
-                .padding([0., theme.space.xxs]),
+                container(text(self.format_timestamp(notification.timestamp)).size(font_size.xs))
+                    .padding([0., space.xxs]),
             )
         } else {
             None
@@ -470,7 +469,7 @@ impl Notifications {
         let body_element = if (!toast || self.config.show_bodies) && !notification.body.is_empty() {
             Some(
                 text(&notification.body)
-                    .size(theme.font_size.sm)
+                    .size(font_size.sm)
                     .wrapping(text::Wrapping::WordOrGlyph),
             )
         } else {
@@ -489,17 +488,17 @@ impl Notifications {
                             .push(app_icon_button)
                             .push(column!(
                                 text(&notification.app_name)
-                                    .size(theme.font_size.md)
+                                    .size(font_size.md)
                                     .wrapping(text::Wrapping::WordOrGlyph),
                                 timestamp_element
                             ))
                             .width(Length::Fill)
-                            .spacing(theme.space.xxs)
-                            .padding(theme.space.xs)
+                            .spacing(space.xxs)
+                            .padding(space.xs)
                             .align_y(Alignment::Center),
                     )
                     .push(
-                        icon_button(theme, StaticIcon::Close)
+                        icon_button(StaticIcon::Close)
                             .kind(ButtonKind::Transparent)
                             .hierarchy(ButtonHierarchy::Danger)
                             .on_press(Message::CloseNotificationById(notification_id))
@@ -508,10 +507,10 @@ impl Notifications {
                     text(&notification.summary).wrapping(text::Wrapping::WordOrGlyph),
                     body_element,
                 )
-                .spacing(theme.space.xxs)
-                .padding(Padding::new(theme.space.xs).top(0.))
+                .spacing(space.xxs)
+                .padding(Padding::new(space.xs).top(0.))
             )
-            .spacing(theme.space.xxs),
+            .spacing(space.xxs),
         );
 
         if toast {
@@ -521,9 +520,8 @@ impl Notifications {
         button(card)
             .on_press(on_press)
             .width(Length::Fill)
-            .padding(theme.space.xxs)
+            .padding(space.xxs)
             .style(Self::notification_button_style(
-                theme,
                 if toast {
                     NotificationStyle::Toast
                 } else {
@@ -538,23 +536,22 @@ impl Notifications {
         &'a self,
         notification: &'a Notification,
         is_last: bool,
-        theme: &'a AshellTheme,
     ) -> Element<'a, Message> {
+        let (space_xs, font_size_sm) = use_theme(|t| (t.space.xs, t.font_size.sm));
         button(
             column!(
                 row!(
                     text(&notification.summary)
                         .wrapping(text::Wrapping::WordOrGlyph)
                         .width(Length::Fill),
-                    text(self.format_timestamp(notification.timestamp)).size(theme.font_size.sm)
+                    text(self.format_timestamp(notification.timestamp)).size(font_size_sm)
                 ),
                 text(&notification.body).wrapping(text::Wrapping::WordOrGlyph)
             )
-            .padding(theme.space.xs)
-            .spacing(theme.space.xs),
+            .padding(space_xs)
+            .spacing(space_xs),
         )
         .style(Self::notification_button_style(
-            theme,
             if is_last {
                 NotificationStyle::GroupLast
             } else {
@@ -566,7 +563,7 @@ impl Notifications {
         .into()
     }
 
-    pub fn view(&'_ self, _: &AshellTheme) -> Element<'_, Message> {
+    pub fn view(&'_ self) -> Element<'_, Message> {
         if !self.notifications.is_empty() {
             icon(StaticIcon::BellBadge).into()
         } else {
@@ -574,50 +571,47 @@ impl Notifications {
         }
     }
 
-    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn menu_view<'a>(&'a self) -> Element<'a, Message> {
+        let (space, font_size) = use_theme(|t| (t.space, t.font_size));
         let is_empty = self.notifications.is_empty();
 
         let content = if is_empty {
-            container(text("No notifications").size(theme.font_size.md))
+            container(text("No notifications").size(font_size.md))
                 .width(Length::Fill)
                 .center_x(Length::Fill)
-                .padding(theme.space.xxl)
+                .padding(space.xxl)
                 .into()
         } else if self.config.grouped {
-            self.grouped_notifications(theme)
+            self.grouped_notifications()
         } else {
-            self.list_notifications(theme)
+            self.list_notifications()
         };
 
         column!(
             Row::new()
-                .push(
-                    text("Notifications")
-                        .width(Length::Fill)
-                        .size(theme.font_size.lg)
-                )
+                .push(text("Notifications").width(Length::Fill).size(font_size.lg))
                 .push((!is_empty).then(|| {
-                    icon_button(theme, StaticIcon::Delete).on_press(Message::ClearNotifications)
+                    icon_button(StaticIcon::Delete).on_press(Message::ClearNotifications)
                 })),
-            container(scrollable(content).spacing(theme.space.xs)).max_height(400.),
+            container(scrollable(content).spacing(space.xs)).max_height(400.),
         )
         .width(MenuSize::Medium)
-        .spacing(theme.space.sm)
+        .spacing(space.sm)
         .into()
     }
 
-    pub fn toast_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn toast_view<'a>(&'a self) -> Element<'a, Message> {
+        let space_sm = use_theme(|t| t.space.sm);
         if self.toasts.is_empty() {
             return Space::new().into();
         }
 
-        let mut toast_column = column!().spacing(theme.space.sm);
+        let mut toast_column = column!().spacing(space_sm);
 
         for &toast_id in &self.toasts {
             if let Some(notification) = self.find_notification(toast_id) {
                 toast_column = toast_column.push(self.notification_card(
                     notification,
-                    theme,
                     Message::DismissToast(notification.id),
                     true,
                 ));
@@ -634,7 +628,7 @@ impl Notifications {
         let toast_content = sensor(
             container(toast_column)
                 .width(MenuSize::Medium)
-                .padding(theme.space.sm),
+                .padding(space_sm),
         )
         .on_resize(Message::ToastResized);
 
@@ -649,12 +643,11 @@ impl Notifications {
         NotificationsService::subscribe().map(Message::Event)
     }
 
-    fn grouped_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let mut content = column!().spacing(theme.space.sm).padding(
-            Padding::default()
-                .right(theme.space.md)
-                .left(theme.space.xs),
-        );
+    fn grouped_notifications<'a>(&'a self) -> Element<'a, Message> {
+        let (space, font_size) = use_theme(|t| (t.space, t.font_size));
+        let mut content = column!()
+            .spacing(space.sm)
+            .padding(Padding::default().right(space.md).left(space.xs));
 
         for (_app_name, group) in self
             .notifications
@@ -673,7 +666,6 @@ impl Notifications {
             if iter.peek().is_none() {
                 content = content.push(self.notification_card(
                     first,
-                    theme,
                     Message::NotificationClicked(first.id),
                     false,
                 ));
@@ -690,19 +682,19 @@ impl Notifications {
             let mut group_notifications = vec![];
 
             if is_expanded {
-                group_notifications.push(self.group_item(first, false, theme));
+                group_notifications.push(self.group_item(first, false));
                 while let Some(notification) = iter.next() {
                     count += 1;
                     has_critical = has_critical || notification.urgency == Urgency::Critical;
                     let is_last = iter.peek().is_none();
-                    group_notifications.push(self.group_item(notification, is_last, theme));
+                    group_notifications.push(self.group_item(notification, is_last));
                 }
             } else {
                 for notification in iter {
                     count += 1;
                     has_critical = has_critical || notification.urgency == Urgency::Critical;
                 }
-                group_notifications.push(self.group_item(first, true, theme));
+                group_notifications.push(self.group_item(first, true));
             }
 
             let clear_msg = Message::ClearGroup(app_name.clone());
@@ -711,24 +703,23 @@ impl Notifications {
             let header = row!(
                 app_icon,
                 text(app_name)
-                    .size(theme.font_size.md)
+                    .size(font_size.md)
                     .wrapping(text::Wrapping::WordOrGlyph)
                     .width(Length::Fill),
                 text(format!("{count} new")),
-                icon_button(theme, StaticIcon::Delete)
+                icon_button(StaticIcon::Delete)
                     .on_press(clear_msg)
                     .size(ButtonSize::Large)
                     .kind(ButtonKind::Transparent)
                     .hierarchy(ButtonHierarchy::Danger)
             )
-            .spacing(theme.space.xs)
+            .spacing(space.xs)
             .align_y(Alignment::Center);
 
             let item = Column::new()
                 .push(
                     button(header)
                         .style(Self::notification_button_style(
-                            theme,
                             NotificationStyle::GroupHeader,
                             if has_critical {
                                 Urgency::Critical
@@ -739,33 +730,29 @@ impl Notifications {
                         .on_press(toggle_msg),
                 )
                 .extend(group_notifications)
-                .spacing(theme.space.xxs);
+                .spacing(space.xxs);
 
             content = content.push(item);
         }
         content.into()
     }
 
-    fn list_notifications<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    fn list_notifications<'a>(&'a self) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         Column::with_children(
             self.notifications
                 .iter()
                 .map(|notification| {
                     self.notification_card(
                         notification,
-                        theme,
                         Message::NotificationClicked(notification.id),
                         false,
                     )
                 })
                 .collect::<Vec<Element<'a, Message>>>(),
         )
-        .padding(
-            Padding::default()
-                .right(theme.space.md)
-                .left(theme.space.xs),
-        )
-        .spacing(theme.space.sm)
+        .padding(Padding::default().right(space.md).left(space.xs))
+        .spacing(space.sm)
         .into()
     }
 

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -380,27 +380,26 @@ impl Notifications {
         style: NotificationStyle,
         urgency: Urgency,
     ) -> impl Fn(&Theme, iced::widget::button::Status) -> iced::widget::button::Style + use<> {
-        let (radius_lg, radius_sm, menu_opacity) =
-            use_theme(|t| (t.radius.lg, t.radius.sm, t.menu.opacity));
+        let (radius, menu_opacity) = use_theme(|t| (t.radius, t.menu.opacity));
         move |iced_theme: &Theme, status| {
             let mut border = match style {
                 NotificationStyle::Toast => Border::default()
                     .width(1)
                     .color(iced_theme.extended_palette().background.weakest.color)
-                    .rounded(radius_lg),
-                NotificationStyle::Standalone => Border::default().rounded(radius_lg),
+                    .rounded(radius.lg),
+                NotificationStyle::Standalone => Border::default().rounded(radius.lg),
                 NotificationStyle::GroupHeader => Border::default().rounded(iced::border::Radius {
-                    top_left: radius_lg,
-                    top_right: radius_lg,
-                    bottom_left: radius_sm,
-                    bottom_right: radius_sm,
+                    top_left: radius.lg,
+                    top_right: radius.lg,
+                    bottom_left: radius.sm,
+                    bottom_right: radius.sm,
                 }),
-                NotificationStyle::GroupItem => Border::default().rounded(radius_sm),
+                NotificationStyle::GroupItem => Border::default().rounded(radius.sm),
                 NotificationStyle::GroupLast => Border::default().rounded(iced::border::Radius {
                     top_left: 0.0,
                     top_right: 0.0,
-                    bottom_left: radius_lg,
-                    bottom_right: radius_lg,
+                    bottom_left: radius.lg,
+                    bottom_right: radius.lg,
                 }),
             };
 
@@ -537,19 +536,19 @@ impl Notifications {
         notification: &'a Notification,
         is_last: bool,
     ) -> Element<'a, Message> {
-        let (space_xs, font_size_sm) = use_theme(|t| (t.space.xs, t.font_size.sm));
+        let (space, font_size) = use_theme(|t| (t.space, t.font_size));
         button(
             column!(
                 row!(
                     text(&notification.summary)
                         .wrapping(text::Wrapping::WordOrGlyph)
                         .width(Length::Fill),
-                    text(self.format_timestamp(notification.timestamp)).size(font_size_sm)
+                    text(self.format_timestamp(notification.timestamp)).size(font_size.sm)
                 ),
                 text(&notification.body).wrapping(text::Wrapping::WordOrGlyph)
             )
-            .padding(space_xs)
-            .spacing(space_xs),
+            .padding(space.xs)
+            .spacing(space.xs),
         )
         .style(Self::notification_button_style(
             if is_last {
@@ -601,12 +600,12 @@ impl Notifications {
     }
 
     pub fn toast_view<'a>(&'a self) -> Element<'a, Message> {
-        let space_sm = use_theme(|t| t.space.sm);
+        let space = use_theme(|t| t.space);
         if self.toasts.is_empty() {
             return Space::new().into();
         }
 
-        let mut toast_column = column!().spacing(space_sm);
+        let mut toast_column = column!().spacing(space.sm);
 
         for &toast_id in &self.toasts {
             if let Some(notification) = self.find_notification(toast_id) {
@@ -628,7 +627,7 @@ impl Notifications {
         let toast_content = sensor(
             container(toast_column)
                 .width(MenuSize::Medium)
-                .padding(space_sm),
+                .padding(space.sm),
         )
         .on_resize(Message::ToastResized);
 

--- a/src/modules/privacy.rs
+++ b/src/modules/privacy.rs
@@ -1,7 +1,7 @@
 use crate::{
     components::icons::{StaticIcon, icon},
     services::{ReadOnlyService, ServiceEvent, privacy::PrivacyService},
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Alignment, Element, Subscription,
@@ -35,7 +35,8 @@ impl Privacy {
         }
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme) -> Option<Element<'_, Message>> {
+    pub fn view(&'_ self) -> Option<Element<'_, Message>> {
+        let space_xs = use_theme(|theme| theme.space.xs);
         if let Some(service) = self.service.as_ref()
             && !service.no_access()
         {
@@ -50,7 +51,7 @@ impl Privacy {
                         .push(service.webcam_access().then(|| icon(StaticIcon::Webcam)))
                         .push(service.microphone_access().then(|| icon(StaticIcon::Mic1)))
                         .align_y(Alignment::Center)
-                        .spacing(theme.space.xs),
+                        .spacing(space_xs),
                 )
                 .style(|theme| container::Style {
                     text_color: Some(theme.palette().warning),

--- a/src/modules/privacy.rs
+++ b/src/modules/privacy.rs
@@ -36,7 +36,7 @@ impl Privacy {
     }
 
     pub fn view(&'_ self) -> Option<Element<'_, Message>> {
-        let space_xs = use_theme(|theme| theme.space.xs);
+        let space = use_theme(|theme| theme.space);
         if let Some(service) = self.service.as_ref()
             && !service.no_access()
         {
@@ -51,7 +51,7 @@ impl Privacy {
                         .push(service.webcam_access().then(|| icon(StaticIcon::Webcam)))
                         .push(service.microphone_access().then(|| icon(StaticIcon::Mic1)))
                         .align_y(Alignment::Center)
-                        .spacing(space_xs),
+                        .spacing(space.xs),
                 )
                 .style(|theme| container::Style {
                     text_color: Some(theme.palette().warning),

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -10,7 +10,7 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         audio::{AudioCommand, AudioService, ChannelVolumesExt, DevicePortType, Port},
     },
-    theme::AshellTheme,
+    theme::use_theme,
     utils::IndicatorState,
     utils::remote_value::{self, Remote},
 };
@@ -264,7 +264,7 @@ impl AudioSettings {
         }
     }
 
-    pub fn sink_indicator<'a>(&'a self, theme: &'a AshellTheme) -> Option<Element<'a, Message>> {
+    pub fn sink_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service
             .as_ref()
             .and_then(|service| {
@@ -277,7 +277,6 @@ impl AudioSettings {
             .map(|(service, icon_type)| {
                 let volume = service.sink_slider.value();
                 format_indicator(
-                    theme,
                     self.config.indicator_format,
                     icon_type,
                     Self::vol_text(volume).into(),
@@ -289,7 +288,7 @@ impl AudioSettings {
             })
     }
 
-    pub fn source_indicator<'a>(&'a self, theme: &'a AshellTheme) -> Option<Element<'a, Message>> {
+    pub fn source_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service
             .as_ref()
             .and_then(|service| {
@@ -307,7 +306,6 @@ impl AudioSettings {
             .map(|(service, icon_type)| {
                 let volume = service.source_slider.value();
                 format_indicator(
-                    theme,
                     self.config.microphone_indicator_format,
                     icon_type,
                     Self::vol_text(volume).into(),
@@ -321,13 +319,11 @@ impl AudioSettings {
 
     pub fn sliders<'a>(
         &'a self,
-        theme: &'a AshellTheme,
         sub_menu: Option<SubMenu>,
     ) -> (Option<Element<'a, Message>>, Option<Element<'a, Message>>) {
         if let Some(service) = &self.service {
             let sink_slider = service.active_sink().map(|s| {
                 Self::audio_slider(
-                    theme,
                     SliderType::Sink,
                     s.is_mute,
                     Message::ToggleSinkMute,
@@ -343,7 +339,6 @@ impl AudioSettings {
 
             let source_slider = service.active_source().map(|s| {
                 Self::audio_slider(
-                    theme,
                     SliderType::Source,
                     s.is_mute,
                     Message::ToggleSourceMute,
@@ -363,14 +358,9 @@ impl AudioSettings {
         }
     }
 
-    pub fn sinks_submenu<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn sinks_submenu<'a>(&'a self, id: SurfaceId) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
             Self::submenu(
-                theme,
                 service
                     .sink_iter()
                     .map(|route| SubmenuEntry {
@@ -395,14 +385,9 @@ impl AudioSettings {
         })
     }
 
-    pub fn sources_submenu<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn sources_submenu<'a>(&'a self, id: SurfaceId) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
             Self::submenu(
-                theme,
                 service
                     .source_iter()
                     .map(|route| SubmenuEntry {
@@ -456,7 +441,6 @@ impl AudioSettings {
     }
 
     fn audio_slider<'a>(
-        theme: &'a AshellTheme,
         slider_type: SliderType,
         is_mute: bool,
         toggle_mute: Message,
@@ -477,7 +461,6 @@ impl AudioSettings {
         };
 
         let mut ctrl = slider_control(
-            theme,
             mute_icon,
             Volume::MUTED.0..=Volume::NORMAL.0,
             volume.value(),
@@ -525,10 +508,10 @@ impl AudioSettings {
     }
 
     fn submenu<'a>(
-        theme: &'a AshellTheme,
         entries: Vec<SubmenuEntry<Message>>,
         more_msg: Option<Message>,
     ) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         let entries: Element<'a, Message> = Column::with_children(
             entries
                 .into_iter()
@@ -537,8 +520,8 @@ impl AudioSettings {
                         container(
                             row![e.icon.to_text(), text(e.name)]
                                 .align_y(Alignment::Center)
-                                .spacing(theme.space.md)
-                                .padding([theme.space.xxs, theme.space.sm]),
+                                .spacing(space.md)
+                                .padding([space.xxs, space.sm]),
                         )
                         .style(|theme: &Theme| container::Style {
                             text_color: Some(theme.palette().success),
@@ -546,7 +529,7 @@ impl AudioSettings {
                         })
                         .into()
                     } else {
-                        styled_button(theme, e.name)
+                        styled_button(e.name)
                             .icon(e.icon, IconPosition::Before)
                             .on_press(e.msg)
                             .width(Length::Fill)
@@ -555,18 +538,16 @@ impl AudioSettings {
                 })
                 .collect::<Vec<_>>(),
         )
-        .spacing(theme.space.xxs)
+        .spacing(space.xxs)
         .into();
 
         match more_msg {
             Some(more_msg) => column!(
                 entries,
                 divider(),
-                styled_button(theme, "More")
-                    .on_press(more_msg)
-                    .width(Length::Fill),
+                styled_button("More").on_press(more_msg).width(Length::Fill),
             )
-            .spacing(theme.space.sm)
+            .spacing(space.sm)
             .into(),
             _ => entries,
         }

--- a/src/modules/settings/bluetooth.rs
+++ b/src/modules/settings/bluetooth.rs
@@ -10,7 +10,7 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         bluetooth::{BluetoothCommand, BluetoothDevice, BluetoothService, BluetoothState},
     },
-    theme::use_theme,
+    theme::{AshellTheme, use_theme},
     utils::IndicatorState,
 };
 use iced::{
@@ -210,7 +210,14 @@ impl BluetoothSettings {
     }
 
     fn bluetooth_menu<'a>(&'a self, id: SurfaceId) -> Option<Element<'a, Message>> {
-        let theme = use_theme(|t| t.clone());
+        use_theme(|theme| self.bluetooth_menu_with_theme(id, theme))
+    }
+
+    fn bluetooth_menu_with_theme<'a>(
+        &'a self,
+        id: SurfaceId,
+        theme: &AshellTheme,
+    ) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
             let connected_devices = service
                 .devices
@@ -372,7 +379,7 @@ impl BluetoothSettings {
     }
 
     fn battery_level<'a>(battery: u8) -> Element<'a, Message> {
-        let space_xs = use_theme(|t| t.space.xs);
+        let space = use_theme(|t| t.space);
         container(
             row!(
                 icon(match battery {
@@ -384,7 +391,7 @@ impl BluetoothSettings {
                 }),
                 text(format!("{battery}%"))
             )
-            .spacing(space_xs)
+            .spacing(space.xs)
             .width(Length::Shrink),
         )
         .style(move |theme: &Theme| container::Style {

--- a/src/modules/settings/bluetooth.rs
+++ b/src/modules/settings/bluetooth.rs
@@ -272,7 +272,7 @@ impl BluetoothSettings {
                                 .push(
                                     text(d.name.clone())
                                         .color_maybe(if d.connected {
-                                            Some(theme.get_theme().palette().success)
+                                            Some(theme.iced_theme.palette().success)
                                         } else {
                                             None
                                         })
@@ -282,7 +282,7 @@ impl BluetoothSettings {
                                 .push(
                                     icon_button(StaticIcon::Remove)
                                         .on_press(Message::RemoveDevice(d.path.clone()))
-                                        .color(theme.get_theme().palette().danger)
+                                        .color(theme.iced_theme.palette().danger)
                                         .size(ButtonSize::Small),
                                 )
                                 .align_y(Vertical::Center)

--- a/src/modules/settings/bluetooth.rs
+++ b/src/modules/settings/bluetooth.rs
@@ -10,7 +10,7 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         bluetooth::{BluetoothCommand, BluetoothDevice, BluetoothService, BluetoothState},
     },
-    theme::AshellTheme,
+    theme::use_theme,
     utils::IndicatorState,
 };
 use iced::{
@@ -170,7 +170,6 @@ impl BluetoothSettings {
     pub fn quick_setting_button<'a>(
         &'a self,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         sub_menu: Option<SubMenu>,
     ) -> Option<(Element<'a, Message>, Option<Element<'a, Message>>)> {
         if let Some(service) = &self.service
@@ -192,7 +191,6 @@ impl BluetoothSettings {
 
             Some((
                 quick_setting_button(
-                    theme,
                     StaticIcon::Bluetooth,
                     "Bluetooth".to_owned(),
                     device_name,
@@ -204,18 +202,15 @@ impl BluetoothSettings {
                 ),
                 sub_menu
                     .filter(|menu_type| *menu_type == SubMenu::Bluetooth)
-                    .and_then(|_| self.bluetooth_menu(id, theme)),
+                    .and_then(|_| self.bluetooth_menu(id)),
             ))
         } else {
             None
         }
     }
 
-    fn bluetooth_menu<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    fn bluetooth_menu<'a>(&'a self, id: SurfaceId) -> Option<Element<'a, Message>> {
+        let theme = use_theme(|t| t.clone());
         self.service.as_ref().map(|service| {
             let connected_devices = service
                 .devices
@@ -248,14 +243,11 @@ impl BluetoothSettings {
                             ""
                         })
                         .size(theme.font_size.xs),
-                        icon_button(
-                            theme,
-                            if service.discovering {
-                                StaticIcon::Close
-                            } else {
-                                StaticIcon::Refresh
-                            }
-                        )
+                        icon_button(if service.discovering {
+                            StaticIcon::Close
+                        } else {
+                            StaticIcon::Refresh
+                        })
                         .on_press(if service.discovering {
                             Message::StopDiscovery
                         } else {
@@ -268,34 +260,28 @@ impl BluetoothSettings {
                 )
                 .push(if some_known {
                     let known_device_entry = |d: &BluetoothDevice| {
-                        styled_button(
-                            theme,
-                            Element::from(
-                                Row::with_capacity(3)
-                                    .push(
-                                        text(d.name.clone())
-                                            .color_maybe(if d.connected {
-                                                Some(theme.get_theme().palette().success)
-                                            } else {
-                                                None
-                                            })
-                                            .width(Length::Fill),
-                                    )
-                                    .push(
-                                        d.battery
-                                            .map(|battery| Self::battery_level(theme, battery)),
-                                    )
-                                    .push(
-                                        icon_button(theme, StaticIcon::Remove)
-                                            .on_press(Message::RemoveDevice(d.path.clone()))
-                                            .color(theme.get_theme().palette().danger)
-                                            .size(ButtonSize::Small),
-                                    )
-                                    .align_y(Vertical::Center)
-                                    .spacing(theme.space.xs)
-                                    .width(Length::Fill),
-                            ),
-                        )
+                        styled_button(Element::from(
+                            Row::with_capacity(3)
+                                .push(
+                                    text(d.name.clone())
+                                        .color_maybe(if d.connected {
+                                            Some(theme.get_theme().palette().success)
+                                        } else {
+                                            None
+                                        })
+                                        .width(Length::Fill),
+                                )
+                                .push(d.battery.map(Self::battery_level))
+                                .push(
+                                    icon_button(StaticIcon::Remove)
+                                        .on_press(Message::RemoveDevice(d.path.clone()))
+                                        .color(theme.get_theme().palette().danger)
+                                        .size(ButtonSize::Small),
+                                )
+                                .align_y(Vertical::Center)
+                                .spacing(theme.space.xs)
+                                .width(Length::Fill),
+                        ))
                         .on_press(if d.connected {
                             Message::DisconnectDevice(d.path.clone())
                         } else {
@@ -346,17 +332,14 @@ impl BluetoothSettings {
                             container(
                                 scrollable(
                                     Column::with_children(available_devices.map(|d| {
-                                        styled_button(
-                                            theme,
-                                            Element::from(
-                                                row![
-                                                    text(d.name.clone()).width(Length::Fill),
-                                                    text("Pair").size(theme.font_size.xs),
-                                                ]
-                                                .align_y(Vertical::Center)
-                                                .spacing(theme.space.xs),
-                                            ),
-                                        )
+                                        styled_button(Element::from(
+                                            row![
+                                                text(d.name.clone()).width(Length::Fill),
+                                                text("Pair").size(theme.font_size.xs),
+                                            ]
+                                            .align_y(Vertical::Center)
+                                            .spacing(theme.space.xs),
+                                        ))
                                         .on_press(Message::PairDevice(d.path.clone()))
                                         .width(Length::Fill)
                                         .into()
@@ -379,7 +362,7 @@ impl BluetoothSettings {
                 })
                 .push(self.config.more_cmd.as_ref().map(|_| divider()))
                 .push(self.config.more_cmd.as_ref().map(|_| {
-                    styled_button(theme, "More")
+                    styled_button("More")
                         .on_press(Message::More(id))
                         .width(Length::Fill)
                 }))
@@ -388,7 +371,8 @@ impl BluetoothSettings {
         })
     }
 
-    fn battery_level<'a>(theme: &AshellTheme, battery: u8) -> Element<'a, Message> {
+    fn battery_level<'a>(battery: u8) -> Element<'a, Message> {
+        let space_xs = use_theme(|t| t.space.xs);
         container(
             row!(
                 icon(match battery {
@@ -400,7 +384,7 @@ impl BluetoothSettings {
                 }),
                 text(format!("{battery}%"))
             )
-            .spacing(theme.space.xs)
+            .spacing(space_xs)
             .width(Length::Shrink),
         )
         .style(move |theme: &Theme| container::Style {
@@ -414,10 +398,7 @@ impl BluetoothSettings {
         .into()
     }
 
-    pub fn bluetooth_indicator<'a>(
-        &'a self,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn bluetooth_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         if let Some(service) = &self.service
             && service.state == BluetoothState::Active
         {
@@ -426,7 +407,6 @@ impl BluetoothSettings {
             if connected_count > 0 {
                 Some(
                     format_indicator(
-                        theme,
                         self.config.indicator_format,
                         StaticIcon::BluetoothConnected,
                         text(format!("{}", connected_count)).into(),

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -5,7 +5,6 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         brightness::{BrightnessCommand, BrightnessService},
     },
-    theme::AshellTheme,
     utils::IndicatorState,
     utils::remote_value,
 };
@@ -117,10 +116,9 @@ impl BrightnessSettings {
         }
     }
 
-    pub fn slider<'a>(&'a self, theme: &'a AshellTheme) -> Option<Element<'a, Message>> {
+    pub fn slider<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
             slider_control(
-                theme,
                 StaticIcon::Brightness,
                 0..=service.max,
                 service.current.value(),
@@ -131,15 +129,11 @@ impl BrightnessSettings {
         })
     }
 
-    pub fn brightness_indicator<'a>(
-        &'a self,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn brightness_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
             let scroll_handler = Self::on_scroll(service.current.value(), service.max);
 
             format_indicator(
-                theme,
                 self.config,
                 StaticIcon::Brightness,
                 Self::percent_text(service).into(),

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -21,7 +21,7 @@ use crate::{
         power::{PowerSettings, PowerSettingsConfig},
     },
     services::idle_inhibitor::IdleInhibitorManager,
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Element, Length, Subscription, SurfaceId, Task, Theme,
@@ -514,16 +514,11 @@ impl Settings {
         }
     }
 
-    pub fn menu_view<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-        position: Position,
-    ) -> Element<'a, Message> {
+    pub fn menu_view<'a>(&'a self, id: SurfaceId, position: Position) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         container(if let Some(dialog) = &self.network_dialog {
             password_dialog::view(
                 id,
-                theme,
                 &dialog.ssid,
                 dialog.password.as_deref().unwrap_or(""),
                 self.network_dialog_show_password,
@@ -533,39 +528,36 @@ impl Settings {
         } else {
             let battery_data = self
                 .power
-                .battery_menu_indicator(theme)
+                .battery_menu_indicator()
                 .map(|e| e.map(Message::Power));
             let right_buttons = Row::with_capacity(2)
                 .push(
                     self.lock_cmd
                         .as_ref()
-                        .map(|_| icon_button(theme, StaticIcon::Lock).on_press(Message::Lock)),
+                        .map(|_| icon_button(StaticIcon::Lock).on_press(Message::Lock)),
                 )
                 .push(
-                    icon_button(
-                        theme,
-                        if self.sub_menu == Some(SubMenu::Power) {
-                            StaticIcon::Close
-                        } else {
-                            StaticIcon::Power
-                        },
-                    )
+                    icon_button(if self.sub_menu == Some(SubMenu::Power) {
+                        StaticIcon::Close
+                    } else {
+                        StaticIcon::Power
+                    })
                     .on_press(Message::ToggleSubMenu(SubMenu::Power)),
                 )
-                .spacing(theme.space.xs);
+                .spacing(space.xs);
 
             let header = Row::with_capacity(3)
                 .push(battery_data)
                 .push(Space::new().width(Length::Fill))
                 .push(right_buttons)
-                .spacing(theme.space.xs)
+                .spacing(space.xs)
                 .width(Length::Fill);
 
-            let (sink_slider, source_slider) = self.audio.sliders(theme, self.sub_menu);
+            let (sink_slider, source_slider) = self.audio.sliders(self.sub_menu);
 
             let wifi_setting_button = self
                 .network
-                .wifi_quick_setting_button(id, theme, self.sub_menu)
+                .wifi_quick_setting_button(id, self.sub_menu)
                 .map(|(button, submenu)| {
                     (
                         button.map(Message::Network),
@@ -573,19 +565,18 @@ impl Settings {
                     )
                 });
             let quick_settings = quick_settings_section(
-                theme,
                 vec![
                     wifi_setting_button,
-                    self.bluetooth
-                        .quick_setting_button(id, theme, self.sub_menu)
-                        .map(|(button, submenu)| {
+                    self.bluetooth.quick_setting_button(id, self.sub_menu).map(
+                        |(button, submenu)| {
                             (
                                 button.map(Message::Bluetooth),
                                 submenu.map(|e| e.map(Message::Bluetooth)),
                             )
-                        }),
+                        },
+                    ),
                     self.network
-                        .vpn_quick_setting_button(id, theme, self.sub_menu)
+                        .vpn_quick_setting_button(id, self.sub_menu)
                         .map(|(button, submenu)| {
                             (
                                 button.map(Message::Network),
@@ -593,12 +584,11 @@ impl Settings {
                             )
                         }),
                     self.network
-                        .airplane_mode_quick_setting_button(theme)
+                        .airplane_mode_quick_setting_button()
                         .map(|(button, _)| (button.map(Message::Network), None)),
                     self.idle_inhibitor.as_ref().map(|idle_inhibitor| {
                         (
                             quick_setting_button(
-                                theme,
                                 if idle_inhibitor.is_inhibited() {
                                     StaticIcon::EyeOpened
                                 } else {
@@ -614,14 +604,12 @@ impl Settings {
                             None,
                         )
                     }),
-                    self.power
-                        .quick_setting_button(theme)
-                        .map(|(button, submenu)| {
-                            (
-                                button.map(Message::Power),
-                                submenu.map(|e| e.map(Message::Power)),
-                            )
-                        }),
+                    self.power.quick_setting_button().map(|(button, submenu)| {
+                        (
+                            button.map(Message::Power),
+                            submenu.map(|e| e.map(Message::Power)),
+                        )
+                    }),
                 ]
                 .into_iter()
                 .flatten()
@@ -633,7 +621,6 @@ impl Settings {
                         .unwrap_or(false);
                     (
                         quick_setting_button(
-                            theme,
                             DynamicIcon(button.icon.clone()),
                             button.name.clone(),
                             button.tooltip.clone(),
@@ -664,16 +651,14 @@ impl Settings {
                         .filter(|menu_type| *menu_type == SubMenu::PeripheralMenu)
                         .and_then(|_| {
                             self.power
-                                .peripheral_menu(theme)
-                                .map(|e| sub_menu_wrapper(theme, e.map(Message::Power)))
+                                .peripheral_menu()
+                                .map(|e| sub_menu_wrapper(e.map(Message::Power)))
                         }),
                 )
                 .push(
                     self.sub_menu
                         .filter(|menu_type| *menu_type == SubMenu::Power)
-                        .map(|_| {
-                            sub_menu_wrapper(theme, self.power.menu(theme).map(Message::Power))
-                        }),
+                        .map(|_| sub_menu_wrapper(self.power.menu().map(Message::Power))),
                 )
                 .push(top_sink_slider)
                 .push(
@@ -681,8 +666,8 @@ impl Settings {
                         .filter(|menu_type| *menu_type == SubMenu::Sinks)
                         .and_then(|_| {
                             self.audio
-                                .sinks_submenu(id, theme)
-                                .map(|submenu| sub_menu_wrapper(theme, submenu.map(Message::Audio)))
+                                .sinks_submenu(id)
+                                .map(|submenu| sub_menu_wrapper(submenu.map(Message::Audio)))
                         }),
                 )
                 .push(bottom_sink_slider)
@@ -692,25 +677,22 @@ impl Settings {
                         .filter(|menu_type| *menu_type == SubMenu::Sources)
                         .and_then(|_| {
                             self.audio
-                                .sources_submenu(id, theme)
-                                .map(|submenu| sub_menu_wrapper(theme, submenu.map(Message::Audio)))
+                                .sources_submenu(id)
+                                .map(|submenu| sub_menu_wrapper(submenu.map(Message::Audio)))
                         }),
                 )
                 .push(bottom_source_slider)
-                .push(
-                    self.brightness
-                        .slider(theme)
-                        .map(|e| e.map(Message::Brightness)),
-                )
+                .push(self.brightness.slider().map(|e| e.map(Message::Brightness)))
                 .push(quick_settings)
-                .spacing(theme.space.md)
+                .spacing(space.md)
                 .into()
         })
         .width(MenuSize::Medium)
         .into()
     }
 
-    pub fn view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn view<'a>(&'a self) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         let mut row = Row::with_capacity(self.indicators.len());
 
         for indicator in &self.indicators {
@@ -742,10 +724,8 @@ impl Settings {
                     }
                 }
                 SettingsIndicator::Audio => {
-                    if let Some(element) = self
-                        .audio
-                        .sink_indicator(theme)
-                        .map(|e| e.map(Message::Audio))
+                    if let Some(element) =
+                        self.audio.sink_indicator().map(|e| e.map(Message::Audio))
                     {
                         row = row.push(element);
                     }
@@ -753,7 +733,7 @@ impl Settings {
                 SettingsIndicator::Network => {
                     if let Some(element) = self
                         .network
-                        .connection_indicator(theme)
+                        .connection_indicator()
                         .map(|e| e.map(Message::Network))
                     {
                         row = row.push(element);
@@ -762,7 +742,7 @@ impl Settings {
                 SettingsIndicator::Vpn => {
                     if let Some(element) = self
                         .network
-                        .vpn_indicator(theme)
+                        .vpn_indicator()
                         .map(|e| e.map(Message::Network))
                     {
                         row = row.push(element);
@@ -771,17 +751,15 @@ impl Settings {
                 SettingsIndicator::Bluetooth => {
                     if let Some(element) = self
                         .bluetooth
-                        .bluetooth_indicator(theme)
+                        .bluetooth_indicator()
                         .map(|e| e.map(Message::Bluetooth))
                     {
                         row = row.push(element);
                     }
                 }
                 SettingsIndicator::Microphone => {
-                    if let Some(element) = self
-                        .audio
-                        .source_indicator(theme)
-                        .map(|e| e.map(Message::Audio))
+                    if let Some(element) =
+                        self.audio.source_indicator().map(|e| e.map(Message::Audio))
                     {
                         row = row.push(element);
                     }
@@ -789,7 +767,7 @@ impl Settings {
                 SettingsIndicator::Battery => {
                     if let Some(element) = self
                         .power
-                        .battery_indicator(theme)
+                        .battery_indicator()
                         .map(|e| e.map(Message::Power))
                     {
                         row = row.push(element);
@@ -798,7 +776,7 @@ impl Settings {
                 SettingsIndicator::PeripheralBattery => {
                     if let Some(element) = self
                         .power
-                        .peripheral_indicators(theme)
+                        .peripheral_indicators()
                         .map(|e| e.map(Message::Power))
                     {
                         row = row.push(element);
@@ -807,7 +785,7 @@ impl Settings {
                 SettingsIndicator::Brightness => {
                     if let Some(element) = self
                         .brightness
-                        .brightness_indicator(theme)
+                        .brightness_indicator()
                         .map(|e| e.map(Message::Brightness))
                     {
                         row = row.push(element);
@@ -816,7 +794,7 @@ impl Settings {
             }
         }
 
-        row.spacing(theme.space.xs).into()
+        row.spacing(space.xs).into()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
@@ -831,13 +809,13 @@ impl Settings {
 }
 
 fn quick_settings_section<'a>(
-    theme: &'a AshellTheme,
     buttons: Vec<(Element<'a, Message>, Option<Element<'a, Message>>)>,
 ) -> Element<'a, Message> {
+    let space = use_theme(|t| t.space);
     // TODO trying to read this function gives me a headache; there's surely
     // a better way to do this, maybe with Iterator::chunks or something?
     // I might be way off though, I still don't fully understand how this works.
-    let mut section = Column::with_capacity(buttons.len() * 3).spacing(theme.space.xs);
+    let mut section = Column::with_capacity(buttons.len() * 3).spacing(space.xs);
 
     let mut before: Option<(Element<'a, Message>, Option<Element<'a, Message>>)> = None;
 
@@ -847,15 +825,15 @@ fn quick_settings_section<'a>(
                 section = section.push(
                     row![before_button, button]
                         .width(Length::Fill)
-                        .spacing(theme.space.xs),
+                        .spacing(space.xs),
                 );
 
                 if let Some(menu) = before_menu {
-                    section = section.push(sub_menu_wrapper(theme, menu));
+                    section = section.push(sub_menu_wrapper(menu));
                 }
 
                 if let Some(menu) = menu {
-                    section = section.push(sub_menu_wrapper(theme, menu));
+                    section = section.push(sub_menu_wrapper(menu));
                 }
             }
             _ => {
@@ -868,11 +846,11 @@ fn quick_settings_section<'a>(
         section = section.push(
             row![before_button, space::horizontal()]
                 .width(Length::Fill)
-                .spacing(theme.space.xs),
+                .spacing(space.xs),
         );
 
         if let Some(menu) = before_menu {
-            section = section.push(sub_menu_wrapper(theme, menu));
+            section = section.push(sub_menu_wrapper(menu));
         }
     }
 

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -13,7 +13,7 @@ use crate::{
             NetworkService, Vpn, dbus::ConnectivityState,
         },
     },
-    theme::AshellTheme,
+    theme::use_theme,
     utils::IndicatorState,
 };
 use iced::{
@@ -303,10 +303,7 @@ impl NetworkSettings {
         }
     }
 
-    pub fn connection_indicator<'a>(
-        &'a self,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn connection_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().and_then(|service| {
             if service.airplane_mode || !service.wifi_present {
                 None
@@ -327,7 +324,6 @@ impl NetworkSettings {
                     let strength_text = strength.map_or("100%".to_string(), |s| format!("{}%", s));
 
                     format_indicator(
-                        theme,
                         self.config.indicator_format,
                         icon_type,
                         text(strength_text).into(),
@@ -337,7 +333,6 @@ impl NetworkSettings {
                     .into()
                 } else {
                     format_indicator(
-                        theme,
                         self.config.indicator_format,
                         StaticIcon::Wifi0,
                         text("0%").into(),
@@ -350,7 +345,7 @@ impl NetworkSettings {
         })
     }
 
-    pub fn vpn_indicator<'a>(&'a self, _: &AshellTheme) -> Option<Element<'a, Message>> {
+    pub fn vpn_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().and_then(|service| {
             service
                 .active_connections
@@ -372,7 +367,6 @@ impl NetworkSettings {
     pub fn wifi_quick_setting_button<'a>(
         &'a self,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         sub_menu: Option<SubMenu>,
     ) -> Option<(Element<'a, Message>, Option<Element<'a, Message>>)> {
         self.service.as_ref().and_then(|service| {
@@ -386,7 +380,6 @@ impl NetworkSettings {
 
                 Some((
                     quick_setting_button(
-                        theme,
                         active_connection.map_or_else(|| StaticIcon::Wifi0, |(_, _, icon)| icon),
                         "Wi-Fi".to_string(),
                         active_connection.map(|(name, _, _)| name.to_string()),
@@ -402,7 +395,6 @@ impl NetworkSettings {
                             Self::wifi_menu(
                                 service,
                                 id,
-                                theme,
                                 active_connection
                                     .map(|(name, strength, _)| (name.as_str(), *strength)),
                                 self.config.wifi_more_cmd.is_some(),
@@ -418,7 +410,6 @@ impl NetworkSettings {
     pub fn vpn_quick_setting_button<'a>(
         &'a self,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         sub_menu: Option<SubMenu>,
     ) -> Option<(Element<'a, Message>, Option<Element<'a, Message>>)> {
         self.service.as_ref().and_then(|service| {
@@ -457,7 +448,6 @@ impl NetworkSettings {
 
                     (
                         quick_setting_button(
-                            theme,
                             StaticIcon::Vpn,
                             "VPN".to_string(),
                             subtitle,
@@ -479,12 +469,7 @@ impl NetworkSettings {
                         sub_menu
                             .filter(|menu_type| *menu_type == SubMenu::Vpn)
                             .map(|_| {
-                                Self::vpn_menu(
-                                    service,
-                                    id,
-                                    theme,
-                                    self.config.vpn_more_cmd.is_some(),
-                                )
+                                Self::vpn_menu(service, id, self.config.vpn_more_cmd.is_some())
                             }),
                     )
                 })
@@ -493,7 +478,6 @@ impl NetworkSettings {
 
     pub fn airplane_mode_quick_setting_button<'a>(
         &'a self,
-        theme: &'a AshellTheme,
     ) -> Option<(Element<'a, Message>, Option<Element<'a, Message>>)> {
         if self.config.remove_airplane_btn {
             None
@@ -501,7 +485,6 @@ impl NetworkSettings {
             self.service.as_ref().map(|service| {
                 (
                     quick_setting_button(
-                        theme,
                         StaticIcon::Airplane,
                         "Airplane Mode".to_string(),
                         None,
@@ -519,10 +502,10 @@ impl NetworkSettings {
     fn wifi_menu<'a>(
         service: &'a NetworkService,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         active_connection: Option<(&str, u8)>,
         show_more_button: bool,
     ) -> Element<'a, Message> {
+        let (space, font_size) = use_theme(|t| (t.space, t.font_size));
         let main = column!(
             row!(
                 text("Nearby Wifi").width(Length::Fill),
@@ -531,10 +514,10 @@ impl NetworkSettings {
                 } else {
                     ""
                 })
-                .size(theme.font_size.sm),
-                icon_button(theme, StaticIcon::Refresh).on_press(Message::ScanNearByWiFi)
+                .size(font_size.sm),
+                icon_button(StaticIcon::Refresh).on_press(Message::ScanNearByWiFi)
             )
-            .spacing(theme.space.xs)
+            .spacing(space.xs)
             .width(Length::Fill)
             .align_y(Alignment::Center),
             divider(),
@@ -558,7 +541,6 @@ impl NetworkSettings {
                             });
 
                             styled_button(
-                                theme,
                                 Element::from(
                                     container(
                                         row!(
@@ -601,21 +583,21 @@ impl NetworkSettings {
                         })
                         .collect::<Vec<Element<'a, Message>>>()
                 })
-                .spacing(theme.space.xxs)
-            ).spacing(theme.space.xs))
+                .spacing(space.xxs)
+            ).spacing(space.xs))
             .max_height(200),
         )
-        .spacing(theme.space.xs);
+        .spacing(space.xs);
 
         if show_more_button {
             column!(
                 main,
                 divider(),
-                styled_button(theme, "More")
+                styled_button("More")
                     .on_press(Message::WiFiMore(id))
                     .width(Length::Fill)
             )
-            .spacing(theme.space.sm)
+            .spacing(space.sm)
             .into()
         } else {
             main.into()
@@ -625,9 +607,9 @@ impl NetworkSettings {
     fn vpn_menu<'a>(
         service: &'a NetworkService,
         id: SurfaceId,
-        theme: &'a AshellTheme,
         show_more_button: bool,
     ) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         // Create HashSet of active VPN names for O(1) lookup
         let active_vpn_names: std::collections::HashSet<&str> = service
             .active_connections
@@ -666,12 +648,8 @@ impl NetworkSettings {
                 })
                 .collect::<Vec<Element<'a, Message>>>(),
         )
-        .spacing(theme.space.xs)
-        .padding(
-            Padding::default()
-                .right(theme.space.md)
-                .left(theme.space.xs),
-        );
+        .spacing(space.xs)
+        .padding(Padding::default().right(space.md).left(space.xs));
 
         let main = container(scrollable(vpn_list))
             .height(Length::Shrink)
@@ -681,11 +659,11 @@ impl NetworkSettings {
             column!(
                 main,
                 divider(),
-                styled_button(theme, "More")
+                styled_button("More")
                     .on_press(Message::VpnMore(id))
                     .width(Length::Fill)
             )
-            .spacing(theme.space.sm)
+            .spacing(space.sm)
             .into()
         } else {
             main.into()

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -14,7 +14,7 @@ use crate::{
             UPowerService,
         },
     },
-    theme::AshellTheme,
+    theme::use_theme,
     utils::{self, IndicatorState, format_duration},
 };
 use iced::{
@@ -165,37 +165,39 @@ impl PowerSettings {
         }
     }
 
-    pub fn menu<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn menu<'a>(&'a self) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         column!(
-            styled_button(theme, "Suspend")
+            styled_button("Suspend")
                 .icon(StaticIcon::Suspend, IconPosition::Before)
                 .on_press(Message::Suspend)
                 .width(Length::Fill),
-            styled_button(theme, "Hibernate")
+            styled_button("Hibernate")
                 .icon(StaticIcon::Hibernate, IconPosition::Before)
                 .on_press(Message::Hibernate)
                 .width(Length::Fill),
-            styled_button(theme, "Reboot")
+            styled_button("Reboot")
                 .icon(StaticIcon::Reboot, IconPosition::Before)
                 .on_press(Message::Reboot)
                 .width(Length::Fill),
-            styled_button(theme, "Shutdown")
+            styled_button("Shutdown")
                 .icon(StaticIcon::Power, IconPosition::Before)
                 .on_press(Message::Shutdown)
                 .width(Length::Fill),
             divider(),
-            styled_button(theme, "Logout")
+            styled_button("Logout")
                 .icon(StaticIcon::Logout, IconPosition::Before)
                 .on_press(Message::Logout)
                 .width(Length::Fill),
         )
-        .padding(theme.space.xs)
+        .padding(space.xs)
         .width(Length::Fill)
-        .spacing(theme.space.xs)
+        .spacing(space.xs)
         .into()
     }
 
-    pub fn peripheral_menu<'a>(&'a self, theme: &'a AshellTheme) -> Option<Element<'a, Message>> {
+    pub fn peripheral_menu<'a>(&'a self) -> Option<Element<'a, Message>> {
+        let space = use_theme(|t| t.space);
         self.service
             .as_ref()
             .filter(|s| !s.peripherals.is_empty())
@@ -208,23 +210,21 @@ impl PowerSettings {
                             row![
                                 icon(p.kind.get_icon()),
                                 text(p.name.to_string()).width(Length::Fill),
-                                self.menu_indicator(theme, p.data, None),
+                                self.menu_indicator(p.data, None),
                             ]
                             .align_y(Vertical::Center)
-                            .spacing(theme.space.sm)
+                            .spacing(space.sm)
                             .into()
                         })
                         .collect::<Vec<Element<Message>>>(),
                 )
-                .spacing(theme.space.xs)
+                .spacing(space.xs)
                 .into()
             })
     }
 
-    pub fn peripheral_indicators<'a>(
-        &self,
-        ashell_theme: &AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn peripheral_indicators<'a>(&self) -> Option<Element<'a, Message>> {
+        let space = use_theme(|t| t.space);
         let get_indicators = |kinds: Option<&[PeripheralDeviceKind]>| {
             self.service
                 .as_ref()
@@ -236,7 +236,7 @@ impl PowerSettings {
                 })
                 .map(|service| {
                     let mut row = Row::with_capacity(service.peripherals.len())
-                        .spacing(ashell_theme.space.xxs)
+                        .spacing(space.xxs)
                         .align_y(Alignment::Center);
 
                     for p in service.peripherals.iter() {
@@ -255,14 +255,14 @@ impl PowerSettings {
                                             icon(p.kind.get_icon()),
                                             text(format!("{}%", p.data.capacity))
                                         )
-                                        .spacing(ashell_theme.space.xxs)
+                                        .spacing(space.xxs)
                                         .align_y(Alignment::Center)
                                         .into(),
                                         SettingsFormat::IconAndPercentage => row!(
                                             icon(p.get_icon_state()),
                                             text(format!("{}%", p.data.capacity))
                                         )
-                                        .spacing(ashell_theme.space.xxs)
+                                        .spacing(space.xxs)
                                         .align_y(Alignment::Center)
                                         .into(),
                                         SettingsFormat::Time => {
@@ -272,7 +272,7 @@ impl PowerSettings {
                                             icon(p.get_icon_state()),
                                             text(format_time_for_battery(&p.data))
                                         )
-                                        .spacing(ashell_theme.space.xxs)
+                                        .spacing(space.xxs)
                                         .align_y(Alignment::Center)
                                         .into(),
                                     })
@@ -304,10 +304,7 @@ impl PowerSettings {
         .map(|r| r.into())
     }
 
-    pub fn battery_indicator<'a>(
-        &self,
-        ashell_theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn battery_indicator<'a>(&self) -> Option<Element<'a, Message>> {
         self.service.as_ref().and_then(|service| {
             service.system_battery.map(|battery| {
                 let state = battery.get_indicator_state();
@@ -319,7 +316,6 @@ impl PowerSettings {
                 };
 
                 format_indicator(
-                    ashell_theme,
                     self.config.battery_format,
                     battery.get_icon(),
                     text(label).into(),
@@ -332,10 +328,10 @@ impl PowerSettings {
 
     fn menu_indicator<'a>(
         &self,
-        ashell_theme: &'a AshellTheme,
         battery: BatteryData,
         peripheral_icon: Option<StaticIcon>,
     ) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
         let state = battery.get_indicator_state();
 
         container({
@@ -344,7 +340,7 @@ impl PowerSettings {
                     .push(peripheral_icon.map(icon))
                     .push(icon(battery.get_icon()))
                     .push(text(format!("{}%", battery.capacity)))
-                    .spacing(ashell_theme.space.xxs),
+                    .spacing(space.xxs),
             )
             .style(move |theme: &Theme| container::Style {
                 text_color: Some(match state {
@@ -360,7 +356,7 @@ impl PowerSettings {
                     battery_info,
                     text(format!("Full in {}", format_duration(&remaining)))
                 )
-                .spacing(ashell_theme.space.md),
+                .spacing(space.md),
                 BatteryStatus::Discharging(remaining)
                     if battery.capacity < 95 && !remaining.is_zero() =>
                 {
@@ -368,27 +364,24 @@ impl PowerSettings {
                         battery_info,
                         text(format!("Empty in {}", format_duration(&remaining)))
                     )
-                    .spacing(ashell_theme.space.md)
+                    .spacing(space.md)
                 }
                 _ => row!(battery_info),
             }
         })
-        .padding([ashell_theme.space.xs, ashell_theme.space.xxs])
+        .padding([space.xs, space.xxs])
         .into()
     }
 
-    pub fn battery_menu_indicator<'a>(
-        &self,
-        ashell_theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn battery_menu_indicator<'a>(&self) -> Option<Element<'a, Message>> {
         self.service.as_ref().and_then(|service| {
             service
                 .system_battery
                 .map(|battery| {
-                    let indicator = self.menu_indicator(ashell_theme, battery, None);
+                    let indicator = self.menu_indicator(battery, None);
 
                     if !service.peripherals.is_empty() {
-                        styled_button(ashell_theme, indicator)
+                        styled_button(indicator)
                             .kind(ButtonKind::Solid)
                             .on_press(Message::TogglePeripheralMenu)
                             .into()
@@ -398,14 +391,11 @@ impl PowerSettings {
                 })
                 .or_else(|| {
                     if let Some(peripheral) = service.peripherals.first() {
-                        let indicator = self.menu_indicator(
-                            ashell_theme,
-                            peripheral.data,
-                            Some(peripheral.kind.get_icon()),
-                        );
+                        let indicator =
+                            self.menu_indicator(peripheral.data, Some(peripheral.kind.get_icon()));
 
                         Some(if service.peripherals.len() > 1 {
-                            styled_button(ashell_theme, indicator)
+                            styled_button(indicator)
                                 .kind(ButtonKind::Solid)
                                 .on_press(Message::TogglePeripheralMenu)
                                 .into()
@@ -446,13 +436,11 @@ impl PowerSettings {
 
     pub fn quick_setting_button<'a>(
         &'a self,
-        theme: &'a AshellTheme,
     ) -> Option<(Element<'a, Message>, Option<Element<'a, Message>>)> {
         self.service.as_ref().and_then(|service| {
             if !matches!(service.power_profile, PowerProfile::Unknown) {
                 Some((
                     quick_setting_button(
-                        theme,
                         convert::Into::<StaticIcon>::into(service.power_profile),
                         match service.power_profile {
                             PowerProfile::Balanced => "Balanced",

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -322,15 +322,14 @@ impl SystemInfo {
         label: String,
         value: String,
     ) -> Element<'a, Message> {
-        let (font_size_xl, space_xl, space_xs) =
-            use_theme(|t| (t.font_size.xl, t.space.xl, t.space.xs));
+        let (font_size, space) = use_theme(|t| (t.font_size, t.space));
         row!(
-            container(icon(info_icon).size(font_size_xl)).center_x(Length::Fixed(space_xl)),
+            container(icon(info_icon).size(font_size.xl)).center_x(Length::Fixed(space.xl)),
             text(label).width(Length::Fill),
             text(value)
         )
         .align_y(Alignment::Center)
-        .spacing(space_xs)
+        .spacing(space.xs)
         .into()
     }
 
@@ -340,7 +339,7 @@ impl SystemInfo {
         threshold: Option<(V, V, V)>,
         prefix: Option<&str>,
     ) -> Element<'a, Message> {
-        let space_xxs = use_theme(|t| t.space.xxs);
+        let space = use_theme(|t| t.space);
         let element = container(
             row!(
                 icon(info_icon),
@@ -350,7 +349,7 @@ impl SystemInfo {
                     text(format!("{display}{unit}"))
                 }
             )
-            .spacing(space_xxs),
+            .spacing(space.xxs),
         );
 
         if let Some((value, warn_threshold, alert_threshold)) = threshold {
@@ -372,11 +371,10 @@ impl SystemInfo {
     }
 
     pub fn menu_view(&'_ self) -> Element<'_, Message> {
-        let (font_size_lg, space_xs, space_xxs) =
-            use_theme(|t| (t.font_size.lg, t.space.xs, t.space.xxs));
+        let (font_size, space) = use_theme(|t| (t.font_size, t.space));
         container(
             column!(
-                text("System Info").size(font_size_lg),
+                text("System Info").size(font_size.lg),
                 divider(),
                 Column::with_capacity(6)
                     .push(Self::info_element(
@@ -441,7 +439,7 @@ impl SystemInfo {
                                 })
                                 .collect::<Vec<Element<_>>>(),
                         )
-                        .spacing(space_xxs),
+                        .spacing(space.xxs),
                     )
                     .push(self.data.network.as_ref().map(|network| {
                         Column::with_children(vec![
@@ -470,17 +468,17 @@ impl SystemInfo {
                             ),
                         ])
                     }))
-                    .spacing(space_xxs)
-                    .padding([0.0, space_xs])
+                    .spacing(space.xxs)
+                    .padding([0.0, space.xs])
             )
-            .spacing(space_xs),
+            .spacing(space.xs),
         )
         .width(MenuSize::Medium)
         .into()
     }
 
     pub fn view(&'_ self) -> Element<'_, Message> {
-        let space_xxs = use_theme(|t| t.space.xxs);
+        let space = use_theme(|t| t.space);
         let indicators = self.config.indicators.iter().filter_map(|i| match i {
             SystemInfoIndicator::Cpu => Some(Self::indicator_info_element(
                 StaticIcon::Cpu,
@@ -620,7 +618,7 @@ impl SystemInfo {
 
         Row::with_children(indicators)
             .align_y(Alignment::Center)
-            .spacing(space_xxs)
+            .spacing(space.xxs)
             .into()
     }
 

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -6,7 +6,7 @@ use crate::{
         CpuFormat, DiskFormat, MemoryFormat, SystemInfoIndicator, SystemInfoModuleConfig,
         TemperatureFormat,
     },
-    theme::AshellTheme,
+    theme::use_theme,
     utils,
 };
 use iced::{
@@ -318,29 +318,29 @@ impl SystemInfo {
     }
 
     fn info_element<'a>(
-        theme: &AshellTheme,
         info_icon: StaticIcon,
         label: String,
         value: String,
     ) -> Element<'a, Message> {
+        let (font_size_xl, space_xl, space_xs) =
+            use_theme(|t| (t.font_size.xl, t.space.xl, t.space.xs));
         row!(
-            container(icon(info_icon).size(theme.font_size.xl))
-                .center_x(Length::Fixed(theme.space.xl)),
+            container(icon(info_icon).size(font_size_xl)).center_x(Length::Fixed(space_xl)),
             text(label).width(Length::Fill),
             text(value)
         )
         .align_y(Alignment::Center)
-        .spacing(theme.space.xs)
+        .spacing(space_xs)
         .into()
     }
 
     fn indicator_info_element<'a, V: PartialOrd + 'a>(
-        theme: &AshellTheme,
         info_icon: StaticIcon,
         (display, unit): (impl std::fmt::Display + 'a, &str),
         threshold: Option<(V, V, V)>,
         prefix: Option<&str>,
     ) -> Element<'a, Message> {
+        let space_xxs = use_theme(|t| t.space.xxs);
         let element = container(
             row!(
                 icon(info_icon),
@@ -350,7 +350,7 @@ impl SystemInfo {
                     text(format!("{display}{unit}"))
                 }
             )
-            .spacing(theme.space.xxs),
+            .spacing(space_xxs),
         );
 
         if let Some((value, warn_threshold, alert_threshold)) = threshold {
@@ -371,14 +371,15 @@ impl SystemInfo {
         }
     }
 
-    pub fn menu_view(&'_ self, theme: &AshellTheme) -> Element<'_, Message> {
+    pub fn menu_view(&'_ self) -> Element<'_, Message> {
+        let (font_size_lg, space_xs, space_xxs) =
+            use_theme(|t| (t.font_size.lg, t.space.xs, t.space.xxs));
         container(
             column!(
-                text("System Info").size(theme.font_size.lg),
+                text("System Info").size(font_size_lg),
                 divider(),
                 Column::with_capacity(6)
                     .push(Self::info_element(
-                        theme,
                         StaticIcon::Cpu,
                         "CPU Usage".to_string(),
                         match self.config.cpu.format {
@@ -388,7 +389,6 @@ impl SystemInfo {
                         }
                     ))
                     .push(Self::info_element(
-                        theme,
                         StaticIcon::Mem,
                         "Memory Usage".to_string(),
                         match self.config.memory.format {
@@ -399,7 +399,6 @@ impl SystemInfo {
                         }
                     ))
                     .push(Self::info_element(
-                        theme,
                         StaticIcon::Mem,
                         "Swap memory Usage".to_string(),
                         match self.config.memory.format {
@@ -411,7 +410,6 @@ impl SystemInfo {
                     ))
                     .push(self.data.temperature.celsius.map(|cel| {
                         Self::info_element(
-                            theme,
                             StaticIcon::Temp,
                             "Temperature".to_string(),
                             match self.config.temperature.format {
@@ -429,7 +427,6 @@ impl SystemInfo {
                                 .iter()
                                 .map(|(mount_point, usage)| {
                                     Self::info_element(
-                                        theme,
                                         StaticIcon::Drive,
                                         format!("Disk Usage {mount_point}"),
                                         match self.config.disk.format {
@@ -444,18 +441,16 @@ impl SystemInfo {
                                 })
                                 .collect::<Vec<Element<_>>>(),
                         )
-                        .spacing(theme.space.xxs),
+                        .spacing(space_xxs),
                     )
                     .push(self.data.network.as_ref().map(|network| {
                         Column::with_children(vec![
                             Self::info_element(
-                                theme,
                                 StaticIcon::IpAddress,
                                 "IP Address".to_string(),
                                 network.ip.to_string(),
                             ),
                             Self::info_element(
-                                theme,
                                 StaticIcon::DownloadSpeed,
                                 "Download Speed".to_string(),
                                 if network.download_speed > 1000 {
@@ -465,7 +460,6 @@ impl SystemInfo {
                                 },
                             ),
                             Self::info_element(
-                                theme,
                                 StaticIcon::UploadSpeed,
                                 "Upload Speed".to_string(),
                                 if network.upload_speed > 1000 {
@@ -476,19 +470,19 @@ impl SystemInfo {
                             ),
                         ])
                     }))
-                    .spacing(theme.space.xxs)
-                    .padding([0.0, theme.space.xs])
+                    .spacing(space_xxs)
+                    .padding([0.0, space_xs])
             )
-            .spacing(theme.space.xs),
+            .spacing(space_xs),
         )
         .width(MenuSize::Medium)
         .into()
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme) -> Element<'_, Message> {
+    pub fn view(&'_ self) -> Element<'_, Message> {
+        let space_xxs = use_theme(|t| t.space.xxs);
         let indicators = self.config.indicators.iter().filter_map(|i| match i {
             SystemInfoIndicator::Cpu => Some(Self::indicator_info_element(
-                theme,
                 StaticIcon::Cpu,
                 match self.config.cpu.format {
                     CpuFormat::Percentage => (self.data.cpu_usage.percentage.to_string(), "%"),
@@ -503,7 +497,6 @@ impl SystemInfo {
             )),
 
             SystemInfoIndicator::Memory => Some(Self::indicator_info_element(
-                theme,
                 StaticIcon::Mem,
                 match self.config.memory.format {
                     MemoryFormat::Percentage => {
@@ -520,7 +513,6 @@ impl SystemInfo {
             )),
 
             SystemInfoIndicator::MemorySwap => Some(Self::indicator_info_element(
-                theme,
                 StaticIcon::Mem,
                 match self.config.memory.format {
                     MemoryFormat::Percentage => {
@@ -544,7 +536,6 @@ impl SystemInfo {
                     TemperatureFormat::Fahrenheit => utils::celsius_to_fahrenheit(cel),
                 };
                 Self::indicator_info_element(
-                    theme,
                     StaticIcon::Temp,
                     match self.config.temperature.format {
                         TemperatureFormat::Celsius => (temp_value, "°C"),
@@ -562,7 +553,6 @@ impl SystemInfo {
                 self.data.disks.iter().find_map(|(disk_mount, disk)| {
                     if disk_mount == &config.path {
                         Some(Self::indicator_info_element(
-                            theme,
                             StaticIcon::Drive,
                             match self.config.disk.format {
                                 DiskFormat::Percentage => (disk.percentage.to_string(), "%"),
@@ -582,7 +572,6 @@ impl SystemInfo {
             }
             SystemInfoIndicator::IpAddress => self.data.network.as_ref().map(|network| {
                 Self::indicator_info_element(
-                    theme,
                     StaticIcon::IpAddress,
                     (network.ip.to_string(), ""),
                     None::<(u32, u32, u32)>,
@@ -591,7 +580,6 @@ impl SystemInfo {
             }),
             SystemInfoIndicator::DownloadSpeed => self.data.network.as_ref().map(|network| {
                 Self::indicator_info_element(
-                    theme,
                     StaticIcon::DownloadSpeed,
                     (
                         if network.download_speed > 1000 {
@@ -611,7 +599,6 @@ impl SystemInfo {
             }),
             SystemInfoIndicator::UploadSpeed => self.data.network.as_ref().map(|network| {
                 Self::indicator_info_element(
-                    theme,
                     StaticIcon::UploadSpeed,
                     (
                         if network.upload_speed > 1000 {
@@ -633,7 +620,7 @@ impl SystemInfo {
 
         Row::with_children(indicators)
             .align_y(Alignment::Center)
-            .spacing(theme.space.xxs)
+            .spacing(space_xxs)
             .into()
     }
 

--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -5,7 +5,7 @@ use crate::{
         styled_button,
     },
     config::{TempoModuleConfig, WeatherIndicator, WeatherLocation},
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use chrono::{
     DateTime, Datelike, Days, FixedOffset, Local, Months, NaiveDate, NaiveDateTime, TimeZone, Utc,
@@ -162,14 +162,15 @@ impl Tempo {
         }
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme) -> Element<'_, Message> {
+    pub fn view(&'_ self) -> Element<'_, Message> {
+        let space_sm = use_theme(|t| t.space.sm);
         let display_text = self.time_str(self.current_format(), self.current_timezone_index);
 
         Row::with_capacity(2)
-            .push(self.weather_indicator(theme))
+            .push(self.weather_indicator())
             .push(text(display_text))
             .align_y(Vertical::Center)
-            .spacing(theme.space.sm)
+            .spacing(space_sm)
             .into()
     }
 
@@ -208,7 +209,8 @@ impl Tempo {
             })
     }
 
-    pub fn weather_indicator(&'_ self, theme: &AshellTheme) -> Option<Element<'_, Message>> {
+    pub fn weather_indicator(&'_ self) -> Option<Element<'_, Message>> {
+        let (font_size_sm, space_xxs) = use_theme(|t| (t.font_size.sm, t.space.xxs));
         if self.config.weather_location.is_none()
             || self.config.weather_indicator == WeatherIndicator::None
         {
@@ -221,28 +223,29 @@ impl Tempo {
                 Row::new()
                     .push(
                         weather_icon(data.current.weather_code, data.current.is_day > 0)
-                            .width(Length::Fixed(theme.font_size.sm)),
+                            .width(Length::Fixed(font_size_sm)),
                     )
                     .push(
                         (self.config.weather_indicator == WeatherIndicator::IconAndTemperature)
                             .then(|| {
                                 text(format!("{}°C", data.current.temperature_2m))
                                     .align_y(Vertical::Center)
-                                    .size(theme.font_size.sm)
+                                    .size(font_size_sm)
                             }),
                     )
                     .align_y(Vertical::Center)
-                    .spacing(theme.space.xxs)
+                    .spacing(space_xxs)
                     .into()
             })
     }
 
-    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn menu_view<'a>(&'a self) -> Element<'a, Message> {
+        let space_lg = use_theme(|t| t.space.lg);
         container(
             Row::with_capacity(2)
-                .push(self.calendar(theme))
-                .push(self.weather(theme))
-                .spacing(theme.space.lg),
+                .push(self.calendar())
+                .push(self.weather())
+                .spacing(space_lg),
         )
         .max_width(MenuSize::XLarge)
         .into()
@@ -268,7 +271,8 @@ impl Tempo {
             .unwrap_or_else(|| self.date.date_naive())
     }
 
-    fn calendar<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    fn calendar<'a>(&'a self) -> Element<'a, Message> {
+        let theme = use_theme(|t| t.clone());
         let selected_date = self
             .selected_date
             .unwrap_or(self.naive_date(self.current_timezone_index));
@@ -296,7 +300,7 @@ impl Tempo {
 
         let calendar = column![
             row![
-                icon_button::<Message>(theme, StaticIcon::LeftChevron)
+                icon_button::<Message>(StaticIcon::LeftChevron)
                     .kind(ButtonKind::Solid)
                     .on_press(Message::ChangeSelectDate(
                         selected_date.checked_sub_months(Months::new(1)),
@@ -309,7 +313,7 @@ impl Tempo {
                 .size(theme.font_size.md)
                 .width(Length::Fill)
                 .align_x(Horizontal::Center),
-                icon_button::<Message>(theme, StaticIcon::RightChevron)
+                icon_button::<Message>(StaticIcon::RightChevron)
                     .kind(ButtonKind::Solid)
                     .on_press(Message::ChangeSelectDate(
                         selected_date.checked_add_months(Months::new(1))
@@ -352,35 +356,30 @@ impl Tempo {
                                     let day = current;
                                     current = current.succ_opt().unwrap_or(current);
 
-                                    styled_button(
-                                        theme,
-                                        Element::from(
-                                            text(
-                                                day.format_localized("%d", self.config.locale)
-                                                    .to_string(),
-                                            )
-                                            .align_x(Horizontal::Center)
-                                            .color_maybe({
-                                                if day
-                                                    == self.naive_date(self.current_timezone_index)
-                                                {
-                                                    Some(theme.iced_theme.palette().success)
-                                                } else if day == selected_date {
-                                                    Some(theme.iced_theme.palette().primary)
-                                                } else if day.month0() != current_month {
-                                                    Some(
-                                                        theme
-                                                            .iced_theme
-                                                            .palette()
-                                                            .text
-                                                            .scale_alpha(0.2),
-                                                    )
-                                                } else {
-                                                    None
-                                                }
-                                            }),
-                                        ),
-                                    )
+                                    styled_button(Element::from(
+                                        text(
+                                            day.format_localized("%d", self.config.locale)
+                                                .to_string(),
+                                        )
+                                        .align_x(Horizontal::Center)
+                                        .color_maybe({
+                                            if day == self.naive_date(self.current_timezone_index) {
+                                                Some(theme.iced_theme.palette().success)
+                                            } else if day == selected_date {
+                                                Some(theme.iced_theme.palette().primary)
+                                            } else if day.month0() != current_month {
+                                                Some(
+                                                    theme
+                                                        .iced_theme
+                                                        .palette()
+                                                        .text
+                                                        .scale_alpha(0.2),
+                                                )
+                                            } else {
+                                                None
+                                            }
+                                        }),
+                                    ))
                                     .on_press_maybe(
                                         if day != self.naive_date(self.current_timezone_index) {
                                             Some(Message::ChangeSelectDate(Some(day)))
@@ -422,39 +421,33 @@ impl Tempo {
                         })
                         .into()
                     } else {
-                        styled_button(
-                            theme,
-                            format!("{}: {}", tz_name, self.time_str("%d %h %R", index)),
-                        )
-                        .width(Length::Fill)
-                        .on_press(Message::SetTimezone(index))
-                        .into()
+                        styled_button(format!("{}: {}", tz_name, self.time_str("%d %h %R", index)))
+                            .width(Length::Fill)
+                            .on_press(Message::SetTimezone(index))
+                            .into()
                     }
                 })
                 .collect::<Vec<Element<'a, Message>>>(),
         );
 
         column!(
-            styled_button(
-                theme,
-                Element::from(
-                    column!(
-                        text(
-                            self.date
-                                .format_localized("%A", self.config.locale)
-                                .to_string()
-                        )
-                        .size(theme.font_size.sm),
-                        text(
-                            self.date
-                                .format_localized("%d %B %Y", self.config.locale)
-                                .to_string()
-                        )
-                        .size(theme.font_size.md),
+            styled_button(Element::from(
+                column!(
+                    text(
+                        self.date
+                            .format_localized("%A", self.config.locale)
+                            .to_string()
                     )
-                    .spacing(theme.space.xs),
-                ),
-            )
+                    .size(theme.font_size.sm),
+                    text(
+                        self.date
+                            .format_localized("%d %B %Y", self.config.locale)
+                            .to_string()
+                    )
+                    .size(theme.font_size.md),
+                )
+                .spacing(theme.space.xs),
+            ),)
             .size(ButtonSize::Large)
             .kind(ButtonKind::Outline)
             .on_press_maybe(if self.selected_date.is_some() {
@@ -471,7 +464,9 @@ impl Tempo {
         .into()
     }
 
-    fn weather<'a>(&'a self, theme: &'a AshellTheme) -> Option<Element<'a, Message>> {
+    fn weather<'a>(&'a self) -> Option<Element<'a, Message>> {
+        let (space, font_size, opacity, radius_lg, radius_sm) =
+            use_theme(|t| (t.space, t.font_size, t.opacity, t.radius.lg, t.radius.sm));
         self.weather_data
             .as_ref()
             .zip(self.location.as_ref())
@@ -480,7 +475,7 @@ impl Tempo {
                     container(
                         row!(
                             weather_icon(data.current.weather_code, data.current.is_day > 0)
-                                .height(theme.font_size.xxl)
+                                .height(font_size.xxl)
                                 .width(Length::Shrink),
                             column!(
                                 text(format!(
@@ -493,7 +488,7 @@ impl Tempo {
                                     },
                                     data.current.time.format("%R")
                                 ))
-                                .size(theme.font_size.sm),
+                                .size(font_size.sm),
                                 text(weather_description(data.current.weather_code)),
                                 row!(
                                     text(format!("{} °C", data.current.temperature_2m)),
@@ -501,39 +496,39 @@ impl Tempo {
                                         "Feels like {}°C",
                                         data.current.apparent_temperature
                                     ))
-                                    .size(theme.font_size.sm)
+                                    .size(font_size.sm)
                                 )
                                 .align_y(Vertical::Bottom)
-                                .spacing(theme.space.sm),
+                                .spacing(space.sm),
                             )
                             .width(FillPortion(2))
-                            .spacing(theme.space.xs),
+                            .spacing(space.xs),
                             column!(
                                 row!(
                                     svg(Handle::from_memory(include_bytes!(
                                         "../../assets/weather_icon/drop.svg"
                                     )))
                                     .width(Length::Shrink)
-                                    .height(theme.font_size.lg),
+                                    .height(font_size.lg),
                                     column!(
                                         text("Humidity")
-                                            .size(theme.font_size.xs)
+                                            .size(font_size.xs)
                                             .align_x(Horizontal::Right)
                                             .width(Length::Fill),
                                         text(format!("{}%", data.current.relative_humidity_2m))
                                             .align_x(Horizontal::Right)
-                                            .size(theme.font_size.xs)
+                                            .size(font_size.xs)
                                             .width(Length::Fill),
                                     )
-                                    .spacing(theme.space.xxs)
+                                    .spacing(space.xxs)
                                 )
                                 .align_y(Vertical::Center)
-                                .spacing(theme.space.sm),
+                                .spacing(space.sm),
                                 row!(
                                     svg(Handle::from_memory(include_bytes!(
                                         "../../assets/weather_icon/wind.svg"
                                     )))
-                                    .height(theme.font_size.lg)
+                                    .height(font_size.lg)
                                     .width(Length::Shrink)
                                     .rotation(
                                         Rotation::Floating(
@@ -543,27 +538,27 @@ impl Tempo {
                                     ),
                                     column!(
                                         text("Wind")
-                                            .size(theme.font_size.xs)
+                                            .size(font_size.xs)
                                             .align_x(Horizontal::Right)
                                             .width(Length::Fill),
                                         text(format!("{} km/h", data.current.wind_speed_10m))
                                             .align_x(Horizontal::Right)
-                                            .size(theme.font_size.xs)
+                                            .size(font_size.xs)
                                             .width(Length::Fill),
                                     )
-                                    .spacing(theme.space.xxs)
+                                    .spacing(space.xxs)
                                 )
                                 .align_y(Vertical::Center)
-                                .spacing(theme.space.sm),
+                                .spacing(space.sm),
                             )
                             .width(Length::Fill)
-                            .spacing(theme.space.xs),
+                            .spacing(space.xs),
                         )
-                        .spacing(theme.space.lg)
+                        .spacing(space.lg)
                         .align_y(Vertical::Center)
                         .width(Length::Fill),
                     )
-                    .padding(theme.space.md)
+                    .padding(space.md)
                     .style(move |app_theme: &Theme| container::Style {
                         background: Background::Color(
                             app_theme
@@ -571,10 +566,10 @@ impl Tempo {
                                 .background
                                 .weak
                                 .color
-                                .scale_alpha(theme.opacity),
+                                .scale_alpha(opacity),
                         )
                         .into(),
-                        border: Border::default().rounded(theme.radius.lg),
+                        border: Border::default().rounded(radius_lg),
                         ..container::Style::default()
                     }),
                     container(
@@ -606,23 +601,22 @@ impl Tempo {
                                     column!(
                                         text(format!("{}°", temp.round())),
                                         weather_icon(*weather_code, *is_day > 0)
-                                            .height(theme.font_size.md)
+                                            .height(font_size.md)
                                             .width(Length::Shrink),
-                                        text(time.format("%H:%M").to_string())
-                                            .size(theme.font_size.sm)
+                                        text(time.format("%H:%M").to_string()).size(font_size.sm)
                                     )
-                                    .spacing(theme.space.xs)
+                                    .spacing(space.xs)
                                     .align_x(Horizontal::Center)
                                     .into()
                                 })
                                 .collect::<Vec<_>>()
                             })
-                            .spacing(theme.space.sm)
-                            .padding(Padding::default().bottom(theme.space.sm))
+                            .spacing(space.sm)
+                            .padding(Padding::default().bottom(space.sm))
                         )
                         .horizontal()
                     )
-                    .padding(theme.space.sm)
+                    .padding(space.sm)
                     .style(move |app_theme: &Theme| container::Style {
                         background: Background::Color(
                             app_theme
@@ -630,10 +624,10 @@ impl Tempo {
                                 .background
                                 .weak
                                 .color
-                                .scale_alpha(theme.opacity),
+                                .scale_alpha(opacity),
                         )
                         .into(),
-                        border: Border::default().rounded(theme.radius.lg),
+                        border: Border::default().rounded(radius_lg),
                         ..container::Style::default()
                     }),
                     Column::with_children(
@@ -652,6 +646,7 @@ impl Tempo {
                                 index,
                                 (time, weather_code, temp_min, temp_max, wind_dir, wind_speed),
                             )| {
+                                let last_index = data.daily.time.len() - 2;
                                 container(
                                     row!(
                                         text(
@@ -660,7 +655,7 @@ impl Tempo {
                                         )
                                         .width(Length::Fill),
                                         weather_icon(*weather_code, true)
-                                            .height(theme.font_size.md)
+                                            .height(font_size.md)
                                             .width(Length::Shrink),
                                         container(
                                             row!(
@@ -674,23 +669,23 @@ impl Tempo {
                                                     svg(Handle::from_memory(include_bytes!(
                                                         "../../assets/weather_icon/wind.svg"
                                                     )))
-                                                    .height(theme.font_size.md)
+                                                    .height(font_size.md)
                                                     .width(Length::Shrink)
                                                     .rotation(Rotation::Floating(
                                                         Degrees(*wind_dir as f32 + 90.).into()
                                                     )),
                                                     text(format!("{} km/h", wind_speed))
                                                 )
-                                                .spacing(theme.space.xxs)
+                                                .spacing(space.xxs)
                                             )
-                                            .spacing(theme.space.sm)
+                                            .spacing(space.sm)
                                         )
                                         .width(Length::FillPortion(2))
                                         .align_x(Horizontal::Right)
                                     )
-                                    .spacing(theme.space.sm),
+                                    .spacing(space.sm),
                                 )
-                                .padding(theme.space.sm)
+                                .padding(space.sm)
                                 .style(move |app_theme: &Theme| container::Style {
                                     background: Background::Color(
                                         app_theme
@@ -698,29 +693,21 @@ impl Tempo {
                                             .background
                                             .weak
                                             .color
-                                            .scale_alpha(theme.opacity),
+                                            .scale_alpha(opacity),
                                     )
                                     .into(),
                                     border: Border::default().rounded(iced::border::Radius {
-                                        top_left: if index == 0 {
-                                            theme.radius.lg
+                                        top_left: if index == 0 { radius_lg } else { radius_sm },
+                                        top_right: if index == 0 { radius_lg } else { radius_sm },
+                                        bottom_right: if index == last_index {
+                                            radius_lg
                                         } else {
-                                            theme.radius.sm
+                                            radius_sm
                                         },
-                                        top_right: if index == 0 {
-                                            theme.radius.lg
+                                        bottom_left: if index == last_index {
+                                            radius_lg
                                         } else {
-                                            theme.radius.sm
-                                        },
-                                        bottom_right: if index == data.daily.time.len() - 2 {
-                                            theme.radius.lg
-                                        } else {
-                                            theme.radius.sm
-                                        },
-                                        bottom_left: if index == data.daily.time.len() - 2 {
-                                            theme.radius.lg
-                                        } else {
-                                            theme.radius.sm
+                                            radius_sm
                                         },
                                     }),
                                     ..container::Style::default()
@@ -729,9 +716,9 @@ impl Tempo {
                             }
                         )
                     )
-                    .spacing(theme.space.xxs)
+                    .spacing(space.xxs)
                 )
-                .spacing(theme.space.sm)
+                .spacing(space.sm)
                 .into()
             })
     }

--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -5,7 +5,7 @@ use crate::{
         styled_button,
     },
     config::{TempoModuleConfig, WeatherIndicator, WeatherLocation},
-    theme::use_theme,
+    theme::{AshellTheme, use_theme},
 };
 use chrono::{
     DateTime, Datelike, Days, FixedOffset, Local, Months, NaiveDate, NaiveDateTime, TimeZone, Utc,
@@ -163,14 +163,14 @@ impl Tempo {
     }
 
     pub fn view(&'_ self) -> Element<'_, Message> {
-        let space_sm = use_theme(|t| t.space.sm);
+        let space = use_theme(|t| t.space);
         let display_text = self.time_str(self.current_format(), self.current_timezone_index);
 
         Row::with_capacity(2)
             .push(self.weather_indicator())
             .push(text(display_text))
             .align_y(Vertical::Center)
-            .spacing(space_sm)
+            .spacing(space.sm)
             .into()
     }
 
@@ -210,7 +210,7 @@ impl Tempo {
     }
 
     pub fn weather_indicator(&'_ self) -> Option<Element<'_, Message>> {
-        let (font_size_sm, space_xxs) = use_theme(|t| (t.font_size.sm, t.space.xxs));
+        let (font_size, space) = use_theme(|t| (t.font_size, t.space));
         if self.config.weather_location.is_none()
             || self.config.weather_indicator == WeatherIndicator::None
         {
@@ -223,29 +223,29 @@ impl Tempo {
                 Row::new()
                     .push(
                         weather_icon(data.current.weather_code, data.current.is_day > 0)
-                            .width(Length::Fixed(font_size_sm)),
+                            .width(Length::Fixed(font_size.sm)),
                     )
                     .push(
                         (self.config.weather_indicator == WeatherIndicator::IconAndTemperature)
                             .then(|| {
                                 text(format!("{}°C", data.current.temperature_2m))
                                     .align_y(Vertical::Center)
-                                    .size(font_size_sm)
+                                    .size(font_size.sm)
                             }),
                     )
                     .align_y(Vertical::Center)
-                    .spacing(space_xxs)
+                    .spacing(space.xxs)
                     .into()
             })
     }
 
     pub fn menu_view<'a>(&'a self) -> Element<'a, Message> {
-        let space_lg = use_theme(|t| t.space.lg);
+        let space = use_theme(|t| t.space);
         container(
             Row::with_capacity(2)
                 .push(self.calendar())
                 .push(self.weather())
-                .spacing(space_lg),
+                .spacing(space.lg),
         )
         .max_width(MenuSize::XLarge)
         .into()
@@ -272,7 +272,10 @@ impl Tempo {
     }
 
     fn calendar<'a>(&'a self) -> Element<'a, Message> {
-        let theme = use_theme(|t| t.clone());
+        use_theme(|theme| self.calendar_with_theme(theme))
+    }
+
+    fn calendar_with_theme<'a>(&'a self, theme: &AshellTheme) -> Element<'a, Message> {
         let selected_date = self
             .selected_date
             .unwrap_or(self.naive_date(self.current_timezone_index));
@@ -465,8 +468,8 @@ impl Tempo {
     }
 
     fn weather<'a>(&'a self) -> Option<Element<'a, Message>> {
-        let (space, font_size, opacity, radius_lg, radius_sm) =
-            use_theme(|t| (t.space, t.font_size, t.opacity, t.radius.lg, t.radius.sm));
+        let (space, font_size, opacity, radius) =
+            use_theme(|t| (t.space, t.font_size, t.opacity, t.radius));
         self.weather_data
             .as_ref()
             .zip(self.location.as_ref())
@@ -569,7 +572,7 @@ impl Tempo {
                                 .scale_alpha(opacity),
                         )
                         .into(),
-                        border: Border::default().rounded(radius_lg),
+                        border: Border::default().rounded(radius.lg),
                         ..container::Style::default()
                     }),
                     container(
@@ -627,7 +630,7 @@ impl Tempo {
                                 .scale_alpha(opacity),
                         )
                         .into(),
-                        border: Border::default().rounded(radius_lg),
+                        border: Border::default().rounded(radius.lg),
                         ..container::Style::default()
                     }),
                     Column::with_children(
@@ -697,17 +700,17 @@ impl Tempo {
                                     )
                                     .into(),
                                     border: Border::default().rounded(iced::border::Radius {
-                                        top_left: if index == 0 { radius_lg } else { radius_sm },
-                                        top_right: if index == 0 { radius_lg } else { radius_sm },
+                                        top_left: if index == 0 { radius.lg } else { radius.sm },
+                                        top_right: if index == 0 { radius.lg } else { radius.sm },
                                         bottom_right: if index == last_index {
-                                            radius_lg
+                                            radius.lg
                                         } else {
-                                            radius_sm
+                                            radius.sm
                                         },
                                         bottom_left: if index == last_index {
-                                            radius_lg
+                                            radius.lg
                                         } else {
-                                            radius_sm
+                                            radius.sm
                                         },
                                     }),
                                     ..container::Style::default()

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -173,9 +173,9 @@ impl TrayModule {
     }
 
     pub fn view<'a>(&'a self, id: SurfaceId) -> Option<Element<'a, Message>> {
-        let (space_xxs, font_size, button_style) = use_theme(|theme| {
+        let (space, font_size, button_style) = use_theme(|theme| {
             (
-                theme.space.xxs,
+                theme.space,
                 theme.font_size,
                 theme.button_style(ButtonKind::Transparent, ButtonHierarchy::Secondary),
             )
@@ -209,7 +209,7 @@ impl TrayModule {
                                 .on_press_with_position(move |button_ui_ref| {
                                     Message::ToggleMenu(item.name.to_owned(), id, button_ui_ref)
                                 })
-                                .padding(space_xxs)
+                                .padding(space.xxs)
                                 .style(move |t, s| button_style(t, s))
                                 .into()
                             })
@@ -221,7 +221,7 @@ impl TrayModule {
     }
 
     pub fn menu_view<'a>(&'a self, name: &'a str) -> Element<'a, Message> {
-        let space_xs = use_theme(|theme| theme.space.xs);
+        let space = use_theme(|theme| theme.space);
         container(
             match self
                 .service
@@ -235,7 +235,7 @@ impl TrayModule {
                         .filter(|menu| menu.1.visible != Some(false))
                         .map(|menu| self.menu_voice(name, menu)),
                 )
-                .spacing(space_xs),
+                .spacing(space.xs),
                 _ => Column::new(),
             },
         )

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -12,7 +12,7 @@ use crate::{
             dbus::{Layout, LayoutProps},
         },
     },
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Alignment, Element, Length, Padding, Subscription, SurfaceId, Task,
@@ -102,12 +102,8 @@ impl TrayModule {
         }
     }
 
-    fn menu_voice<'a>(
-        &'a self,
-        theme: &'a AshellTheme,
-        name: &'a str,
-        layout: &'a Layout,
-    ) -> Element<'a, Message> {
+    fn menu_voice<'a>(&'a self, name: &'a str, layout: &'a Layout) -> Element<'a, Message> {
+        let space = use_theme(|theme| theme.space);
         match &layout.1 {
             LayoutProps {
                 label: Some(label),
@@ -125,7 +121,7 @@ impl TrayModule {
                     })
                     .width(Length::Fill),
             )
-            .padding([theme.space.xs, theme.space.md])
+            .padding([space.xs, space.md])
             .into(),
             LayoutProps {
                 children_display: Some(display),
@@ -135,7 +131,7 @@ impl TrayModule {
                 let is_open = self.submenus.contains(&layout.0);
                 Column::with_capacity(2)
                     .push(
-                        styled_button(theme, label.replace("_", ""))
+                        styled_button(label.replace("_", ""))
                             .icon(
                                 if is_open {
                                     StaticIcon::MenuOpen
@@ -154,11 +150,11 @@ impl TrayModule {
                                     .2
                                     .iter()
                                     .filter(|menu| menu.1.visible != Some(false))
-                                    .map(|menu| self.menu_voice(theme, name, menu))
+                                    .map(|menu| self.menu_voice(name, menu))
                                     .collect::<Vec<_>>(),
                             )
-                            .padding(Padding::default().left(theme.space.md))
-                            .spacing(theme.space.xxs),
+                            .padding(Padding::default().left(space.md))
+                            .spacing(space.xxs),
                         )
                     } else {
                         None
@@ -167,7 +163,7 @@ impl TrayModule {
             }
             LayoutProps {
                 label: Some(label), ..
-            } if !label.is_empty() => styled_button(theme, label.replace("_", ""))
+            } if !label.is_empty() => styled_button(label.replace("_", ""))
                 .on_press(Message::MenuSelected(name.to_owned(), layout.0))
                 .width(Length::Fill)
                 .into(),
@@ -176,11 +172,16 @@ impl TrayModule {
         }
     }
 
-    pub fn view<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-    ) -> Option<Element<'a, Message>> {
+    pub fn view<'a>(&'a self, id: SurfaceId) -> Option<Element<'a, Message>> {
+        let (space_xxs, font_size, button_style) = use_theme(|theme| {
+            (
+                theme.space.xxs,
+                theme.font_size,
+                theme.button_style(ButtonKind::Transparent, ButtonHierarchy::Secondary),
+            )
+        });
+        let button_style = std::sync::Arc::new(button_style);
+
         self.service
             .as_ref()
             .filter(|s| !s.data.is_empty())
@@ -191,15 +192,16 @@ impl TrayModule {
                             .data
                             .iter()
                             .map(|item| {
+                                let button_style = button_style.clone();
                                 position_button(match &item.icon {
                                     Some(TrayIcon::Image(handle)) => Into::<Element<_>>::into(
                                         Image::new(handle.clone())
-                                            .height(Length::Fixed(theme.font_size.md - 2.0)),
+                                            .height(Length::Fixed(font_size.md - 2.0)),
                                     ),
                                     Some(TrayIcon::Svg(handle)) => Into::<Element<_>>::into(
                                         Svg::new(handle.clone())
-                                            .height(Length::Fixed(theme.font_size.md + 2.))
-                                            .width(Length::Fixed(theme.font_size.md + 2.))
+                                            .height(Length::Fixed(font_size.md + 2.))
+                                            .width(Length::Fixed(font_size.md + 2.))
                                             .content_fit(iced::ContentFit::Cover),
                                     ),
                                     _ => icon(StaticIcon::Point).into(),
@@ -207,11 +209,8 @@ impl TrayModule {
                                 .on_press_with_position(move |button_ui_ref| {
                                     Message::ToggleMenu(item.name.to_owned(), id, button_ui_ref)
                                 })
-                                .padding(theme.space.xxs)
-                                .style(theme.button_style(
-                                    ButtonKind::Transparent,
-                                    ButtonHierarchy::Secondary,
-                                ))
+                                .padding(space_xxs)
+                                .style(move |t, s| button_style(t, s))
                                 .into()
                             })
                             .collect::<Vec<_>>(),
@@ -221,7 +220,8 @@ impl TrayModule {
             })
     }
 
-    pub fn menu_view<'a>(&'a self, theme: &'a AshellTheme, name: &'a str) -> Element<'a, Message> {
+    pub fn menu_view<'a>(&'a self, name: &'a str) -> Element<'a, Message> {
+        let space_xs = use_theme(|theme| theme.space.xs);
         container(
             match self
                 .service
@@ -233,9 +233,9 @@ impl TrayModule {
                         .2
                         .iter()
                         .filter(|menu| menu.1.visible != Some(false))
-                        .map(|menu| self.menu_voice(theme, name, menu)),
+                        .map(|menu| self.menu_voice(name, menu)),
                 )
-                .spacing(theme.space.xs),
+                .spacing(space_xs),
                 _ => Column::new(),
             },
         )

--- a/src/modules/updates.rs
+++ b/src/modules/updates.rs
@@ -162,14 +162,14 @@ impl Updates {
     }
 
     pub fn view(&'_ self) -> Element<'_, Message> {
-        let space_xxs = use_theme(|theme| theme.space.xxs);
+        let space = use_theme(|theme| theme.space);
         let mut content = row!(container(icon(match self.state {
             State::Checking => StaticIcon::Refresh,
             State::Ready if self.updates.is_empty() => StaticIcon::NoUpdatesAvailable,
             _ => StaticIcon::UpdatesAvailable,
         })))
         .align_y(Alignment::Center)
-        .spacing(space_xxs);
+        .spacing(space.xxs);
 
         if !self.updates.is_empty() {
             content = content.push(text(self.updates.len()));
@@ -255,8 +255,8 @@ impl Updates {
     }
 
     fn update_buttons<'a>(&'a self, id: SurfaceId) -> Element<'a, Message> {
-        let space_xs = use_theme(|theme| theme.space.xs);
-        let mut buttons = column!().spacing(space_xs);
+        let space = use_theme(|theme| theme.space);
+        let mut buttons = column!().spacing(space.xs);
 
         if !self.updates.is_empty() {
             buttons = buttons.push(
@@ -272,7 +272,7 @@ impl Updates {
                     .on_press(Message::CheckNow)
                     .width(Length::Fill),
             )
-            .spacing(space_xs)
+            .spacing(space.xs)
             .width(MenuSize::Small)
             .into()
     }

--- a/src/modules/updates.rs
+++ b/src/modules/updates.rs
@@ -3,7 +3,7 @@ use crate::{
     components::icons::{StaticIcon, icon},
     components::{IconPosition, MenuSize, styled_button},
     config::UpdatesModuleConfig,
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Alignment, Element, Length, Padding, Subscription, SurfaceId, Task,
@@ -161,14 +161,15 @@ impl Updates {
         }
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme) -> Element<'_, Message> {
+    pub fn view(&'_ self) -> Element<'_, Message> {
+        let space_xxs = use_theme(|theme| theme.space.xxs);
         let mut content = row!(container(icon(match self.state {
             State::Checking => StaticIcon::Refresh,
             State::Ready if self.updates.is_empty() => StaticIcon::NoUpdatesAvailable,
             _ => StaticIcon::UpdatesAvailable,
         })))
         .align_y(Alignment::Center)
-        .spacing(theme.space.xxs);
+        .spacing(space_xxs);
 
         if !self.updates.is_empty() {
             content = content.push(text(self.updates.len()));
@@ -177,15 +178,16 @@ impl Updates {
         content.into()
     }
 
-    pub fn menu_view<'a>(&'a self, id: SurfaceId, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn menu_view<'a>(&'a self, id: SurfaceId) -> Element<'a, Message> {
+        let (space, font_size) = use_theme(|theme| (theme.space, theme.font_size));
         column!(
             if self.updates.is_empty() {
                 convert::Into::<Element<'_, _>>::into(
-                    container(text("Up to date ;)")).padding(theme.space.xs),
+                    container(text("Up to date ;)")).padding(space.xs),
                 )
             } else {
                 let mut elements = column!(
-                    styled_button(theme, format!("{} Updates available", self.updates.len()),)
+                    styled_button(format!("{} Updates available", self.updates.len()),)
                         .icon(
                             if self.is_updates_list_open {
                                 StaticIcon::MenuClosed
@@ -197,7 +199,7 @@ impl Updates {
                         .on_press(Message::ToggleUpdatesList)
                         .width(Length::Fill),
                 )
-                .spacing(theme.space.xs);
+                .spacing(space.xs);
 
                 if self.is_updates_list_open {
                     elements = elements.push(
@@ -209,7 +211,7 @@ impl Updates {
                                         .map(|update| {
                                             column!(
                                                 text(update.package.clone())
-                                                    .size(theme.font_size.xs)
+                                                    .size(font_size.xs)
                                                     .width(Length::Fill),
                                                 text(format!(
                                                     "{} -> {}",
@@ -228,16 +230,16 @@ impl Updates {
                                                 ))
                                                 .width(Length::Fill)
                                                 .align_x(Horizontal::Right)
-                                                .size(theme.font_size.xs)
+                                                .size(font_size.xs)
                                             )
                                             .into()
                                         })
                                         .collect::<Vec<Element<'_, _>>>(),
                                 )
-                                .spacing(theme.space.xs)
-                                .padding(Padding::default().left(theme.space.md)),
+                                .spacing(space.xs)
+                                .padding(Padding::default().left(space.md)),
                             )
-                            .spacing(theme.space.xs),
+                            .spacing(space.xs),
                         )
                         .max_height(300),
                     );
@@ -245,19 +247,20 @@ impl Updates {
                 elements.into()
             },
             divider(),
-            self.update_buttons(id, theme),
+            self.update_buttons(id),
         )
         .width(MenuSize::Small)
-        .spacing(theme.space.xs)
+        .spacing(space.xs)
         .into()
     }
 
-    fn update_buttons<'a>(&'a self, id: SurfaceId, theme: &'a AshellTheme) -> Element<'a, Message> {
-        let mut buttons = column!().spacing(theme.space.xs);
+    fn update_buttons<'a>(&'a self, id: SurfaceId) -> Element<'a, Message> {
+        let space_xs = use_theme(|theme| theme.space.xs);
+        let mut buttons = column!().spacing(space_xs);
 
         if !self.updates.is_empty() {
             buttons = buttons.push(
-                styled_button(theme, "Update")
+                styled_button("Update")
                     .on_press(Message::Update(id))
                     .width(Length::Fill),
             );
@@ -265,11 +268,11 @@ impl Updates {
 
         buttons
             .push(
-                styled_button(theme, "Check now")
+                styled_button("Check now")
                     .on_press(Message::CheckNow)
                     .width(Length::Fill),
             )
-            .spacing(theme.space.xs)
+            .spacing(space_xs)
             .width(MenuSize::Small)
             .into()
     }

--- a/src/modules/window_title.rs
+++ b/src/modules/window_title.rs
@@ -1,7 +1,7 @@
 use crate::{
     config::{WindowTitleConfig, WindowTitleMode},
     services::{ReadOnlyService, ServiceEvent, compositor::CompositorService},
-    theme::AshellTheme,
+    theme::use_theme,
     utils::truncate_text,
 };
 use iced::{
@@ -90,14 +90,16 @@ impl WindowTitle {
         self.value.clone()
     }
 
-    pub fn view(&'_ self, theme: &AshellTheme, title: String) -> Element<'_, Message> {
-        container(
-            text(title)
-                .size(theme.font_size.sm)
-                .wrapping(text::Wrapping::None),
-        )
-        .clip(true)
-        .into()
+    pub fn view(&'_ self, title: String) -> Element<'_, Message> {
+        use_theme(|theme| {
+            container(
+                text(title)
+                    .size(theme.font_size.sm)
+                    .wrapping(text::Wrapping::None),
+            )
+            .clip(true)
+            .into()
+        })
     }
 
     pub fn subscription(&self) -> Subscription<Message> {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -5,7 +5,7 @@ use crate::{
         ReadOnlyService, Service, ServiceEvent,
         compositor::{CompositorCommand, CompositorService, CompositorState},
     },
-    theme::AshellTheme,
+    theme::use_theme,
 };
 use iced::{
     Element, Length, Subscription, SurfaceId, alignment,
@@ -395,12 +395,8 @@ impl Workspaces {
         }
     }
 
-    pub fn view<'a>(
-        &'a self,
-        id: SurfaceId,
-        theme: &'a AshellTheme,
-        outputs: &Outputs,
-    ) -> Element<'a, Message> {
+    pub fn view<'a>(&'a self, id: SurfaceId, outputs: &Outputs) -> Element<'a, Message> {
+        let theme = use_theme(|t| t.clone());
         let monitor_name = outputs.get_monitor_name(id);
 
         MouseArea::new(

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -396,10 +396,9 @@ impl Workspaces {
     }
 
     pub fn view<'a>(&'a self, id: SurfaceId, outputs: &Outputs) -> Element<'a, Message> {
-        let theme = use_theme(|t| t.clone());
         let monitor_name = outputs.get_monitor_name(id);
 
-        MouseArea::new(
+        let row = use_theme(|theme| {
             Row::with_children(
                 self.ui_workspaces
                     .iter()
@@ -474,53 +473,55 @@ impl Workspaces {
                     })
                     .collect::<Vec<_>>(),
             )
-            .spacing(theme.space.xxs),
-        )
-        .on_scroll(move |direction| match direction {
-            iced::mouse::ScrollDelta::Lines { y, .. } => {
-                if y.is_sign_positive() {
-                    match self.config.invert_scroll_direction {
-                        Some(InvertScrollDirection::All | InvertScrollDirection::Mouse) => {
-                            Message::Scroll(-1)
-                        }
-                        Some(InvertScrollDirection::Trackpad) => Message::Scroll(1),
-                        None => Message::Scroll(1),
-                    }
-                } else {
-                    match self.config.invert_scroll_direction {
-                        Some(InvertScrollDirection::All | InvertScrollDirection::Mouse) => {
-                            Message::Scroll(1)
-                        }
-                        Some(InvertScrollDirection::Trackpad) => Message::Scroll(-1),
-                        None => Message::Scroll(-1),
-                    }
-                }
-            }
-            iced::mouse::ScrollDelta::Pixels { y, .. } => {
-                let sensibility = 3.;
+            .spacing(theme.space.xxs)
+        });
 
-                if self.scroll_accumulator.abs() < sensibility {
-                    Message::ScrollAccumulator(y)
-                } else if self.scroll_accumulator.is_sign_positive() {
-                    match self.config.invert_scroll_direction {
-                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
-                            Message::Scroll(-1)
+        MouseArea::new(row)
+            .on_scroll(move |direction| match direction {
+                iced::mouse::ScrollDelta::Lines { y, .. } => {
+                    if y.is_sign_positive() {
+                        match self.config.invert_scroll_direction {
+                            Some(InvertScrollDirection::All | InvertScrollDirection::Mouse) => {
+                                Message::Scroll(-1)
+                            }
+                            Some(InvertScrollDirection::Trackpad) => Message::Scroll(1),
+                            None => Message::Scroll(1),
                         }
-                        Some(InvertScrollDirection::Mouse) => Message::Scroll(1),
-                        None => Message::Scroll(1),
-                    }
-                } else {
-                    match self.config.invert_scroll_direction {
-                        Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
-                            Message::Scroll(1)
+                    } else {
+                        match self.config.invert_scroll_direction {
+                            Some(InvertScrollDirection::All | InvertScrollDirection::Mouse) => {
+                                Message::Scroll(1)
+                            }
+                            Some(InvertScrollDirection::Trackpad) => Message::Scroll(-1),
+                            None => Message::Scroll(-1),
                         }
-                        Some(InvertScrollDirection::Mouse) => Message::Scroll(-1),
-                        None => Message::Scroll(-1),
                     }
                 }
-            }
-        })
-        .into()
+                iced::mouse::ScrollDelta::Pixels { y, .. } => {
+                    let sensibility = 3.;
+
+                    if self.scroll_accumulator.abs() < sensibility {
+                        Message::ScrollAccumulator(y)
+                    } else if self.scroll_accumulator.is_sign_positive() {
+                        match self.config.invert_scroll_direction {
+                            Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
+                                Message::Scroll(-1)
+                            }
+                            Some(InvertScrollDirection::Mouse) => Message::Scroll(1),
+                            None => Message::Scroll(1),
+                        }
+                    } else {
+                        match self.config.invert_scroll_direction {
+                            Some(InvertScrollDirection::All | InvertScrollDirection::Trackpad) => {
+                                Message::Scroll(1)
+                            }
+                            Some(InvertScrollDirection::Mouse) => Message::Scroll(-1),
+                            None => Message::Scroll(-1),
+                        }
+                    }
+                }
+            })
+            .into()
     }
 
     pub fn subscription(&self) -> Subscription<Message> {

--- a/src/osd.rs
+++ b/src/osd.rs
@@ -10,7 +10,7 @@ use crate::{
     components::icons::{Icon, StaticIcon},
     config::OsdConfig,
     modules::settings::audio::AudioSettings,
-    theme::AshellTheme,
+    theme::use_theme,
 };
 
 pub struct Osd {
@@ -103,10 +103,12 @@ impl Osd {
         }
     }
 
-    pub fn view<'a>(&'a self, theme: &'a AshellTheme) -> Element<'a, Message> {
+    pub fn view(&self) -> Element<'_, Message> {
         let Some(state) = &self.state else {
             return row![].into();
         };
+
+        let (space, font_size, radius) = use_theme(|t| (t.space, t.font_size, t.radius));
 
         let icon = match state.kind {
             OsdKind::Volume => AudioSettings::speaker_icon(state.muted, state.value),
@@ -131,18 +133,18 @@ impl Osd {
             }
         };
 
-        let content = row![icon.to_text().size(theme.font_size.xxl), detail,]
-            .spacing(theme.space.sm)
+        let content = row![icon.to_text().size(font_size.xxl), detail,]
+            .spacing(space.sm)
             .align_y(Alignment::Center);
 
         container(content)
-            .padding([theme.space.sm, theme.space.md])
-            .style(|t: &Theme| container::Style {
+            .padding([space.sm, space.md])
+            .style(move |t: &Theme| container::Style {
                 background: Some(t.palette().background.into()),
                 border: Border::default()
                     .width(1)
-                    .color(theme.iced_theme.extended_palette().background.weakest.color)
-                    .rounded(theme.radius.xl),
+                    .color(t.extended_palette().background.weakest.color)
+                    .rounded(radius.xl),
 
                 ..Default::default()
             })

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -355,10 +355,6 @@ impl AshellTheme {
         }
     }
 
-    pub fn get_theme(&self) -> &Theme {
-        &self.iced_theme
-    }
-
     pub fn button_style(
         &self,
         kind: ButtonKind,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,3 +1,5 @@
+use std::cell::RefCell;
+
 use crate::{
     components::button::{ButtonHierarchy, ButtonKind},
     config::{
@@ -12,6 +14,18 @@ use iced::{
         text_input::{self},
     },
 };
+
+thread_local! {
+    pub static THEME: RefCell<AshellTheme> =  RefCell::new(AshellTheme::default());
+}
+
+pub fn init_theme(theme: AshellTheme) {
+    THEME.replace(theme);
+}
+
+pub fn use_theme<R, F: FnOnce(&AshellTheme) -> R>(f: F) -> R {
+    THEME.with_borrow(f)
+}
 
 #[allow(unused)]
 #[derive(Debug, Copy, Clone)]
@@ -98,6 +112,128 @@ pub struct AshellTheme {
     pub workspace_colors: Vec<AppearanceColor>,
     pub special_workspace_colors: Option<Vec<AppearanceColor>>,
     pub scale_factor: f64,
+}
+
+impl Default for AshellTheme {
+    fn default() -> Self {
+        let appearance = Appearance::default();
+
+        AshellTheme {
+            space: Space::default(),
+            radius: Radius::default(),
+            font_size: FontSize::default(),
+            bar_position: Position::default(),
+            bar_style: appearance.style,
+            opacity: appearance.opacity,
+            menu: appearance.menu,
+            workspace_colors: appearance.workspace_colors.clone(),
+            special_workspace_colors: appearance.special_workspace_colors.clone(),
+            scale_factor: appearance.scale_factor,
+            iced_theme: Theme::custom_with_fn(
+                "local".to_string(),
+                Palette {
+                    background: appearance.background_color.get_base(),
+                    text: appearance.text_color.get_base(),
+                    primary: appearance.primary_color.get_base(),
+                    success: appearance.success_color.get_base(),
+                    warning: appearance.warning_color.get_base(),
+                    danger: appearance.danger_color.get_base(),
+                },
+                |palette| {
+                    let text = palette.text;
+                    let bg_text = appearance.background_color.get_text().unwrap_or(text);
+
+                    let default_bg = palette::Background::new(palette.background, bg_text);
+                    let bg = |level, fallback| {
+                        appearance
+                            .background_color
+                            .get_pair(level, text)
+                            .unwrap_or(fallback)
+                    };
+
+                    let default_primary = palette::Primary::generate(
+                        palette.primary,
+                        palette.background,
+                        appearance.primary_color.get_text().unwrap_or(text),
+                    );
+                    let default_success = palette::Success::generate(
+                        palette.success,
+                        palette.background,
+                        appearance.success_color.get_text().unwrap_or(text),
+                    );
+                    let default_warning = palette::Warning::generate(
+                        palette.warning,
+                        palette.background,
+                        appearance.warning_color.get_text().unwrap_or(text),
+                    );
+                    let default_danger = palette::Danger::generate(
+                        palette.danger,
+                        palette.background,
+                        appearance.danger_color.get_text().unwrap_or(text),
+                    );
+
+                    palette::Extended {
+                        background: palette::Background {
+                            base: default_bg.base,
+                            weakest: bg(BackgroundLevel::Weakest, default_bg.weakest),
+                            weaker: bg(BackgroundLevel::Weaker, default_bg.weaker),
+                            weak: bg(BackgroundLevel::Weak, default_bg.weak),
+                            neutral: bg(BackgroundLevel::Neutral, default_bg.neutral),
+                            strong: bg(BackgroundLevel::Strong, default_bg.strong),
+                            stronger: bg(BackgroundLevel::Stronger, default_bg.stronger),
+                            strongest: bg(BackgroundLevel::Strongest, default_bg.strongest),
+                        },
+                        primary: palette::Primary {
+                            base: default_primary.base,
+                            weak: appearance
+                                .primary_color
+                                .get_weak_pair(text)
+                                .unwrap_or(default_primary.weak),
+                            strong: appearance
+                                .primary_color
+                                .get_strong_pair(text)
+                                .unwrap_or(default_primary.strong),
+                        },
+                        secondary: palette::Secondary::generate(palette.background, text),
+                        success: palette::Success {
+                            base: default_success.base,
+                            weak: appearance
+                                .success_color
+                                .get_weak_pair(text)
+                                .unwrap_or(default_success.weak),
+                            strong: appearance
+                                .success_color
+                                .get_strong_pair(text)
+                                .unwrap_or(default_success.strong),
+                        },
+                        warning: palette::Warning {
+                            base: default_warning.base,
+                            weak: appearance
+                                .warning_color
+                                .get_weak_pair(text)
+                                .unwrap_or(default_warning.weak),
+                            strong: appearance
+                                .warning_color
+                                .get_strong_pair(text)
+                                .unwrap_or(default_warning.strong),
+                        },
+                        danger: palette::Danger {
+                            base: default_danger.base,
+                            weak: appearance
+                                .danger_color
+                                .get_weak_pair(text)
+                                .unwrap_or(default_danger.weak),
+                            strong: appearance
+                                .danger_color
+                                .get_strong_pair(text)
+                                .unwrap_or(default_danger.strong),
+                        },
+                        is_dark: true,
+                    }
+                },
+            ),
+        }
+    }
 }
 
 impl AshellTheme {
@@ -227,7 +363,7 @@ impl AshellTheme {
         &self,
         kind: ButtonKind,
         hierarchy: ButtonHierarchy,
-    ) -> impl Fn(&Theme, Status) -> button::Style {
+    ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
         let radius = match kind {
             ButtonKind::Transparent => self.radius.sm,
             ButtonKind::Solid | ButtonKind::Outline => self.radius.xl,
@@ -393,13 +529,15 @@ impl AshellTheme {
     pub fn quick_settings_submenu_button_style(
         &self,
         is_active: bool,
-    ) -> impl Fn(&Theme, Status) -> button::Style {
+    ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
+        let radius_lg = self.radius.lg;
+        let opacity = self.opacity;
         move |theme: &Theme, status: Status| {
             let mut base = button::Style {
                 background: None,
                 border: Border {
                     width: 0.0,
-                    radius: self.radius.lg.into(),
+                    radius: radius_lg.into(),
                     color: Color::TRANSPARENT,
                 },
                 text_color: if is_active {
@@ -418,7 +556,7 @@ impl AshellTheme {
                             .background
                             .weak
                             .color
-                            .scale_alpha(self.opacity)
+                            .scale_alpha(opacity)
                             .into(),
                     );
                     base.text_color = theme.palette().text;
@@ -432,7 +570,9 @@ impl AshellTheme {
     pub fn quick_settings_button_style(
         &self,
         is_active: bool,
-    ) -> impl Fn(&Theme, Status) -> button::Style {
+    ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
+        let radius_xl = self.radius.xl;
+        let opacity = self.opacity;
         move |theme: &Theme, status: Status| {
             let mut base = button::Style {
                 background: Some(
@@ -441,12 +581,12 @@ impl AshellTheme {
                     } else {
                         theme.extended_palette().background.weak.color
                     }
-                    .scale_alpha(self.opacity)
+                    .scale_alpha(opacity)
                     .into(),
                 ),
                 border: Border {
                     width: 0.0,
-                    radius: self.radius.xl.into(),
+                    radius: radius_xl.into(),
                     color: Color::TRANSPARENT,
                 },
                 text_color: if is_active {
@@ -466,7 +606,7 @@ impl AshellTheme {
                         } else {
                             theme.extended_palette().background.strong.color
                         }
-                        .scale_alpha(self.opacity)
+                        .scale_alpha(opacity)
                         .into(),
                     );
                     base
@@ -480,7 +620,8 @@ impl AshellTheme {
         &self,
         is_empty: bool,
         colors: Option<Option<AppearanceColor>>,
-    ) -> impl Fn(&Theme, Status) -> button::Style {
+    ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
+        let radius_lg = self.radius.lg;
         move |theme: &Theme, status: Status| {
             let (bg_color, fg_color) = colors.map_or_else(
                 || {
@@ -517,7 +658,7 @@ impl AshellTheme {
                 border: Border {
                     width: if is_empty { 1.0 } else { 0.0 },
                     color: bg_color,
-                    radius: self.radius.lg.into(),
+                    radius: radius_lg.into(),
                 },
                 text_color: if is_empty {
                     theme.extended_palette().background.weak.text
@@ -573,13 +714,16 @@ impl AshellTheme {
         }
     }
 
-    pub fn text_input_style(&self) -> impl Fn(&Theme, text_input::Status) -> text_input::Style {
+    pub fn text_input_style(
+        &self,
+    ) -> impl Fn(&Theme, text_input::Status) -> text_input::Style + use<> {
+        let radius_xl = self.radius.xl;
         move |theme: &Theme, status: text_input::Status| {
             let mut base = text_input::Style {
                 background: theme.palette().background.into(),
                 border: Border {
                     width: 2.0,
-                    radius: self.radius.xl.into(),
+                    radius: radius_xl.into(),
                     color: theme.extended_palette().background.weak.color,
                 },
                 icon: theme.palette().text,
@@ -604,13 +748,15 @@ impl AshellTheme {
 
     /// Module button style: transparent base with hover highlight.
     /// The Islands background is handled by `module_group`, not the button.
-    pub fn module_button_style(&self) -> impl Fn(&Theme, Status) -> button::Style {
+    pub fn module_button_style(&self) -> impl Fn(&Theme, Status) -> button::Style + use<> {
+        let radius_lg = self.radius.lg;
+        let opacity = self.opacity;
         move |theme, status| {
             let mut base = button::Style {
                 background: None,
                 border: Border {
                     width: 0.0,
-                    radius: self.radius.lg.into(),
+                    radius: radius_lg.into(),
                     color: Color::TRANSPARENT,
                 },
                 text_color: theme.palette().text,
@@ -625,7 +771,7 @@ impl AshellTheme {
                             .background
                             .weak
                             .color
-                            .scale_alpha(self.opacity)
+                            .scale_alpha(opacity)
                             .into(),
                     );
                     base


### PR DESCRIPTION
I decided to drop the AshellTheme ref parameter drilling to a thread_local variable. 

We lost just a little-little-bit of performance for a huge benefit in terms of API ergonomics