### PR TITLE
feature: add optional step parameter to volume, microphone and brightness IPCs

### DIFF
--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -94,6 +94,8 @@ ashell msg toggle-airplane-mode
 ashell msg toggle-idle-inhibitor
 ```
 
+Volume, microphone and brightness up/down accept optional `step` parameter in the range of 1 to 5.
+
 Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD overlay. Add `--no-osd` to suppress it.
 
 ## Signal Handling

--- a/src/app.rs
+++ b/src/app.rs
@@ -548,16 +548,26 @@ impl App {
 
                 // Execute the action via Settings.
                 let action = match &cmd {
-                    IpcCommand::VolumeUp { .. } => self.settings.volume_adjust(true),
-                    IpcCommand::VolumeDown { .. } => self.settings.volume_adjust(false),
+                    IpcCommand::VolumeUp { step, .. } => self.settings.volume_adjust(*step, true),
+                    IpcCommand::VolumeDown { step, .. } => {
+                        self.settings.volume_adjust(*step, false)
+                    }
                     IpcCommand::VolumeToggleMute { .. } => self.settings.toggle_mute(),
-                    IpcCommand::MicrophoneUp { .. } => self.settings.microphone_adjust(true),
-                    IpcCommand::MicrophoneDown { .. } => self.settings.microphone_adjust(false),
+                    IpcCommand::MicrophoneUp { step, .. } => {
+                        self.settings.microphone_adjust(*step, true)
+                    }
+                    IpcCommand::MicrophoneDown { step, .. } => {
+                        self.settings.microphone_adjust(*step, false)
+                    }
                     IpcCommand::MicrophoneToggleMute { .. } => {
                         self.settings.microphone_toggle_mute()
                     }
-                    IpcCommand::BrightnessUp { .. } => self.settings.brightness_adjust(true),
-                    IpcCommand::BrightnessDown { .. } => self.settings.brightness_adjust(false),
+                    IpcCommand::BrightnessUp { step, .. } => {
+                        self.settings.brightness_adjust(*step, true)
+                    }
+                    IpcCommand::BrightnessDown { step, .. } => {
+                        self.settings.brightness_adjust(*step, false)
+                    }
                     IpcCommand::ToggleAirplaneMode { .. } => self.settings.toggle_airplane(),
                     IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
                     IpcCommand::ToggleVisibility => unreachable!(),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -13,6 +13,11 @@ use anyhow::{Context, Result, anyhow};
 use clap::Subcommand;
 use iced::Subscription;
 
+use crate::modules::settings::{
+    audio::DEFAULT_AUDIO_STEP, audio::MAX_AUDIO_STEP, brightness::DEFAULT_BRIGHTNESS_STEP,
+    brightness::MAX_BRIGHTNESS_STEP,
+};
+
 /// Maximum bytes to read from a client connection.
 const MAX_REQUEST_LEN: u64 = 4096;
 
@@ -22,10 +27,14 @@ pub enum IpcCommand {
     /// Toggle bar visibility
     ToggleVisibility,
     VolumeUp {
+        #[arg(default_value_t = DEFAULT_AUDIO_STEP)]
+        step: u32,
         #[arg(long)]
         no_osd: bool,
     },
     VolumeDown {
+        #[arg(default_value_t = DEFAULT_AUDIO_STEP)]
+        step: u32,
         #[arg(long)]
         no_osd: bool,
     },
@@ -34,10 +43,14 @@ pub enum IpcCommand {
         no_osd: bool,
     },
     MicrophoneUp {
+        #[arg(default_value_t = DEFAULT_AUDIO_STEP)]
+        step: u32,
         #[arg(long)]
         no_osd: bool,
     },
     MicrophoneDown {
+        #[arg(default_value_t = DEFAULT_AUDIO_STEP)]
+        step: u32,
         #[arg(long)]
         no_osd: bool,
     },
@@ -46,10 +59,14 @@ pub enum IpcCommand {
         no_osd: bool,
     },
     BrightnessUp {
+        #[arg(default_value_t = DEFAULT_BRIGHTNESS_STEP)]
+        step: u32,
         #[arg(long)]
         no_osd: bool,
     },
     BrightnessDown {
+        #[arg(default_value_t = DEFAULT_BRIGHTNESS_STEP)]
+        step: u32,
         #[arg(long)]
         no_osd: bool,
     },
@@ -67,21 +84,41 @@ impl IpcCommand {
     pub fn no_osd(&self) -> bool {
         match self {
             IpcCommand::ToggleVisibility => false,
-            IpcCommand::VolumeUp { no_osd }
-            | IpcCommand::VolumeDown { no_osd }
+            IpcCommand::VolumeUp { no_osd, .. }
+            | IpcCommand::VolumeDown { no_osd, .. }
             | IpcCommand::VolumeToggleMute { no_osd }
-            | IpcCommand::MicrophoneUp { no_osd }
-            | IpcCommand::MicrophoneDown { no_osd }
+            | IpcCommand::MicrophoneUp { no_osd, .. }
+            | IpcCommand::MicrophoneDown { no_osd, .. }
             | IpcCommand::MicrophoneToggleMute { no_osd }
-            | IpcCommand::BrightnessUp { no_osd }
-            | IpcCommand::BrightnessDown { no_osd }
+            | IpcCommand::BrightnessUp { no_osd, .. }
+            | IpcCommand::BrightnessDown { no_osd, .. }
             | IpcCommand::ToggleAirplaneMode { no_osd }
             | IpcCommand::ToggleIdleInhibitor { no_osd } => *no_osd,
         }
     }
+
+    fn parse_step_parameter(s: &str, max: u32, default: u32) -> Option<u32> {
+        if s.is_empty() {
+            return Some(default);
+        }
+        match s.parse::<u32>() {
+            Ok(step) => {
+                if (1..=max).contains(&step) {
+                    Some(step)
+                } else {
+                    None
+                }
+            }
+            Err(_e) => None,
+        }
+    }
+
+    fn invalid_step_parameter_msg(cmd: &str, max: u32) -> String {
+        format!("{cmd} IPC command 'step' parameter must be in the range of 1 to {max}")
+    }
 }
 
-const NO_OSD_SUFFIX: &str = "?no-osd";
+const NO_OSD_SUFFIX: &str = "no-osd";
 
 impl fmt::Display for IpcCommand {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -99,8 +136,17 @@ impl fmt::Display for IpcCommand {
             IpcCommand::ToggleIdleInhibitor { .. } => "toggle-idle-inhibitor",
         };
         write!(f, "{base}")?;
+        match self {
+            IpcCommand::VolumeUp { step, .. }
+            | IpcCommand::VolumeDown { step, .. }
+            | IpcCommand::MicrophoneUp { step, .. }
+            | IpcCommand::MicrophoneDown { step, .. }
+            | IpcCommand::BrightnessUp { step, .. }
+            | IpcCommand::BrightnessDown { step, .. } => write!(f, " {}", step)?,
+            _ => (),
+        }
         if self.no_osd() {
-            write!(f, "{NO_OSD_SUFFIX}")?;
+            write!(f, " {NO_OSD_SUFFIX}")?;
         }
         Ok(())
     }
@@ -110,20 +156,76 @@ impl FromStr for IpcCommand {
     type Err = anyhow::Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        let (cmd, no_osd) = match s.strip_suffix(NO_OSD_SUFFIX) {
-            Some(base) => (base, true),
+        let (request, no_osd) = match s.trim().strip_suffix(NO_OSD_SUFFIX) {
+            Some(base) => (base.trim_end(), true),
             None => (s, false),
+        };
+        let (cmd, args) = match request.split_once(' ') {
+            Some((cmd, args)) => (cmd, args.trim_start()),
+            None => (request, ""),
         };
         match cmd {
             "toggle-visibility" => Ok(IpcCommand::ToggleVisibility),
-            "volume-up" => Ok(IpcCommand::VolumeUp { no_osd }),
-            "volume-down" => Ok(IpcCommand::VolumeDown { no_osd }),
+            "volume-up" => {
+                match IpcCommand::parse_step_parameter(args, MAX_AUDIO_STEP, DEFAULT_AUDIO_STEP) {
+                    Some(step) => Ok(IpcCommand::VolumeUp { step, no_osd }),
+                    None => Err(anyhow!(IpcCommand::invalid_step_parameter_msg(
+                        "volume-up",
+                        MAX_AUDIO_STEP
+                    ))),
+                }
+            }
+            "volume-down" => {
+                match IpcCommand::parse_step_parameter(args, MAX_AUDIO_STEP, DEFAULT_AUDIO_STEP) {
+                    Some(step) => Ok(IpcCommand::VolumeDown { step, no_osd }),
+                    None => Err(anyhow!(IpcCommand::invalid_step_parameter_msg(
+                        "volume-down",
+                        MAX_AUDIO_STEP
+                    ))),
+                }
+            }
             "volume-toggle-mute" => Ok(IpcCommand::VolumeToggleMute { no_osd }),
-            "microphone-up" => Ok(IpcCommand::MicrophoneUp { no_osd }),
-            "microphone-down" => Ok(IpcCommand::MicrophoneDown { no_osd }),
+            "microphone-up" => {
+                match IpcCommand::parse_step_parameter(args, MAX_AUDIO_STEP, DEFAULT_AUDIO_STEP) {
+                    Some(step) => Ok(IpcCommand::MicrophoneUp { step, no_osd }),
+                    None => Err(anyhow!(IpcCommand::invalid_step_parameter_msg(
+                        "microphone-up",
+                        MAX_AUDIO_STEP
+                    ))),
+                }
+            }
+            "microphone-down" => {
+                match IpcCommand::parse_step_parameter(args, MAX_AUDIO_STEP, DEFAULT_AUDIO_STEP) {
+                    Some(step) => Ok(IpcCommand::MicrophoneDown { step, no_osd }),
+                    None => Err(anyhow!(IpcCommand::invalid_step_parameter_msg(
+                        "microphone-down",
+                        MAX_AUDIO_STEP
+                    ))),
+                }
+            }
             "microphone-toggle-mute" => Ok(IpcCommand::MicrophoneToggleMute { no_osd }),
-            "brightness-up" => Ok(IpcCommand::BrightnessUp { no_osd }),
-            "brightness-down" => Ok(IpcCommand::BrightnessDown { no_osd }),
+            "brightness-up" => match IpcCommand::parse_step_parameter(
+                args,
+                MAX_BRIGHTNESS_STEP,
+                DEFAULT_BRIGHTNESS_STEP,
+            ) {
+                Some(step) => Ok(IpcCommand::BrightnessUp { step, no_osd }),
+                None => Err(anyhow!(IpcCommand::invalid_step_parameter_msg(
+                    "brightness-up",
+                    MAX_BRIGHTNESS_STEP
+                ))),
+            },
+            "brightness-down" => match IpcCommand::parse_step_parameter(
+                args,
+                MAX_BRIGHTNESS_STEP,
+                DEFAULT_BRIGHTNESS_STEP,
+            ) {
+                Some(step) => Ok(IpcCommand::BrightnessDown { step, no_osd }),
+                None => Err(anyhow!(IpcCommand::invalid_step_parameter_msg(
+                    "brightness-down",
+                    MAX_BRIGHTNESS_STEP
+                ))),
+            },
             "toggle-airplane-mode" => Ok(IpcCommand::ToggleAirplaneMode { no_osd }),
             "toggle-idle-inhibitor" => Ok(IpcCommand::ToggleIdleInhibitor { no_osd }),
             _ => Err(anyhow!("unknown IPC command: {s:?}")),

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -21,6 +21,8 @@ use iced::{
 };
 use libpulse_binding::volume::Volume;
 
+pub const MAX_AUDIO_STEP: u32 = 5;
+pub const DEFAULT_AUDIO_STEP: u32 = 5;
 const VOL_PERCENT: u32 = Volume::NORMAL.0 / 100;
 
 #[derive(Debug, Clone)]
@@ -120,11 +122,11 @@ impl AudioSettings {
         Volume::NORMAL.0
     }
 
-    pub fn volume_adjust(&mut self, up: bool) -> Action {
+    pub fn volume_adjust(&mut self, step: u32, up: bool) -> Action {
         let Some(cur) = self.real_sink_volume() else {
             return Action::None;
         };
-        let step = 5 * VOL_PERCENT;
+        let step = step * VOL_PERCENT;
         let new_vol = if up {
             (cur + step).min(Self::vol_max())
         } else {
@@ -171,11 +173,11 @@ impl AudioSettings {
         Volume::NORMAL.0
     }
 
-    pub fn microphone_adjust(&mut self, up: bool) -> Action {
+    pub fn microphone_adjust(&mut self, step: u32, up: bool) -> Action {
         let Some(cur) = self.real_source_volume() else {
             return Action::None;
         };
-        let step = 5 * VOL_PERCENT;
+        let step = step * VOL_PERCENT;
         let new_vol = if up {
             (cur + step).min(Self::mic_max())
         } else {
@@ -533,7 +535,7 @@ impl AudioSettings {
                 ScrollDelta::Lines { y, .. } => y,
                 ScrollDelta::Pixels { y, .. } => y,
             };
-            let step = 5 * VOL_PERCENT;
+            let step = DEFAULT_AUDIO_STEP * VOL_PERCENT;
             let new_volume = if y > 0.0 {
                 (cur_volume + step).min(Volume::NORMAL.0)
             } else {

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -14,6 +14,9 @@ use iced::{
     widget::{Text, text},
 };
 
+pub const MAX_BRIGHTNESS_STEP: u32 = 5;
+pub const DEFAULT_BRIGHTNESS_STEP: u32 = 5;
+
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(ServiceEvent<BrightnessService>),
@@ -45,14 +48,14 @@ impl BrightnessSettings {
     }
 
     fn step(max: u32) -> u32 {
-        (5 * max / 100).max(1)
+        (DEFAULT_BRIGHTNESS_STEP * max / 100).max(1)
     }
 
-    pub fn brightness_adjust(&mut self, up: bool) -> Action {
+    pub fn brightness_adjust(&mut self, step: u32, up: bool) -> Action {
         let Some((cur, max)) = self.current_brightness() else {
             return Action::None;
         };
-        let step = Self::step(max);
+        let step = (step * max / 100).max(1);
         let new_val = if up {
             (cur + step).min(max)
         } else {

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -135,8 +135,8 @@ impl Settings {
         &self.idle_inhibitor
     }
 
-    pub fn volume_adjust(&mut self, up: bool) -> Action {
-        match self.audio.volume_adjust(up) {
+    pub fn volume_adjust(&mut self, step: u32, up: bool) -> Action {
+        match self.audio.volume_adjust(step, up) {
             audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
             _ => Action::None,
         }
@@ -147,8 +147,8 @@ impl Settings {
         Action::None
     }
 
-    pub fn microphone_adjust(&mut self, up: bool) -> Action {
-        match self.audio.microphone_adjust(up) {
+    pub fn microphone_adjust(&mut self, step: u32, up: bool) -> Action {
+        match self.audio.microphone_adjust(step, up) {
             audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
             _ => Action::None,
         }
@@ -159,8 +159,8 @@ impl Settings {
         Action::None
     }
 
-    pub fn brightness_adjust(&mut self, up: bool) -> Action {
-        match self.brightness.brightness_adjust(up) {
+    pub fn brightness_adjust(&mut self, step: u32, up: bool) -> Action {
+        match self.brightness.brightness_adjust(step, up) {
             brightness::Action::Command(task) => Action::Command(task.map(Message::Brightness)),
             brightness::Action::None => Action::None,
         }

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -54,6 +54,11 @@ Available commands:
 | `toggle-airplane-mode`   | Toggle airplane mode                 |
 | `toggle-idle-inhibitor`  | Toggle idle inhibitor                |
 
+Volume, microphone and brightness up/down accept optional `step` parameter in the range of 1 to 5:
+
+```bash
+ashell msg brightness-up 4
+```
 
 Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD (On-Screen Display)
 overlay by default. Add `--no-osd` to suppress it:

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -179,6 +179,12 @@ ashell msg toggle-airplane-mode
 ashell msg toggle-idle-inhibitor
 ```
 
+Volume, microphone and brightness up/down accept optional `step` parameter in the range of 1 to 5:
+
+```bash
+ashell msg brightness-up 4
+```
+
 The OSD appears at center-bottom and auto-hides after a timeout. To suppress
 it for a specific command, add `--no-osd`:
 


### PR DESCRIPTION
Adds optional steps parameter to these IPCs:
```
ashell msg volume-up [step]
ashell msg volume-down [step]
ashell msg microphone-up [step]
ashell msg microphone-down [step]
ashell msg brightness-up [step]
ashell msg brightness-down [step]
```

Part of #673

