### PR TITLE
revert: disk deduplication (#679)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -319,7 +319,6 @@ pub struct SystemInfoDisk {
     pub warn_threshold: u32,
     pub alert_threshold: u32,
     pub format: DiskFormat,
-    pub deduplicate: bool,
 }
 
 impl SystemInfoDisk {
@@ -334,7 +333,6 @@ impl Default for SystemInfoDisk {
             warn_threshold: 80,
             alert_threshold: 90,
             format: DiskFormat::Percentage,
-            deduplicate: true,
         }
     }
 }

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -87,7 +87,6 @@ fn get_system_info(
     (networks, last_check): (&mut Networks, Option<Instant>),
     temperature_sensor: &str,
     sensor_index: Option<usize>,
-    deduplicate_disks: bool,
 ) -> SystemInfoData {
     system.refresh_memory();
     system.refresh_cpu_all();
@@ -153,31 +152,14 @@ fn get_system_info(
     let disks: Vec<(String, DiskView)> = disks
         .iter()
         .filter(|d| !d.is_removable() && d.total_space() != 0)
-        .unique_by(|d| {
-            if deduplicate_disks {
-                d.name().to_os_string()
-            } else {
-                d.mount_point().as_os_str().to_os_string()
-            }
-        })
         .map(|d| {
             let total_space = d.total_space();
             let avail_space = d.available_space();
 
             let space_per = (total_space - avail_space) as f32 / total_space as f32 * 100.;
 
-            let label = if deduplicate_disks {
-                std::path::Path::new(d.name())
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or_else(|| d.name().to_str().unwrap_or("?"))
-                    .to_string()
-            } else {
-                d.mount_point().display().to_string()
-            };
-
             (
-                label,
+                d.mount_point().display().to_string(),
                 DiskView {
                     percentage: space_per as u32,
                     fraction: format!(
@@ -304,7 +286,6 @@ impl SystemInfo {
             (&mut networks, None),
             config.temperature.sensor.as_str(),
             cached_sensor_index,
-            config.disk.deduplicate,
         );
 
         Self {
@@ -331,7 +312,6 @@ impl SystemInfo {
                     ),
                     &self.config.temperature.sensor,
                     self.cached_sensor_index,
-                    self.config.disk.deduplicate,
                 );
             }
         }

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -69,17 +69,6 @@ You can change the display format using the `format` option in `[system_info.dis
 - `"Percentage"` (default) — shows disk usage as a percentage (e.g., `54%`)
 - `"Fraction"` — shows used and total disk space in GB (e.g., `256.00/512.00 GB`)
 
-#### Deduplication
-
-When multiple mount points share the same underlying block device, the Disk indicator can show a separate entry for each mount point, which may be redundant.
-
-Setting `deduplicate = true` in `[system_info.disk]` collapses these into a single entry per device, labelled by the device name (e.g., `sda`) rather than the mount path. Defaults to `true`.
-
-```toml
-[system_info.disk]
-deduplicate = false
-```
-
 #### Example
 
 To monitor the home directory disk space, you can add the following to your configuration:
@@ -233,7 +222,6 @@ format = "Percentage"
 warn_threshold = 80
 alert_threshold = 90
 format = "Percentage"
-deduplicate = true
 
 [system_info.temperature]
 warn_threshold = 60


### PR DESCRIPTION
Reverts #679.

This reverts the merge commit 4a7f8c04f082ae185788a6e348e132c3f1055ead, undoing the changes from PR #679 ("Disk deduplication").

## Test plan
- [ ] `make check` passes
- [ ] Confirm `system_info` disk listing returns to pre-#679 behavior (one entry per mount point)
- [ ] Confirm the `deduplicate` config option is no longer accepted