### PR TITLE
fix(tray): drop malformed icon pixmaps to avoid panic

### DIFF
--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -267,6 +267,55 @@ pub enum TrayIcon {
     Svg(svg::Handle),
 }
 
+fn pixmap_to_icon(icons: Vec<dbus::Icon>) -> Option<TrayIcon> {
+    icons
+        .into_iter()
+        .filter(|i| {
+            // SNI clients sometimes return entries with zero dimensions or a
+            // bytes payload that doesn't match width*height*4 (e.g. when only
+            // IconName is populated). Feeding those to iced's atlas uploader
+            // panics in the padding loop, so drop them up front.
+            if i.width <= 0 || i.height <= 0 {
+                debug!(
+                    "unable to convert pixmap to icon: invalid dimensions {}x{}",
+                    i.width, i.height
+                );
+                return false;
+            }
+            let expected = (i.width as usize)
+                .checked_mul(i.height as usize)
+                .and_then(|v| v.checked_mul(4));
+
+            if Some(i.bytes.len()) != expected {
+                debug!(
+                    "pixmap byte mismatch ({}x{} expected {:?} bytes, got {})",
+                    i.width,
+                    i.height,
+                    expected,
+                    i.bytes.len()
+                );
+                return false;
+            }
+
+            true
+        })
+        .max_by_key(|i| {
+            trace!("tray icon w {}, h {}", i.width, i.height);
+            (i.width, i.height)
+        })
+        .map(|mut i| {
+            // Convert ARGB to RGBA
+            for pixel in i.bytes.chunks_exact_mut(4) {
+                pixel.rotate_left(1);
+            }
+            TrayIcon::Image(image::Handle::from_rgba(
+                i.width as u32,
+                i.height as u32,
+                i.bytes,
+            ))
+        })
+}
+
 #[derive(Debug, Clone)]
 pub enum TrayEvent {
     Registered(StatusNotifierItem),
@@ -301,29 +350,9 @@ impl StatusNotifierItem {
 
         debug!("item_proxy {item_proxy:?}");
 
-        let icon_pixmap = item_proxy.icon_pixmap().await;
-
-        let icon = match icon_pixmap {
-            Ok(icons) => {
-                icons
-                    .into_iter()
-                    .max_by_key(|i| {
-                        trace!("tray icon w {}, h {}", i.width, i.height);
-                        (i.width, i.height)
-                    })
-                    .map(|mut i| {
-                        // Convert ARGB to RGBA
-                        for pixel in i.bytes.chunks_exact_mut(4) {
-                            pixel.rotate_left(1);
-                        }
-                        TrayIcon::Image(image::Handle::from_rgba(
-                            i.width as u32,
-                            i.height as u32,
-                            i.bytes,
-                        ))
-                    })
-            }
-            Err(_) => item_proxy
+        let icon = match item_proxy.icon_pixmap().await.ok().and_then(pixmap_to_icon) {
+            Some(icon) => Some(icon),
+            None => item_proxy
                 .icon_name()
                 .await
                 .ok()
@@ -453,27 +482,9 @@ impl TrayService {
                         move |icon| {
                             let name = name.clone();
                             async move {
-                                icon.get().await.ok().and_then(|icon| {
-                                    icon.into_iter()
-                                        .max_by_key(|i| {
-                                            trace!("tray icon w {}, h {}", i.width, i.height);
-                                            (i.width, i.height)
-                                        })
-                                        .map(|mut i| {
-                                            // Convert ARGB to RGBA
-                                            for pixel in i.bytes.chunks_exact_mut(4) {
-                                                pixel.rotate_left(1);
-                                            }
-                                            TrayEvent::IconChanged(
-                                                name.to_owned(),
-                                                TrayIcon::Image(image::Handle::from_rgba(
-                                                    i.width as u32,
-                                                    i.height as u32,
-                                                    i.bytes,
-                                                )),
-                                            )
-                                        })
-                                })
+                                let icons = icon.get().await.ok()?;
+                                pixmap_to_icon(icons)
+                                    .map(|icon| TrayEvent::IconChanged(name.to_owned(), icon))
                             }
                         }
                     })


### PR DESCRIPTION
As an example, the PX struct in fyne.io/systray can initialize to an empty pixmap, which was resulting in a core dump from iced.

Filter those entries before picking the icon.

Additionally, refactor the conversion so both the initial quert and the property change subscription applies the same validation.