### PR TITLE
feat(i18n): respect LC_MEASUREMENT for unit system

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -143,8 +143,9 @@ fn env_chain(config: Option<&str>, category_var: &str) -> Option<String> {
 }
 
 fn derive_units(c: Locale) -> UnitSystem {
+    // `en_LR` omitted: not a chrono Locale variant.
     match c {
-        Locale::en_US => UnitSystem::Imperial,
+        Locale::en_US | Locale::my_MM => UnitSystem::Imperial,
         _ => UnitSystem::Metric,
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -44,6 +44,7 @@ impl UnitSystem {
 
 pub struct Localizer {
     pub chrono: Locale,
+    units: UnitSystem,
     loader: FluentLanguageLoader,
 }
 
@@ -56,6 +57,7 @@ impl Default for Localizer {
         let loader = FluentLanguageLoader::new("ashell", en_us_langid());
         Self {
             chrono: FALLBACK_CHRONO,
+            units: derive_units(FALLBACK_CHRONO),
             loader,
         }
     }
@@ -65,12 +67,17 @@ impl Localizer {
     pub fn resolve(language: Option<&str>, region: Option<&str>) -> Self {
         let langid = resolve_language(language);
         let chrono = resolve_region(region);
+        let units = resolve_units(chrono);
         let loader = load_loader(&langid);
-        Self { chrono, loader }
+        Self {
+            chrono,
+            units,
+            loader,
+        }
     }
 
     pub fn units(&self) -> UnitSystem {
-        derive_units(self.chrono)
+        self.units
     }
 
     pub fn loader(&self) -> &FluentLanguageLoader {
@@ -138,6 +145,25 @@ fn env_chain(config: Option<&str>, category_var: &str) -> Option<String> {
 fn derive_units(c: Locale) -> UnitSystem {
     match c {
         Locale::en_US => UnitSystem::Imperial,
+        _ => UnitSystem::Metric,
+    }
+}
+
+// `LC_MEASUREMENT` is independent from `LC_TIME` in glibc, so users with
+// `LANG=en_US.UTF-8` + `LC_MEASUREMENT=de_DE.UTF-8` get metric without
+// having to override their date-format locale.
+fn resolve_units(chrono: Locale) -> UnitSystem {
+    env_chain(None, "LC_MEASUREMENT")
+        .as_deref()
+        .map(units_from_locale_name)
+        .unwrap_or_else(|| derive_units(chrono))
+}
+
+fn units_from_locale_name(s: &str) -> UnitSystem {
+    let posix = normalize_to_posix(s);
+    let base = posix.split_once('@').map_or(posix.as_str(), |(b, _)| b);
+    match base {
+        "en_US" | "en_LR" | "my_MM" => UnitSystem::Imperial,
         _ => UnitSystem::Metric,
     }
 }


### PR DESCRIPTION
I ran ashell today and realized everything is in imperial metrics.
To respect the system setup, locale exposes LC_MEASUREMENT

ashell currently derives the unit system solely from LC_TIME (or the region config key), mapping en_US → Imperial and everything else → Metric. This conflates two independent glibc locale categories: users who want US date formatting but metric units (or vice versa) have no way to express that without lying about one of the two locales or manually configuring.

This change reads LC_MEASUREMENT (with the standard LC_ALL → LC_MEASUREMENT → LANG fallback chain) and uses a CLDR-derived allowlist of imperial regions (en_US, en_LR, my_MM). I am not an expert on that and this was an AI recommendation. The three options DO use imperial though. If someone has more insight, happy to adjust.

When LC_MEASUREMENT is unset, falls back to the existing LC_TIME-based derivation — so no behavior change for existing users.