### PR TITLE
feat(settings): add `remove_hibernate_btn` support in power menu

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -567,6 +567,7 @@ pub struct SettingsModuleConfig {
     pub vpn_more_cmd: Option<String>,
     pub bluetooth_more_cmd: Option<String>,
     pub remove_airplane_btn: bool,
+    pub remove_hibernate_btn: bool,
     pub remove_idle_btn: bool,
     pub indicators: Vec<SettingsIndicator>,
     #[serde(rename = "CustomButton")]
@@ -598,6 +599,7 @@ impl Default for SettingsModuleConfig {
             vpn_more_cmd: Default::default(),
             bluetooth_more_cmd: Default::default(),
             remove_airplane_btn: Default::default(),
+            remove_hibernate_btn: Default::default(),
             remove_idle_btn: Default::default(),
             indicators: vec![
                 SettingsIndicator::IdleInhibitor,

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -184,6 +184,7 @@ impl Settings {
                 config.peripheral_indicators,
                 config.peripheral_battery_format,
                 config.peripheral_expanded_by_default,
+                config.remove_hibernate_btn,
             )),
             audio: AudioSettings::new(AudioSettingsConfig::new(
                 config.audio_sinks_more_cmd,
@@ -497,6 +498,7 @@ impl Settings {
                         config.peripheral_indicators,
                         config.peripheral_battery_format,
                         config.peripheral_expanded_by_default,
+                        config.remove_hibernate_btn,
                     )));
                 self.audio
                     .update(audio::Message::ConfigReloaded(AudioSettingsConfig::new(

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -76,6 +76,7 @@ pub struct PowerSettingsConfig {
     pub peripheral_indicators: PeripheralIndicators,
     pub peripheral_battery_format: SettingsFormat,
     pub peripheral_expanded_by_default: bool,
+    pub remove_hibernate_btn: bool,
 }
 
 impl PowerSettingsConfig {
@@ -91,6 +92,7 @@ impl PowerSettingsConfig {
         peripheral_indicators: PeripheralIndicators,
         peripheral_battery_format: SettingsFormat,
         peripheral_expanded_by_default: bool,
+        remove_hibernate_btn: bool,
     ) -> Self {
         Self {
             suspend_cmd,
@@ -103,6 +105,7 @@ impl PowerSettingsConfig {
             peripheral_indicators,
             peripheral_battery_format,
             peripheral_expanded_by_default,
+            remove_hibernate_btn,
         }
     }
 }
@@ -178,10 +181,16 @@ impl PowerSettings {
                 .icon(StaticIcon::Suspend, IconPosition::Before)
                 .on_press(Message::Suspend)
                 .width(Length::Fill),
-            styled_button("Hibernate")
-                .icon(StaticIcon::Hibernate, IconPosition::Before)
-                .on_press(Message::Hibernate)
-                .width(Length::Fill),
+            if self.config.remove_hibernate_btn {
+                None
+            } else {
+                Some(
+                    styled_button("Hibernate")
+                        .icon(StaticIcon::Hibernate, IconPosition::Before)
+                        .on_press(Message::Hibernate)
+                        .width(Length::Fill),
+                )
+            },
             styled_button("Reboot")
                 .icon(StaticIcon::Reboot, IconPosition::Before)
                 .on_press(Message::Reboot)

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -63,6 +63,9 @@ Right-clicking the Wi-Fi, VPN, Bluetooth or airplane-mode quick settings buttons
 
 With the `remove_airplane_btn` option you can remove the airplane mode button.
 
+With the `remove_hibernate_btn` option you can remove the hibernate button from the power menu.  
+Useful on systems where hibernation is unavailable, for example devices that use zram.
+
 With the `remove_idle_btn` option you can remove the idle inhibitor button.
 
 ## Indicator Format Options
@@ -365,6 +368,7 @@ wifi_more_cmd = "nm-connection-editor"
 vpn_more_cmd = "nm-connection-editor"
 bluetooth_more_cmd = "blueman-manager"
 remove_airplane_btn = true
+remove_hibernate_btn = true
 remove_idle_btn = true
 indicators = ["Battery", "Bluetooth", "Network", "Audio", "Microphone", "Brightness"]
 


### PR DESCRIPTION
Add support for `remove_hibernate_btn` so the Hibernate action can be hidden from the power settings menu on devices where hibernation is not usable, such as systems using zram.

## Changes
- Added `remove_hibernate_btn` to settings config
- Passed the config through settings initialization and reload handling
- Hid the Hibernate button in `PowerSettings::menu()` when enabled
- Updated the docs in the website docs

## Notes
This helps avoid showing a Hibernate action that would not work on affected systems.

---

### Before (0.8.0)
<img width="343" height="269" alt="ภาพ" src="https://github.com/user-attachments/assets/cda139c9-860a-4f50-8644-ab45730856cc" />

### After
<img width="342" height="295" alt="ภาพ" src="https://github.com/user-attachments/assets/652a09a6-c181-4488-9f23-14a265ba76b7" />
