### PR TITLE
fix(tray): keep menu open when toggling a checkbox item

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -414,6 +414,7 @@ impl App {
                         .close_all_menus(self.general_config.enable_esc_key),
                     task.map(Message::Tray),
                 ]),
+                modules::tray::Action::TrayMenuCommandKeepOpen(task) => task.map(Message::Tray),
                 modules::tray::Action::CloseTrayMenu(name) => self
                     .outputs
                     .close_all_menu_if(MenuType::Tray(name), self.general_config.enable_esc_key),

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -27,6 +27,7 @@ pub enum Message {
     ToggleMenu(String, SurfaceId, ButtonUIRef),
     ToggleSubmenu(i32),
     MenuSelected(String, i32),
+    MenuToggled(String, i32),
     MenuOpened(String),
 }
 
@@ -34,6 +35,7 @@ pub enum Action {
     None,
     ToggleMenu(String, SurfaceId, ButtonUIRef),
     TrayMenuCommand(Task<Message>),
+    TrayMenuCommandKeepOpen(Task<Message>),
     CloseTrayMenu(String),
 }
 
@@ -102,6 +104,17 @@ impl TrayModule {
                 }
                 _ => Action::None,
             },
+            Message::MenuToggled(name, id) => match self.service.as_mut() {
+                Some(service) => {
+                    debug!("Tray menu toggle: {id}");
+                    Action::TrayMenuCommandKeepOpen(
+                        service
+                            .command(TrayCommand::MenuSelected(name, id))
+                            .map(|event| Message::Event(Box::new(event))),
+                    )
+                }
+                _ => Action::None,
+            },
             Message::MenuOpened(name) => {
                 if let Some(_tray) = self
                     .service
@@ -131,7 +144,7 @@ impl TrayModule {
                         let name = name.to_owned();
                         let id = layout.0;
 
-                        move |_| Message::MenuSelected(name.to_owned(), id)
+                        move |_| Message::MenuToggled(name.to_owned(), id)
                     })
                     .width(Length::Fill),
             )


### PR DESCRIPTION
Toggling a checkmark item dispatched the same MenuSelected message as a regular click, so the handler in app.rs closed all menus immediately.

This change routes checkbox toggles through a dedicated MenuToggled message and that runs the SNI command without closing the menu, matching how desktop tray menus typically behave.

<img width="720" height="481" alt="ashell" src="https://github.com/user-attachments/assets/775a02a2-3f44-47ac-b22f-cf0c3ef74f12" />
