### PR TITLE
feat - Add experimental animation support

### DIFF
--- a/docs/src/core/config-system.md
+++ b/docs/src/core/config-system.md
@@ -32,6 +32,7 @@ pub struct Config {
     pub appearance: Appearance,
     pub media_player: MediaPlayerModuleConfig,
     pub keyboard_layout: KeyboardLayoutModuleConfig,
+    pub animations: AnimationsConfig,               // Master toggle for UI animations
     pub enable_esc_key: bool,                       // Default: false
 }
 ```

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -15,6 +15,7 @@ Complete reference for all configuration options in `~/.config/ashell/config.tom
 | `enable_esc_key` | bool | `false` | Whether ESC key closes menus |
 | `osd.enabled` | bool | `false` | Show OSD overlay for IPC volume/brightness/airplane commands |
 | `osd.timeout` | u64 | `1500` | OSD auto-hide delay in milliseconds |
+| `animations.enabled` | bool | `false` | Master toggle for UI animations (bar widths, menu open/close, toast slides, etc.) |
 
 ## Module Layout
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -120,7 +120,11 @@ impl App {
                 .map(|o| (o.name.clone(), Custom::new(o)))
                 .collect();
 
-            init_theme(AshellTheme::new(config.position, &config.appearance));
+            init_theme(AshellTheme::new(
+                config.position,
+                &config.appearance,
+                &config.animations,
+            ));
             init_localizer(resolve_localizer(&config));
 
             let notifications = Notifications::new(config.notifications);
@@ -158,7 +162,11 @@ impl App {
     }
 
     fn refresh_config(&mut self, config: Box<Config>) {
-        init_theme(AshellTheme::new(config.position, &config.appearance));
+        init_theme(AshellTheme::new(
+            config.position,
+            &config.appearance,
+            &config.animations,
+        ));
         init_localizer(resolve_localizer(&config));
         self.general_config = GeneralConfig {
             outputs: config.outputs,

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,7 @@ pub struct Config {
     pub appearance: Appearance,
     pub media_player: MediaPlayerModuleConfig,
     pub keyboard_layout: KeyboardLayoutModuleConfig,
+    pub animations: AnimationsConfig,
     pub enable_esc_key: bool,
     pub osd: OsdConfig,
 }
@@ -66,11 +67,18 @@ impl Default for Config {
             appearance: Appearance::default(),
             media_player: MediaPlayerModuleConfig::default(),
             keyboard_layout: KeyboardLayoutModuleConfig::default(),
+            animations: AnimationsConfig::default(),
             custom_modules: vec![],
             enable_esc_key: false,
             osd: OsdConfig::default(),
         }
     }
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(default)]
+pub struct AnimationsConfig {
+    pub enabled: bool,
 }
 
 impl Config {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -112,6 +112,9 @@ pub struct AshellTheme {
     pub workspace_colors: Vec<AppearanceColor>,
     pub special_workspace_colors: Option<Vec<AppearanceColor>>,
     pub scale_factor: f64,
+    // Read by animation call sites added in subsequent PRs.
+    #[allow(dead_code)]
+    pub animations_enabled: bool,
 }
 
 impl Default for AshellTheme {
@@ -129,6 +132,7 @@ impl Default for AshellTheme {
             workspace_colors: appearance.workspace_colors.clone(),
             special_workspace_colors: appearance.special_workspace_colors.clone(),
             scale_factor: appearance.scale_factor,
+            animations_enabled: false,
             iced_theme: Theme::custom_with_fn(
                 "local".to_string(),
                 Palette {
@@ -237,8 +241,13 @@ impl Default for AshellTheme {
 }
 
 impl AshellTheme {
-    pub fn new(position: Position, appearance: &Appearance) -> Self {
+    pub fn new(
+        position: Position,
+        appearance: &Appearance,
+        animations: &crate::config::AnimationsConfig,
+    ) -> Self {
         AshellTheme {
+            animations_enabled: animations.enabled,
             space: Space::default(),
             radius: Radius::default(),
             font_size: FontSize::default(),

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -94,6 +94,9 @@ tooltip = "Toggle On-Screen Keyboard"
 enabled = true   # disabled by default
 timeout = 1500
 
+[animations]
+enabled = true   # disabled by default
+
 [appearance]
 style = "Islands"
 

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -190,3 +190,15 @@ ashell msg volume-up --no-osd
 enabled = true   # Disabled by default; set to true to enable the OSD overlay
 timeout = 1500   # Auto-hide delay in milliseconds
 ```
+
+## Animations
+
+Ashell ships a master toggle for UI animations (bar module width transitions,
+menu open/close, toast slides, sub-menu accordion, toggle color fades, etc.).
+It defaults to `false`, so ashell keeps its historical static behavior unless
+you opt in:
+
+```toml
+[animations]
+enabled = true
+```


### PR DESCRIPTION
First PR that introduces a global flag to enable/disable animations. Default = false, this feature is still experimental