### PR TITLE
feat: add width animations for bar modules and workspace buttons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -149,6 +149,7 @@ dependencies = [
  "hyprland",
  "i18n-embed",
  "i18n-embed-fl",
+ "iced_anim",
  "iced_layershell",
  "inotify",
  "itertools 0.14.0",
@@ -868,7 +869,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -986,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1840,6 +1841,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "iced_anim"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea7e0f5f848b041abf2907eda96a4c21cbd5c3aee4ade434bd650d898f39e95b"
+dependencies = [
+ "iced_core",
 ]
 
 [[package]]
@@ -2797,7 +2807,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3713,7 +3723,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3770,7 +3780,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4326,7 +4336,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5309,7 +5319,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ iced = { package = "iced_layershell", git = "https://github.com/MalpenZibo/iced_
   "svg",
   "canvas",
 ] }
+iced_anim = "0.3"
 chrono = { version = "0.4", default-features = false, features = [
   "clock",
   "serde",

--- a/src/components/animated_size.rs
+++ b/src/components/animated_size.rs
@@ -250,7 +250,7 @@ where
 {
     AnimatedSize {
         content: content.into(),
-        duration: Duration::from_millis(400),
+        duration: Duration::from_millis(100),
         easing: Easing::EaseOutCubic,
     }
 }

--- a/src/components/animated_size.rs
+++ b/src/components/animated_size.rs
@@ -1,0 +1,256 @@
+use iced::{
+    Animation, Length, Rectangle, Size, Vector,
+    animation::Easing,
+    core::{
+        Clipboard, Layout, Shell, Widget, event, layout, mouse, overlay, renderer,
+        widget::{Operation, Tree, tree},
+    },
+};
+use std::time::{Duration, Instant};
+
+type Element<'a, Message, Theme, Renderer> = iced::core::Element<'a, Message, Theme, Renderer>;
+
+struct State {
+    width_anim: Animation<f32>,
+    last_child_width: f32,
+    initialized: bool,
+}
+
+impl State {
+    fn new(duration: Duration, easing: Easing) -> Self {
+        Self {
+            width_anim: Animation::new(0.0).duration(duration).easing(easing),
+            last_child_width: 0.0,
+            initialized: false,
+        }
+    }
+}
+
+/// A widget that automatically animates width changes of its content.
+///
+/// Wrap any element in `AnimatedSize` and it will smoothly transition
+/// when the content's natural width changes. No messages, subscriptions,
+/// or manual state management needed.
+///
+/// # Example
+/// ```ignore
+/// animated_size(text("Hello"))
+///     .duration(Duration::from_millis(400))
+/// ```
+pub struct AnimatedSize<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+where
+    Renderer: iced::core::Renderer,
+{
+    content: Element<'a, Message, Theme, Renderer>,
+    duration: Duration,
+    easing: Easing,
+}
+
+impl<'a, Message, Theme, Renderer> AnimatedSize<'a, Message, Theme, Renderer>
+where
+    Renderer: iced::core::Renderer,
+{
+    pub fn duration(mut self, duration: Duration) -> Self {
+        self.duration = duration;
+        self
+    }
+
+    pub fn easing(mut self, easing: Easing) -> Self {
+        self.easing = easing;
+        self
+    }
+}
+
+impl<'a, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for AnimatedSize<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+    Theme: 'a,
+    Renderer: iced::core::Renderer + 'a,
+{
+    fn tag(&self) -> tree::Tag {
+        tree::Tag::of::<State>()
+    }
+
+    fn state(&self) -> tree::State {
+        tree::State::new(State::new(self.duration, self.easing))
+    }
+
+    fn children(&self) -> Vec<Tree> {
+        vec![Tree::new(&self.content)]
+    }
+
+    fn diff(&self, tree: &mut Tree) {
+        tree.diff_children(std::slice::from_ref(&self.content));
+    }
+
+    fn size(&self) -> Size<Length> {
+        Size::new(Length::Shrink, Length::Shrink)
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let child_node =
+            self.content
+                .as_widget_mut()
+                .layout(&mut tree.children[0], renderer, limits);
+        let child_width = child_node.size().width;
+        let child_height = child_node.size().height;
+
+        let state = tree.state.downcast_mut::<State>();
+        let now = Instant::now();
+
+        if !state.initialized {
+            state.width_anim = Animation::new(child_width)
+                .duration(self.duration)
+                .easing(self.easing);
+            state.last_child_width = child_width;
+            state.initialized = true;
+        } else if (child_width - state.last_child_width).abs() > 0.5 {
+            state.last_child_width = child_width;
+            state.width_anim.go_mut(child_width, now);
+        }
+
+        let display_width = if state.width_anim.is_animating(now) {
+            state.width_anim.interpolate_with(|v| v, now)
+        } else {
+            child_width
+        };
+
+        layout::Node::with_children(Size::new(display_width, child_height), vec![child_node])
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut Tree,
+        event: &event::Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        self.content.as_widget_mut().update(
+            &mut tree.children[0],
+            event,
+            layout.children().next().unwrap(),
+            cursor,
+            renderer,
+            clipboard,
+            shell,
+            viewport,
+        );
+
+        if let event::Event::Window(iced::core::window::Event::RedrawRequested(now)) = event {
+            let state = tree.state.downcast_mut::<State>();
+            if state.width_anim.is_animating(*now) {
+                shell.request_redraw();
+                shell.invalidate_layout();
+            }
+        }
+    }
+
+    fn draw(
+        &self,
+        tree: &Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let bounds = layout.bounds();
+        renderer.with_layer(bounds, |renderer| {
+            self.content.as_widget().draw(
+                &tree.children[0],
+                renderer,
+                theme,
+                style,
+                layout.children().next().unwrap(),
+                cursor,
+                viewport,
+            );
+        });
+    }
+
+    fn operate(
+        &mut self,
+        tree: &mut Tree,
+        layout: Layout<'_>,
+        renderer: &Renderer,
+        operation: &mut dyn Operation,
+    ) {
+        self.content.as_widget_mut().operate(
+            &mut tree.children[0],
+            layout.children().next().unwrap(),
+            renderer,
+            operation,
+        );
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.content.as_widget().mouse_interaction(
+            &tree.children[0],
+            layout.children().next().unwrap(),
+            cursor,
+            viewport,
+            renderer,
+        )
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut Tree,
+        layout: Layout<'b>,
+        renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        self.content.as_widget_mut().overlay(
+            &mut tree.children[0],
+            layout.children().next()?,
+            renderer,
+            viewport,
+            translation,
+        )
+    }
+}
+
+impl<'a, Message, Theme, Renderer> From<AnimatedSize<'a, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    Message: Clone + 'a,
+    Theme: 'a,
+    Renderer: iced::core::Renderer + 'a,
+{
+    fn from(widget: AnimatedSize<'a, Message, Theme, Renderer>) -> Self {
+        Self::new(widget)
+    }
+}
+
+/// Wraps content in a widget that automatically animates width changes.
+pub fn animated_size<'a, Message, Theme, Renderer>(
+    content: impl Into<Element<'a, Message, Theme, Renderer>>,
+) -> AnimatedSize<'a, Message, Theme, Renderer>
+where
+    Renderer: iced::core::Renderer,
+{
+    AnimatedSize {
+        content: content.into(),
+        duration: Duration::from_millis(400),
+        easing: Easing::EaseOutCubic,
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod animated_size;
 pub mod button;
 mod centerbox;
 mod format_indicator;
@@ -12,6 +13,7 @@ mod quick_setting_button;
 mod slider_control;
 mod sub_menu_wrapper;
 
+pub use animated_size::animated_size;
 pub use button::*;
 pub use centerbox::*;
 pub use format_indicator::*;

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -1,5 +1,6 @@
 use crate::{
     app::{App, Message},
+    components::animated_size,
     components::menu::MenuType,
     components::{module_group, module_item},
     config::{ModuleDef, ModuleName},
@@ -81,6 +82,11 @@ impl App {
         content: Element<'a, Message>,
         action: Option<OnModulePress>,
     ) -> Element<'a, Message> {
+        let content = if use_theme(|t| t.animations_enabled) {
+            animated_size(content).into()
+        } else {
+            content
+        };
         match action {
             Some(action) => {
                 let mut item = module_item(content);

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -481,7 +481,7 @@ impl Workspaces {
                                             })
                                         })
                                         .animates_layout(true)
-                                        .animation(Easing::EASE.quick())
+                                        .animation(Easing::EASE.very_quick())
                                         .into()
                                     }
                                     Some(tw) => button(

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -11,6 +11,7 @@ use iced::{
     Element, Length, Subscription, SurfaceId, alignment,
     widget::{MouseArea, Row, button, container, text},
 };
+use iced_anim::{AnimationBuilder, transition::Easing};
 use itertools::Itertools;
 use std::collections::HashMap;
 
@@ -437,14 +438,15 @@ impl Workspaces {
                                 }
                             });
 
-                            Some(
-                                button(
-                                    container(text(w.name.as_str()).size(theme.font_size.xs))
-                                        .align_x(alignment::Horizontal::Center)
-                                        .align_y(alignment::Vertical::Center),
-                                )
-                                .style(theme.workspace_button_style(empty, color))
-                                .padding(if w.id < 0 {
+                            {
+                                let target_width = match (w.id < 0, &w.displayed) {
+                                    (true, _) => None,
+                                    (_, Displayed::Active) => Some(theme.space.xl),
+                                    (_, Displayed::Visible) => Some(theme.space.lg),
+                                    (_, Displayed::Hidden) => Some(theme.space.md),
+                                };
+                                let name = w.name.clone();
+                                let padding = if w.id < 0 {
                                     match w.displayed {
                                         Displayed::Active => [0.0, theme.space.md],
                                         Displayed::Visible => [0.0, theme.space.sm],
@@ -452,21 +454,60 @@ impl Workspaces {
                                     }
                                 } else {
                                     [0.0, 0.0]
-                                })
-                                .on_press(if w.id > 0 {
+                                };
+                                let on_press = if w.id > 0 {
                                     Message::ChangeWorkspace(w.id)
                                 } else {
                                     Message::ToggleSpecialWorkspace(w.id)
+                                };
+                                let font_size = theme.font_size.xs;
+                                let height = theme.space.md;
+
+                                Some(match target_width {
+                                    Some(tw) if theme.animations_enabled => {
+                                        AnimationBuilder::new(tw, move |w| {
+                                            use_theme(|theme| {
+                                                button(
+                                                    container(text(name.clone()).size(font_size))
+                                                        .align_x(alignment::Horizontal::Center)
+                                                        .align_y(alignment::Vertical::Center),
+                                                )
+                                                .style(theme.workspace_button_style(empty, color))
+                                                .padding(padding)
+                                                .on_press(on_press.clone())
+                                                .width(Length::Fixed(w))
+                                                .height(height)
+                                                .into()
+                                            })
+                                        })
+                                        .animates_layout(true)
+                                        .animation(Easing::EASE.quick())
+                                        .into()
+                                    }
+                                    Some(tw) => button(
+                                        container(text(name).size(font_size))
+                                            .align_x(alignment::Horizontal::Center)
+                                            .align_y(alignment::Vertical::Center),
+                                    )
+                                    .style(theme.workspace_button_style(empty, color))
+                                    .padding(padding)
+                                    .on_press(on_press)
+                                    .width(Length::Fixed(tw))
+                                    .height(height)
+                                    .into(),
+                                    None => button(
+                                        container(text(name).size(font_size))
+                                            .align_x(alignment::Horizontal::Center)
+                                            .align_y(alignment::Vertical::Center),
+                                    )
+                                    .style(theme.workspace_button_style(empty, color))
+                                    .padding(padding)
+                                    .on_press(on_press)
+                                    .width(Length::Shrink)
+                                    .height(height)
+                                    .into(),
                                 })
-                                .width(match (w.id < 0, &w.displayed) {
-                                    (true, _) => Length::Shrink,
-                                    (_, Displayed::Active) => Length::Fixed(theme.space.xl),
-                                    (_, Displayed::Visible) => Length::Fixed(theme.space.lg),
-                                    (_, Displayed::Hidden) => Length::Fixed(theme.space.md),
-                                })
-                                .height(theme.space.md)
-                                .into(),
-                            )
+                            }
                         } else {
                             None
                         }


### PR DESCRIPTION
Add two complementary animation approaches:

- AnimatedSize widget: auto-detects and smoothly animates content width changes. 

- iced_anim::AnimationBuilder: used in workspaces for explicit button width transitions between active/visible/hidden states.