### PR TITLE
feature: idle inhibitor ipc, osd + 3 related fixes

### DIFF
--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -91,9 +91,10 @@ ashell msg microphone-toggle-mute
 ashell msg brightness-up
 ashell msg brightness-down
 ashell msg airplane-toggle
+ashell msg toggle-idle-inhibitor
 ```
 
-Volume, microphone, brightness, and airplane commands show an OSD overlay. Add `--no-osd` to suppress it.
+Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD overlay. Add `--no-osd` to suppress it.
 
 ## Signal Handling
 

--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -90,7 +90,7 @@ ashell msg microphone-down
 ashell msg microphone-toggle-mute
 ashell msg brightness-up
 ashell msg brightness-down
-ashell msg airplane-toggle
+ashell msg toggle-airplane-mode
 ashell msg toggle-idle-inhibitor
 ```
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -282,6 +282,14 @@ impl App {
                 let active = !self.settings.network().is_airplane_mode().unwrap_or(false);
                 Some((OsdKind::Airplane, 0.0, active))
             }
+            IpcCommand::ToggleIdleInhibitor { .. } => {
+                if let Some(idle_inhibitor) = self.settings.idle_inhibitor() {
+                    let active = idle_inhibitor.is_inhibited();
+                    Some((OsdKind::IdleInhibitor, 0.0, active))
+                } else {
+                    None
+                }
+            }
             IpcCommand::ToggleVisibility => None,
         }
     }
@@ -536,6 +544,7 @@ impl App {
                     IpcCommand::BrightnessUp { .. } => self.settings.brightness_adjust(true),
                     IpcCommand::BrightnessDown { .. } => self.settings.brightness_adjust(false),
                     IpcCommand::AirplaneToggle { .. } => self.settings.toggle_airplane(),
+                    IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
                     IpcCommand::ToggleVisibility => unreachable!(),
                 };
                 if let settings::Action::Command(task) = action {

--- a/src/app.rs
+++ b/src/app.rs
@@ -276,7 +276,7 @@ impl App {
                 .brightness()
                 .current_brightness()
                 .map(|(cur, max)| (OsdKind::Brightness, normalise(cur, max), false)),
-            IpcCommand::AirplaneToggle { .. } => {
+            IpcCommand::ToggleAirplaneMode { .. } => {
                 // After toggle: the new state is the opposite of current.
                 // For toggles, `muted` carries the active/enabled state; `value` is unused.
                 let active = !self.settings.network().is_airplane_mode().unwrap_or(false);
@@ -543,7 +543,7 @@ impl App {
                     }
                     IpcCommand::BrightnessUp { .. } => self.settings.brightness_adjust(true),
                     IpcCommand::BrightnessDown { .. } => self.settings.brightness_adjust(false),
-                    IpcCommand::AirplaneToggle { .. } => self.settings.toggle_airplane(),
+                    IpcCommand::ToggleAirplaneMode { .. } => self.settings.toggle_airplane(),
                     IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
                     IpcCommand::ToggleVisibility => unreachable!(),
                 };

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -57,6 +57,10 @@ pub enum IpcCommand {
         #[arg(long)]
         no_osd: bool,
     },
+    ToggleIdleInhibitor {
+        #[arg(long)]
+        no_osd: bool,
+    },
 }
 
 impl IpcCommand {
@@ -71,7 +75,8 @@ impl IpcCommand {
             | IpcCommand::MicrophoneToggleMute { no_osd }
             | IpcCommand::BrightnessUp { no_osd }
             | IpcCommand::BrightnessDown { no_osd }
-            | IpcCommand::AirplaneToggle { no_osd } => *no_osd,
+            | IpcCommand::AirplaneToggle { no_osd }
+            | IpcCommand::ToggleIdleInhibitor { no_osd } => *no_osd,
         }
     }
 }
@@ -91,6 +96,7 @@ impl fmt::Display for IpcCommand {
             IpcCommand::BrightnessUp { .. } => "brightness-up",
             IpcCommand::BrightnessDown { .. } => "brightness-down",
             IpcCommand::AirplaneToggle { .. } => "airplane-toggle",
+            IpcCommand::ToggleIdleInhibitor { .. } => "toggle-idle-inhibitor",
         };
         write!(f, "{base}")?;
         if self.no_osd() {
@@ -119,6 +125,7 @@ impl FromStr for IpcCommand {
             "brightness-up" => Ok(IpcCommand::BrightnessUp { no_osd }),
             "brightness-down" => Ok(IpcCommand::BrightnessDown { no_osd }),
             "airplane-toggle" => Ok(IpcCommand::AirplaneToggle { no_osd }),
+            "toggle-idle-inhibitor" => Ok(IpcCommand::ToggleIdleInhibitor { no_osd }),
             _ => Err(anyhow!("unknown IPC command: {s:?}")),
         }
     }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -53,7 +53,7 @@ pub enum IpcCommand {
         #[arg(long)]
         no_osd: bool,
     },
-    AirplaneToggle {
+    ToggleAirplaneMode {
         #[arg(long)]
         no_osd: bool,
     },
@@ -75,7 +75,7 @@ impl IpcCommand {
             | IpcCommand::MicrophoneToggleMute { no_osd }
             | IpcCommand::BrightnessUp { no_osd }
             | IpcCommand::BrightnessDown { no_osd }
-            | IpcCommand::AirplaneToggle { no_osd }
+            | IpcCommand::ToggleAirplaneMode { no_osd }
             | IpcCommand::ToggleIdleInhibitor { no_osd } => *no_osd,
         }
     }
@@ -95,7 +95,7 @@ impl fmt::Display for IpcCommand {
             IpcCommand::MicrophoneToggleMute { .. } => "microphone-toggle-mute",
             IpcCommand::BrightnessUp { .. } => "brightness-up",
             IpcCommand::BrightnessDown { .. } => "brightness-down",
-            IpcCommand::AirplaneToggle { .. } => "airplane-toggle",
+            IpcCommand::ToggleAirplaneMode { .. } => "toggle-airplane-mode",
             IpcCommand::ToggleIdleInhibitor { .. } => "toggle-idle-inhibitor",
         };
         write!(f, "{base}")?;
@@ -124,7 +124,7 @@ impl FromStr for IpcCommand {
             "microphone-toggle-mute" => Ok(IpcCommand::MicrophoneToggleMute { no_osd }),
             "brightness-up" => Ok(IpcCommand::BrightnessUp { no_osd }),
             "brightness-down" => Ok(IpcCommand::BrightnessDown { no_osd }),
-            "airplane-toggle" => Ok(IpcCommand::AirplaneToggle { no_osd }),
+            "toggle-airplane-mode" => Ok(IpcCommand::ToggleAirplaneMode { no_osd }),
             "toggle-idle-inhibitor" => Ok(IpcCommand::ToggleIdleInhibitor { no_osd }),
             _ => Err(anyhow!("unknown IPC command: {s:?}")),
         }

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -131,6 +131,10 @@ impl Settings {
         &self.network
     }
 
+    pub fn idle_inhibitor(&self) -> &Option<IdleInhibitorManager> {
+        &self.idle_inhibitor
+    }
+
     pub fn volume_adjust(&mut self, up: bool) -> Action {
         match self.audio.volume_adjust(up) {
             audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
@@ -168,6 +172,13 @@ impl Settings {
             network::Action::Command(task) => Action::Command(task.map(Message::Network)),
             _ => Action::None,
         }
+    }
+
+    pub fn toggle_idle_inhibitor(&mut self) -> Action {
+        if let Some(idle_inhibitor) = &mut self.idle_inhibitor {
+            idle_inhibitor.toggle();
+        }
+        Action::None
     }
 
     pub fn new(config: SettingsModuleConfig) -> Self {
@@ -609,11 +620,9 @@ impl Settings {
                     self.idle_inhibitor.as_ref().map(|idle_inhibitor| {
                         (
                             quick_setting_button(
-                                if idle_inhibitor.is_inhibited() {
-                                    StaticIcon::EyeOpened
-                                } else {
-                                    StaticIcon::EyeClosed
-                                },
+                                IdleInhibitorManager::idle_inhibitor_icon(
+                                    idle_inhibitor.is_inhibited(),
+                                ),
                                 "Idle Inhibitor".to_string(),
                                 None,
                                 idle_inhibitor.is_inhibited(),
@@ -718,18 +727,17 @@ impl Settings {
         for indicator in &self.indicators {
             match indicator {
                 SettingsIndicator::IdleInhibitor => {
-                    if let Some(element) = self
-                        .idle_inhibitor
-                        .as_ref()
-                        .filter(|i| i.is_inhibited())
-                        .map(|_| {
-                            container(icon(StaticIcon::EyeOpened)).style(|theme: &Theme| {
-                                container::Style {
-                                    text_color: Some(theme.palette().danger),
-                                    ..Default::default()
-                                }
+                    if let Some(element) =
+                        self.idle_inhibitor
+                            .as_ref()
+                            .filter(|i| i.is_inhibited())
+                            .map(|_| {
+                                container(icon(IdleInhibitorManager::idle_inhibitor_icon(true)))
+                                    .style(|theme: &Theme| container::Style {
+                                        text_color: Some(theme.palette().danger),
+                                        ..Default::default()
+                                    })
                             })
-                        })
                     {
                         row = row.push(element);
                     }

--- a/src/osd.rs
+++ b/src/osd.rs
@@ -131,14 +131,15 @@ impl Osd {
                 }
                 container(bar).center_x(Length::Fill).into()
             }
-            OsdKind::Airplane => {
+            OsdKind::Airplane | OsdKind::IdleInhibitor => {
+                let subject = match state.kind {
+                    OsdKind::Airplane => "Airplane mode",
+                    OsdKind::IdleInhibitor => "Idle inhibitor",
+                    _ => "",
+                };
                 // For toggles, `muted` carries the active/enabled state.
-                let label = if state.muted { "Enabled" } else { "Disabled" };
-                container(text(label)).center_x(Length::Fill).into()
-            }
-            OsdKind::IdleInhibitor => {
                 let state = if state.muted { "on" } else { "off" };
-                container(text(format!("Idle inhibitor turned {state}")))
+                container(text(format!("{subject} turned {state}")))
                     .center_x(Length::Fill)
                     .into()
             }
@@ -161,6 +162,7 @@ impl Osd {
                     .rounded(radius.xl),
                 text_color: Some(match (state.kind, state.muted) {
                     (OsdKind::IdleInhibitor, true) => t.palette().danger,
+                    (OsdKind::Airplane, true) => t.palette().danger,
                     _ => t.palette().text,
                 }),
                 ..Default::default()

--- a/src/osd.rs
+++ b/src/osd.rs
@@ -10,6 +10,7 @@ use crate::{
     components::icons::{Icon, StaticIcon},
     config::OsdConfig,
     modules::settings::audio::AudioSettings,
+    services::idle_inhibitor::IdleInhibitorManager,
     theme::use_theme,
 };
 
@@ -32,6 +33,7 @@ pub enum OsdKind {
     Microphone,
     Brightness,
     Airplane,
+    IdleInhibitor,
 }
 
 #[derive(Debug, Clone)]
@@ -116,6 +118,7 @@ impl Osd {
             OsdKind::Microphone => AudioSettings::microphone_icon(state.muted),
             OsdKind::Brightness => StaticIcon::Brightness,
             OsdKind::Airplane => StaticIcon::Airplane,
+            OsdKind::IdleInhibitor => IdleInhibitorManager::idle_inhibitor_icon(state.muted),
         };
 
         let detail: Element<'_, Message> = match state.kind {
@@ -133,6 +136,12 @@ impl Osd {
                 let label = if state.muted { "Enabled" } else { "Disabled" };
                 container(text(label)).center_x(Length::Fill).into()
             }
+            OsdKind::IdleInhibitor => {
+                let state = if state.muted { "on" } else { "off" };
+                container(text(format!("Idle inhibitor turned {state}")))
+                    .center_x(Length::Fill)
+                    .into()
+            }
         };
 
         let content = row![icon.to_text().size(font_size.xxl), detail,]
@@ -147,7 +156,10 @@ impl Osd {
                     .width(1)
                     .color(t.extended_palette().background.weakest.color)
                     .rounded(radius.xl),
-
+                text_color: Some(match (state.kind, state.muted) {
+                    (OsdKind::IdleInhibitor, true) => t.palette().danger,
+                    _ => t.palette().text,
+                }),
                 ..Default::default()
             })
             .center_x(Length::Fill)

--- a/src/osd.rs
+++ b/src/osd.rs
@@ -144,9 +144,12 @@ impl Osd {
             }
         };
 
-        let content = row![icon.to_text().size(font_size.xxl), detail,]
-            .spacing(space.sm)
-            .align_y(Alignment::Center);
+        let content = row![
+            container(icon.to_text().size(font_size.xxl)).center_x(font_size.xxl),
+            detail,
+        ]
+        .spacing(space.sm)
+        .align_y(Alignment::Center);
 
         container(content)
             .padding([space.sm, space.md])

--- a/src/services/idle_inhibitor.rs
+++ b/src/services/idle_inhibitor.rs
@@ -1,3 +1,4 @@
+use crate::components::icons::StaticIcon;
 use log::{debug, info, warn};
 use std::os::fd::{AsFd, AsRawFd, FromRawFd};
 use wayland_client::{
@@ -191,6 +192,14 @@ impl IdleInhibitorManager {
         }
 
         Ok(())
+    }
+
+    pub fn idle_inhibitor_icon(active: bool) -> StaticIcon {
+        if active {
+            StaticIcon::EyeOpened
+        } else {
+            StaticIcon::EyeClosed
+        }
     }
 }
 

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -52,8 +52,10 @@ Available commands:
 | `brightness-up`          | Increase screen brightness by 5%     |
 | `brightness-down`        | Decrease screen brightness by 5%     |
 | `airplane-toggle`        | Toggle airplane mode                 |
+| `toggle-idle-inhibitor`  | Toggle idle inhibitor                |
 
-Volume, microphone, brightness, and airplane commands show an OSD (On-Screen Display)
+
+Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD (On-Screen Display)
 overlay by default. Add `--no-osd` to suppress it:
 
 ```bash

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -51,7 +51,7 @@ Available commands:
 | `microphone-toggle-mute` | Toggle source mute                   |
 | `brightness-up`          | Increase screen brightness by 5%     |
 | `brightness-down`        | Decrease screen brightness by 5%     |
-| `airplane-toggle`        | Toggle airplane mode                 |
+| `toggle-airplane-mode`   | Toggle airplane mode                 |
 | `toggle-idle-inhibitor`  | Toggle idle inhibitor                |
 
 

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -154,8 +154,8 @@ kill -SIGUSR1 $(pidof ashell)
 
 ## OSD (On-Screen Display)
 
-Ashell can show a transient overlay when volume, microphone, brightness, or airplane mode
-changes via IPC commands. This is useful for binding compositor keys to ashell:
+Ashell can show a transient overlay when volume, microphone, brightness, airplane mode
+or idle inhibitor changes via IPC commands. This is useful for binding compositor keys to ashell:
 
 ```bash
 # Volume
@@ -174,6 +174,9 @@ ashell msg brightness-down
 
 # Airplane mode
 ashell msg airplane-toggle
+
+# Idle Inhibitor
+ashell msg toggle-idle-inhibitor
 ```
 
 The OSD appears at center-bottom and auto-hides after a timeout. To suppress

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -173,7 +173,7 @@ ashell msg brightness-up
 ashell msg brightness-down
 
 # Airplane mode
-ashell msg airplane-toggle
+ashell msg toggle-airplane-mode
 
 # Idle Inhibitor
 ashell msg toggle-idle-inhibitor


### PR DESCRIPTION
Part of #673 

I have added three related fixes in separate commits:

1. There is subtle horizontal volume bar jiggle due to varying icon glyph widths, it is noticeable when muting/unmuting both volume and microphone. So I have put the icon in a container and set width to its height.
2. I have made airplane mode activation toast icon and message red (.danger) color and made message more expressive.
3. Changed `airplane-toggle` ipc to `toggle-airplane-mode`.