### PR TITLE
fix: improve text truncation accuracy using grapheme clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,7 @@ dependencies = [
  "tokio-stream",
  "toml",
  "udev",
+ "unicode-segmentation",
  "url",
  "wayland-client",
  "wayland-protocols",
@@ -808,7 +809,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -926,7 +927,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2588,7 +2589,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3448,7 +3449,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3505,7 +3506,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4050,7 +4051,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4450,9 +4451,9 @@ checksum = "383ad40bb927465ec0ce7720e033cb4ca06912855fc35db31b5755d0de75b1ee"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-vo"
@@ -4989,7 +4990,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ log = { version = "0.4", features = [] }
 flexi_logger = "0.31"
 pipewire = "0.9"
 itertools = "0.14"
+unicode-segmentation = "1.13.2"
 hex_color = { version = "3", features = ["serde"] }
 anyhow = "1"
 udev = { version = "0.9", features = ["send", "sync"] }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+use unicode_segmentation::UnicodeSegmentation;
+
 pub mod launcher;
 pub mod remote_value;
 
@@ -22,12 +24,13 @@ pub fn format_duration(duration: &Duration) -> String {
 }
 
 pub fn truncate_text(value: &str, max_length: u32) -> String {
-    let length = value.len();
+    let graphemes = value.graphemes(true).collect::<Vec<&str>>();
+    let length = graphemes.len();
 
     if length > max_length as usize {
         let split = max_length as usize / 2;
-        let first_part = value.chars().take(split).collect::<String>();
-        let last_part = value.chars().skip(length - split).collect::<String>();
+        let first_part = graphemes[..split].concat();
+        let last_part = graphemes[length - split..].concat();
         format!("{first_part}...{last_part}")
     } else {
         value.to_string()

--- a/website/docs/configuration/modules/window_title.md
+++ b/website/docs/configuration/modules/window_title.md
@@ -25,6 +25,8 @@ The `truncate_title_after_length` field limits how long the displayed title can 
 - **Set to 0**: Shows the full title up to the 2048 character limit
 - **Default**: 150 characters
 
+This limit uses grapheme-aware counting, so complex scripts and combining characters are handled fairly.
+
 **Important**: Window titles are **hard-limited to 2048 characters** regardless of configuration. This prevents Wayland socket buffer overflow errors that can cause crashes when applications (like games) send very long titles.
 
 When titles are too long, they're shortened to show the beginning and end with "..." in between, so you can still see both the app name and part of the title.


### PR DESCRIPTION
Fixes the text truncation logic to ensure consistent display lengths across all languages and prevents splitting combined characters (e.g., Thai vowels, emojis).

## Problem & Solution

The previous logic relied on byte or scalar lengths, causing aggressive and uneven truncation for multi-byte scripts (Thai, CJK) and complex emojis. 

**Fix:** Migrated to **Grapheme Clusters** via the `unicode-segmentation` crate to count actual "visual characters". This ensures accurate length limits and keeps complex characters intact.

### Screenshots

<img width="649" height="342" alt="ยังไม่ตั้งชื่อ" src="https://github.com/user-attachments/assets/bdd0c915-3eff-414e-ae3e-30d04685be0d" />

**Visual Improvements (Top: Old, Bottom: New):**
* **Thai & Window Titles:** Fully utilizes available UI space instead of cutting off prematurely.
* **Khmer Script:** Now correctly identified as within the length limit, displaying the entire string without unnecessary `...`.
* **English (ASCII):** Remains perfectly intact, confirming our baseline behavior is unaffected.

### Testing Checklist
- [x] English (ASCII)
- [x] Thai (Complex Script)
- [x] Emojis & ZWJ
- [x] CJK (Japanese/Chinese/Korean)
- [x] European (Diacritics) & RTL (Optional)
- [x] Edge Case