### PR TITLE
system_info add mounts option to filter disk display

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -311,6 +311,7 @@ pub struct SystemInfoDisk {
     pub warn_threshold: u32,
     pub alert_threshold: u32,
     pub format: DiskFormat,
+    pub mounts: Option<Vec<String>>,
 }
 
 impl SystemInfoDisk {
@@ -325,6 +326,7 @@ impl Default for SystemInfoDisk {
             warn_threshold: 80,
             alert_threshold: 90,
             format: DiskFormat::Percentage,
+            mounts: None,
         }
     }
 }

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -78,6 +78,7 @@ struct SystemInfoData {
     network: Option<NetworkData>,
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_system_info(
     system: &mut System,
     components: &mut Components,
@@ -85,6 +86,7 @@ fn get_system_info(
     (networks, last_check): (&mut Networks, Option<Instant>),
     temperature_sensor: &str,
     sensor_index: Option<usize>,
+    mounts: Option<&[String]>,
 ) -> SystemInfoData {
     system.refresh_memory();
     system.refresh_cpu_all();
@@ -150,6 +152,14 @@ fn get_system_info(
     let disks: Vec<(String, DiskView)> = disks
         .iter()
         .filter(|d| !d.is_removable() && d.total_space() != 0)
+        .filter(|d| {
+            if let Some(mounts) = mounts {
+                let mount_str = d.mount_point().display().to_string();
+                mounts.contains(&mount_str)
+            } else {
+                true
+            }
+        })
         .map(|d| {
             let total_space = d.total_space();
             let avail_space = d.available_space();
@@ -168,7 +178,21 @@ fn get_system_info(
                 },
             )
         })
-        .sorted_by(|a, b| a.0.cmp(&b.0))
+        .sorted_by(|a, b| {
+            if let Some(mounts_list) = mounts {
+                let pos_a = mounts_list
+                    .iter()
+                    .position(|m| m == &a.0)
+                    .unwrap_or(usize::MAX);
+                let pos_b = mounts_list
+                    .iter()
+                    .position(|m| m == &b.0)
+                    .unwrap_or(usize::MAX);
+                pos_a.cmp(&pos_b)
+            } else {
+                a.0.cmp(&b.0)
+            }
+        })
         .collect();
 
     let elapsed = last_check.map(|v| v.elapsed().as_secs());
@@ -284,6 +308,7 @@ impl SystemInfo {
             (&mut networks, None),
             config.temperature.sensor.as_str(),
             cached_sensor_index,
+            config.disk.mounts.as_deref(),
         );
 
         Self {
@@ -310,6 +335,7 @@ impl SystemInfo {
                     ),
                     &self.config.temperature.sensor,
                     self.cached_sensor_index,
+                    self.config.disk.mounts.as_deref(),
                 );
             }
         }

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -69,6 +69,22 @@ You can change the display format using the `format` option in `[system_info.dis
 - `"Percentage"` (default) — shows disk usage as a percentage (e.g., `54%`)
 - `"Fraction"` — shows used and total disk space in GB (e.g., `256.00/512.00 GB`)
 
+#### Filtering Disk Mounts
+
+By default, all non-removable disks with available space are shown in the system info menu. You can use the `mounts` option in `[system_info.disk]` to specify which mount points to display.
+
+If `mounts` is not specified, all disks are shown (default behavior).
+
+```toml
+[system_info.disk]
+mounts = ["/", "/home"]
+warn_threshold = 80
+alert_threshold = 90
+format = "Percentage"
+```
+
+With the above configuration, only the disks mounted at `/` and `/home` will be displayed in the menu.
+
 #### Example
 
 To monitor the home directory disk space, you can add the following to your configuration:
@@ -222,6 +238,11 @@ format = "Percentage"
 warn_threshold = 80
 alert_threshold = 90
 format = "Percentage"
+<<<<<<< HEAD
+=======
+deduplicate = true
+# mounts = ["/", "/home"]  # uncomment to whitelist specific mount points
+>>>>>>> 41b4dcfe (system_info add mounts option to filter disk display)
 
 [system_info.temperature]
 warn_threshold = 60


### PR DESCRIPTION
This is just a first draft. 

Based on the idea of the indicators Disks 
https://malpenzibo.github.io/ashell/docs/next/configuration/modules/system_info#disk

I added for now (for discussion) the simplest just a filter/whitelist (I didnt want to add any re-naming logic for now) 
And I was unsure if we should merge this and Disks together, and make the config structure more complex)
```
[system_info.disk]
mounts = ["/", "/boot"]
```

and you get
<img width="609" height="531" alt="image" src="https://github.com/user-attachments/assets/00d7cfcd-710c-4fef-b8fc-88b28f48164c" />

related to https://github.com/MalpenZibo/ashell/issues/688