### PR TITLE
feature: OSD on indicators RFC

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::{
         media_player::MediaPlayer,
         notifications::Notifications,
         privacy::Privacy,
-        settings::{self, Settings, audio},
+        settings::{self, EventSource, Settings, audio},
         system_info::SystemInfo,
         tempo::Tempo,
         tray::TrayModule,
@@ -230,26 +230,26 @@ impl App {
         use_theme(|t| t.scale_factor)
     }
 
+    fn normalise(cur: u32, max: u32) -> f32 {
+        if max > 0 {
+            cur as f32 / max as f32
+        } else {
+            0.0
+        }
+    }
+
     /// Build OSD display info (kind, normalised value, muted) for the given
     /// IPC command, reading current state from the Settings services.
     fn osd_info_for(&self, cmd: &IpcCommand) -> Option<(OsdKind, f32, bool)> {
-        fn normalise(cur: u32, max: u32) -> f32 {
-            if max > 0 {
-                cur as f32 / max as f32
-            } else {
-                0.0
-            }
-        }
-
         match cmd {
             IpcCommand::VolumeUp { .. } | IpcCommand::VolumeDown { .. } => {
                 // Use slider value — it has the optimistic RequestAndTimeout update,
                 // which was computed from real_sink_volume in volume_adjust().
                 let vol = self.settings.audio().current_sink_volume().unwrap_or(0);
-                let muted = self.settings.audio().is_sink_muted().unwrap_or(false);
+                let muted = self.settings.audio().is_sink_muted();
                 Some((
                     OsdKind::Volume,
-                    normalise(vol, audio::AudioSettings::vol_max()),
+                    Self::normalise(vol, audio::AudioSettings::vol_max()),
                     muted,
                 ))
             }
@@ -257,10 +257,10 @@ impl App {
                 let vol = self.settings.audio().real_sink_volume().unwrap_or(0);
                 // Invert: the toggle was just sent but PulseAudio hasn't
                 // round-tripped yet, so the current state is stale.
-                let muted = !self.settings.audio().is_sink_muted().unwrap_or(false);
+                let muted = !self.settings.audio().is_sink_muted();
                 Some((
                     OsdKind::Volume,
-                    normalise(vol, audio::AudioSettings::vol_max()),
+                    Self::normalise(vol, audio::AudioSettings::vol_max()),
                     muted,
                 ))
             }
@@ -268,10 +268,10 @@ impl App {
                 // Use slider value — it has the optimistic RequestAndTimeout update,
                 // which was computed from real_source_volume in microphone_adjust().
                 let vol = self.settings.audio().current_source_volume().unwrap_or(0);
-                let muted = self.settings.audio().is_source_muted().unwrap_or(false);
+                let muted = self.settings.audio().is_source_muted();
                 Some((
                     OsdKind::Microphone,
-                    normalise(vol, audio::AudioSettings::mic_max()),
+                    Self::normalise(vol, audio::AudioSettings::mic_max()),
                     muted,
                 ))
             }
@@ -279,10 +279,10 @@ impl App {
                 let vol = self.settings.audio().real_source_volume().unwrap_or(0);
                 // Invert: the toggle was just sent but PulseAudio hasn't
                 // round-tripped yet, so the current state is stale.
-                let muted = !self.settings.audio().is_source_muted().unwrap_or(false);
+                let muted = !self.settings.audio().is_source_muted();
                 Some((
                     OsdKind::Microphone,
-                    normalise(vol, audio::AudioSettings::mic_max()),
+                    Self::normalise(vol, audio::AudioSettings::mic_max()),
                     muted,
                 ))
             }
@@ -290,7 +290,7 @@ impl App {
                 .settings
                 .brightness()
                 .current_brightness()
-                .map(|(cur, max)| (OsdKind::Brightness, normalise(cur, max), false)),
+                .map(|(cur, max)| (OsdKind::Brightness, Self::normalise(cur, max), false)),
             IpcCommand::ToggleAirplaneMode { .. } => {
                 // After toggle: the new state is the opposite of current.
                 // For toggles, `muted` carries the active/enabled state; `value` is unused.
@@ -451,6 +451,39 @@ impl App {
             Message::Settings(message) => match self.settings.update(message) {
                 modules::settings::Action::None => Task::none(),
                 modules::settings::Action::Command(task) => task.map(Message::Settings),
+                modules::settings::Action::SourceTaggedCommand(task, event_source) => {
+                    let mut tasks = vec![task.map(Message::Settings)];
+
+                    if self.osd.config().enabled && !self.outputs.menu_is_open() {
+                        if let Some(message) = match event_source {
+                            EventSource::VolumeIndicator => {
+                                let vol = self.settings.audio().current_sink_volume().unwrap_or(0);
+                                Some(osd::Message::Show {
+                                    kind: OsdKind::Volume,
+                                    value: Self::normalise(vol, audio::AudioSettings::vol_max()),
+                                    muted: false,
+                                })
+                            }
+                            EventSource::MicrophoneIndicator => {
+                                let vol =
+                                    self.settings.audio().current_source_volume().unwrap_or(0);
+                                Some(osd::Message::Show {
+                                    kind: OsdKind::Microphone,
+                                    value: Self::normalise(vol, audio::AudioSettings::mic_max()),
+                                    muted: false,
+                                })
+                            }
+                            EventSource::Irelevant => None,
+                        } {
+                            if let osd::Action::Show(timer) = self.osd.update(message) {
+                                tasks.push(timer.map(Message::Osd));
+                                tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
+                            }
+                        }
+                    }
+
+                    Task::batch(tasks)
+                }
                 modules::settings::Action::CloseMenu(id) => {
                     self.outputs
                         .close_menu(id, None, self.general_config.enable_esc_key)

--- a/src/app.rs
+++ b/src/app.rs
@@ -454,8 +454,9 @@ impl App {
                 modules::settings::Action::SourceTaggedCommand(task, event_source) => {
                     let mut tasks = vec![task.map(Message::Settings)];
 
-                    if self.osd.config().enabled && !self.outputs.menu_is_open() {
-                        if let Some(message) = match event_source {
+                    if self.osd.config().enabled
+                        && !self.outputs.menu_is_open()
+                        && let Some(message) = match event_source {
                             EventSource::VolumeIndicator => {
                                 let vol = self.settings.audio().current_sink_volume().unwrap_or(0);
                                 Some(osd::Message::Show {
@@ -473,23 +474,21 @@ impl App {
                                     muted: false,
                                 })
                             }
-                            EventSource::BrightnessIndicator => {
-                                match self.settings.brightness().current_brightness() {
-                                    Some((cur, max)) => Some(osd::Message::Show {
-                                        kind: OsdKind::Brightness,
-                                        value: Self::normalise(cur, max),
-                                        muted: false,
-                                    }),
-                                    None => None,
-                                }
-                            }
+                            EventSource::BrightnessIndicator => self
+                                .settings
+                                .brightness()
+                                .current_brightness()
+                                .map(|(cur, max)| osd::Message::Show {
+                                    kind: OsdKind::Brightness,
+                                    value: Self::normalise(cur, max),
+                                    muted: false,
+                                }),
                             EventSource::Irelevant => None,
-                        } {
-                            if let osd::Action::Show(timer) = self.osd.update(message) {
-                                tasks.push(timer.map(Message::Osd));
-                                tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
-                            }
                         }
+                        && let osd::Action::Show(timer) = self.osd.update(message)
+                    {
+                        tasks.push(timer.map(Message::Osd));
+                        tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
                     }
 
                     Task::batch(tasks)

--- a/src/app.rs
+++ b/src/app.rs
@@ -473,6 +473,16 @@ impl App {
                                     muted: false,
                                 })
                             }
+                            EventSource::BrightnessIndicator => {
+                                match self.settings.brightness().current_brightness() {
+                                    Some((cur, max)) => Some(osd::Message::Show {
+                                        kind: OsdKind::Brightness,
+                                        value: Self::normalise(cur, max),
+                                        muted: false,
+                                    }),
+                                    None => None,
+                                }
+                            }
                             EventSource::Irelevant => None,
                         } {
                             if let osd::Action::Show(timer) = self.osd.update(message) {

--- a/src/components/slider_control.rs
+++ b/src/components/slider_control.rs
@@ -2,6 +2,7 @@ use std::ops::RangeInclusive;
 
 use crate::{
     components::icons::{IconKind, StaticIcon, icon_button},
+    modules::settings::EventSource,
     theme::use_theme,
     utils::remote_value,
 };
@@ -15,7 +16,7 @@ pub struct SliderControl<'a, Msg> {
     icon: IconKind,
     range: RangeInclusive<u32>,
     value: u32,
-    on_change: Box<dyn Fn(remote_value::Message<u32>) -> Msg + 'a>,
+    on_change: Box<dyn Fn(remote_value::Message<u32>, EventSource) -> Msg + 'a>,
     on_scroll: Box<dyn Fn(ScrollDelta) -> Msg + 'a>,
     on_icon_press: Option<Msg>,
     on_icon_right_press: Option<Msg>,
@@ -26,7 +27,7 @@ pub fn slider_control<'a, Msg: 'static + Clone>(
     icon: impl Into<IconKind>,
     range: RangeInclusive<u32>,
     value: u32,
-    on_change: impl Fn(remote_value::Message<u32>) -> Msg + 'a,
+    on_change: impl Fn(remote_value::Message<u32>, EventSource) -> Msg + 'a,
     on_scroll: impl Fn(ScrollDelta) -> Msg + 'a,
 ) -> SliderControl<'a, Msg> {
     SliderControl {
@@ -82,7 +83,7 @@ impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg>
                 slider(ctrl.range, ctrl.value, remote_value::Message::Request)
                     .on_release(remote_value::Message::Timeout),
             )
-            .map(ctrl.on_change),
+            .map(move |msg| (ctrl.on_change)(msg, EventSource::Irelevant)),
         )
         .on_scroll(ctrl.on_scroll);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,9 +548,13 @@ pub struct SettingsModuleConfig {
     pub peripheral_expanded_by_default: bool,
     pub audio_indicator_format: SettingsFormat,
     pub microphone_indicator_format: SettingsFormat,
+    #[serde(deserialize_with = "step_deserializer")]
+    pub audio_step: u32,
     pub network_indicator_format: SettingsFormat,
     pub bluetooth_indicator_format: SettingsFormat,
     pub brightness_indicator_format: SettingsFormat,
+    #[serde(deserialize_with = "step_deserializer")]
+    pub brightness_step: u32,
     #[serde(default, deserialize_with = "empty_string_as_none")]
     pub audio_sinks_more_cmd: Option<String>,
     #[serde(default, deserialize_with = "empty_string_as_none")]
@@ -566,6 +570,27 @@ pub struct SettingsModuleConfig {
     pub indicators: Vec<SettingsIndicator>,
     #[serde(rename = "CustomButton")]
     pub custom_buttons: Vec<SettingsCustomButton>,
+}
+
+fn step_deserializer<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = u32::deserialize(deserializer)?;
+
+    if v < 1 {
+        return Err(serde::de::Error::custom(
+            "Audio step must be greater than 0",
+        ));
+    }
+
+    if v > 10 {
+        return Err(serde::de::Error::custom(
+            "Audio step cannot be greater than 10",
+        ));
+    }
+
+    Ok(v)
 }
 
 impl Default for SettingsModuleConfig {
@@ -584,9 +609,11 @@ impl Default for SettingsModuleConfig {
             peripheral_expanded_by_default: false,
             audio_indicator_format: SettingsFormat::Icon,
             microphone_indicator_format: SettingsFormat::Icon,
+            audio_step: 5,
             network_indicator_format: SettingsFormat::Icon,
             bluetooth_indicator_format: SettingsFormat::Icon,
             brightness_indicator_format: SettingsFormat::Icon,
+            brightness_step: 5,
             audio_sinks_more_cmd: Default::default(),
             audio_sources_more_cmd: Default::default(),
             wifi_more_cmd: Default::default(),

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -57,6 +57,7 @@ pub struct AudioSettingsConfig {
     pub sources_more_cmd: Option<String>,
     pub indicator_format: SettingsFormat,
     pub microphone_indicator_format: SettingsFormat,
+    pub step: u32,
 }
 
 impl AudioSettingsConfig {
@@ -65,12 +66,14 @@ impl AudioSettingsConfig {
         sources_more_cmd: Option<String>,
         indicator_format: SettingsFormat,
         microphone_indicator_format: SettingsFormat,
+        step: u32,
     ) -> Self {
         Self {
             sinks_more_cmd,
             sources_more_cmd,
             indicator_format,
             microphone_indicator_format,
+            step,
         }
     }
 }
@@ -125,7 +128,7 @@ impl AudioSettings {
         let Some(cur) = self.real_sink_volume() else {
             return Action::None;
         };
-        let step = 5 * VOL_PERCENT;
+        let step = self.config.step * VOL_PERCENT;
         let new_vol = if up {
             (cur + step).min(Self::vol_max())
         } else {
@@ -176,7 +179,7 @@ impl AudioSettings {
         let Some(cur) = self.real_source_volume() else {
             return Action::None;
         };
-        let step = 5 * VOL_PERCENT;
+        let step = self.config.step * VOL_PERCENT;
         let new_vol = if up {
             (cur + step).min(Self::mic_max())
         } else {
@@ -534,11 +537,10 @@ impl AudioSettings {
                 ScrollDelta::Lines { y, .. } => y,
                 ScrollDelta::Pixels { y, .. } => y,
             };
-            let step = 5 * VOL_PERCENT;
             let new_volume = if y > 0.0 {
-                (cur_volume + step).min(Volume::NORMAL.0)
+                (cur_volume + VOL_PERCENT).min(Volume::NORMAL.0)
             } else {
-                cur_volume.saturating_sub(step)
+                cur_volume.saturating_sub(VOL_PERCENT)
             };
             make_msg(remote_value::Message::RequestAndTimeout(new_volume))
         }

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -6,6 +6,7 @@ use crate::{
         slider_control, styled_button,
     },
     config::SettingsFormat,
+    modules::settings::EventSource,
     services::{
         ReadOnlyService, Service, ServiceEvent,
         audio::{AudioCommand, AudioService, ChannelVolumesExt, DevicePortType, Port},
@@ -30,9 +31,9 @@ pub enum Message {
     DefaultSinkChanged(String, Option<String>),
     DefaultSourceChanged(String, Option<String>),
     ToggleSinkMute,
-    SinkVolumeChanged(remote_value::Message<u32>),
+    SinkVolumeChanged(remote_value::Message<u32>, EventSource),
     ToggleSourceMute,
-    SourceVolumeChanged(remote_value::Message<u32>),
+    SourceVolumeChanged(remote_value::Message<u32>, EventSource),
     SinksMore(SurfaceId),
     SourcesMore(SurfaceId),
     OpenMore,
@@ -44,7 +45,7 @@ pub enum Message {
 
 pub enum Action {
     None,
-    Task(Task<Message>),
+    SourceTaggedTask(Task<Message>, EventSource),
     ToggleSinksMenu,
     ToggleSourcesMenu,
     CloseMenu(SurfaceId),
@@ -114,10 +115,11 @@ impl AudioSettings {
             .and_then(|s| s.active_sink().map(|d| d.volume.get_volume()))
     }
 
-    pub fn is_sink_muted(&self) -> Option<bool> {
+    pub fn is_sink_muted(&self) -> bool {
         self.service
             .as_ref()
             .and_then(|s| s.active_sink().map(|d| d.is_mute))
+            .unwrap_or(false)
     }
 
     pub fn vol_max() -> u32 {
@@ -136,6 +138,7 @@ impl AudioSettings {
         };
         self.update(Message::SinkVolumeChanged(
             remote_value::Message::RequestAndTimeout(new_vol),
+            EventSource::Irelevant,
         ))
     }
 
@@ -165,10 +168,11 @@ impl AudioSettings {
             .and_then(|s| s.active_source().map(|d| d.volume.get_volume()))
     }
 
-    pub fn is_source_muted(&self) -> Option<bool> {
+    pub fn is_source_muted(&self) -> bool {
         self.service
             .as_ref()
             .and_then(|s| s.active_source().map(|d| d.is_mute))
+            .unwrap_or(false)
     }
 
     pub fn mic_max() -> u32 {
@@ -187,6 +191,7 @@ impl AudioSettings {
         };
         self.update(Message::SourceVolumeChanged(
             remote_value::Message::RequestAndTimeout(new_vol),
+            EventSource::Irelevant,
         ))
     }
 
@@ -232,16 +237,19 @@ impl AudioSettings {
                 }
                 Action::None
             }
-            Message::SinkVolumeChanged(message) => {
-                if let Some(service) = self.service.as_mut() {
+            Message::SinkVolumeChanged(message, event_source) => {
+                if !self.is_sink_muted()
+                    && let Some(service) = self.service.as_mut()
+                {
                     if let Some(value) = message.value() {
                         let _ = service.command(AudioCommand::SinkVolume(value));
                     }
-                    return Action::Task(
+                    return Action::SourceTaggedTask(
                         service
                             .sink_slider
                             .update(message)
-                            .map(Message::SinkVolumeChanged),
+                            .map(move |msg| Message::SinkVolumeChanged(msg, event_source)),
+                        event_source,
                     );
                 }
                 Action::None
@@ -258,16 +266,19 @@ impl AudioSettings {
                 }
                 Action::None
             }
-            Message::SourceVolumeChanged(message) => {
-                if let Some(service) = self.service.as_mut() {
+            Message::SourceVolumeChanged(message, event_source) => {
+                if !self.is_source_muted()
+                    && let Some(service) = self.service.as_mut()
+                {
                     if let Some(value) = message.value() {
                         let _ = service.command(AudioCommand::SourceVolume(value));
                     }
-                    return Action::Task(
+                    return Action::SourceTaggedTask(
                         service
                             .source_slider
                             .update(message)
-                            .map(Message::SourceVolumeChanged),
+                            .map(move |msg| Message::SourceVolumeChanged(msg, event_source)),
+                        event_source,
                     );
                 }
                 Action::None
@@ -334,7 +345,11 @@ impl AudioSettings {
                     IndicatorState::Normal,
                 )
                 .on_right_press(Message::OpenMore)
-                .on_scroll(Self::on_scroll(volume, Message::SinkVolumeChanged))
+                .on_scroll(Self::on_scroll(
+                    volume,
+                    Message::SinkVolumeChanged,
+                    EventSource::VolumeIndicator,
+                ))
                 .into()
             })
     }
@@ -356,7 +371,11 @@ impl AudioSettings {
                     IndicatorState::Normal,
                 )
                 .on_right_press(Message::OpenSourceMore)
-                .on_scroll(Self::on_scroll(volume, Message::SourceVolumeChanged))
+                .on_scroll(Self::on_scroll(
+                    volume,
+                    Message::SourceVolumeChanged,
+                    EventSource::MicrophoneIndicator,
+                ))
                 .into()
             })
     }
@@ -489,7 +508,7 @@ impl AudioSettings {
         is_mute: bool,
         toggle_mute: Message,
         volume: &'a Remote<u32>,
-        volume_changed: &'a dyn Fn(remote_value::Message<u32>) -> Message,
+        volume_changed: &'a dyn Fn(remote_value::Message<u32>, EventSource) -> Message,
         with_submenu: Option<(Option<SubMenu>, Message)>,
     ) -> Element<'a, Message> {
         let mute_icon = if is_mute {
@@ -509,7 +528,7 @@ impl AudioSettings {
             Volume::MUTED.0..=Volume::NORMAL.0,
             volume.value(),
             volume_changed,
-            Self::on_scroll(volume.value(), volume_changed),
+            Self::on_scroll(volume.value(), volume_changed, EventSource::Irelevant),
         )
         .on_icon_press(toggle_mute)
         .on_icon_right_press(match slider_type {
@@ -528,9 +547,13 @@ impl AudioSettings {
         ctrl.into()
     }
 
-    fn on_scroll<F>(cur_volume: u32, make_msg: F) -> impl Fn(ScrollDelta) -> Message
+    fn on_scroll<F>(
+        cur_volume: u32,
+        make_msg: F,
+        event_source: EventSource,
+    ) -> impl Fn(ScrollDelta) -> Message
     where
-        F: Fn(remote_value::Message<u32>) -> Message,
+        F: Fn(remote_value::Message<u32>, EventSource) -> Message,
     {
         move |delta| {
             let y = match delta {
@@ -542,7 +565,10 @@ impl AudioSettings {
             } else {
                 cur_volume.saturating_sub(VOL_PERCENT)
             };
-            make_msg(remote_value::Message::RequestAndTimeout(new_volume))
+            make_msg(
+                remote_value::Message::RequestAndTimeout(new_volume),
+                event_source,
+            )
         }
     }
 

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -344,7 +344,10 @@ impl AudioSettings {
                     Self::vol_text(volume).into(),
                     IndicatorState::Normal,
                 )
-                .on_right_press(Message::OpenMore)
+                .on_right_press(match self.config.sinks_more_cmd {
+                    Some(_) => Message::OpenSourceMore,
+                    None => Message::ToggleSinkMute,
+                })
                 .on_scroll(Self::on_scroll(
                     volume,
                     Message::SinkVolumeChanged,
@@ -370,7 +373,10 @@ impl AudioSettings {
                     Self::vol_text(volume).into(),
                     IndicatorState::Normal,
                 )
-                .on_right_press(Message::OpenSourceMore)
+                .on_right_press(match self.config.sinks_more_cmd {
+                    Some(_) => Message::OpenMore,
+                    None => Message::ToggleSourceMute,
+                })
                 .on_scroll(Self::on_scroll(
                     volume,
                     Message::SourceVolumeChanged,

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -25,7 +25,7 @@ pub enum Message {
 
 pub enum Action {
     None,
-    Command(Task<Message>),
+    SourceTaggedCommand(Task<Message>, EventSource),
 }
 
 #[derive(Debug, Clone)]
@@ -116,11 +116,12 @@ impl BrightnessSettings {
                     if let Some(value) = message.value() {
                         let _ = service.command(BrightnessCommand(value));
                     }
-                    return Action::Command(
+                    return Action::SourceTaggedCommand(
                         service
                             .current
                             .update(message)
                             .map(move |msg| Message::Changed(msg, event_source)),
+                        event_source,
                     );
                 }
                 Action::None
@@ -153,8 +154,11 @@ impl BrightnessSettings {
 
     pub fn brightness_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
-            let scroll_handler =
-                Self::on_scroll(service.current.value(), service.max, EventSource::Irelevant);
+            let scroll_handler = Self::on_scroll(
+                service.current.value(),
+                service.max,
+                EventSource::BrightnessIndicator,
+            );
 
             format_indicator(
                 self.config.indicator_format,

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -19,7 +19,7 @@ pub enum Message {
     Event(ServiceEvent<BrightnessService>),
     Changed(remote_value::Message<u32>),
     MenuOpened,
-    ConfigReloaded(SettingsFormat),
+    ConfigReloaded(BrightnessSettingsConfig),
 }
 
 pub enum Action {
@@ -27,13 +27,28 @@ pub enum Action {
     Command(Task<Message>),
 }
 
+#[derive(Debug, Clone)]
+pub struct BrightnessSettingsConfig {
+    pub indicator_format: SettingsFormat,
+    pub step: u32,
+}
+
+impl BrightnessSettingsConfig {
+    pub fn new(indicator_format: SettingsFormat, step: u32) -> Self {
+        Self {
+            indicator_format,
+            step,
+        }
+    }
+}
+
 pub struct BrightnessSettings {
-    config: SettingsFormat,
+    config: BrightnessSettingsConfig,
     service: Option<BrightnessService>,
 }
 
 impl BrightnessSettings {
-    pub fn new(config: SettingsFormat) -> Self {
+    pub fn new(config: BrightnessSettingsConfig) -> Self {
         Self {
             config,
             service: None,
@@ -44,15 +59,11 @@ impl BrightnessSettings {
         self.service.as_ref().map(|s| (s.current.value(), s.max))
     }
 
-    fn step(max: u32) -> u32 {
-        (5 * max / 100).max(1)
-    }
-
     pub fn brightness_adjust(&mut self, up: bool) -> Action {
         let Some((cur, max)) = self.current_brightness() else {
             return Action::None;
         };
-        let step = Self::step(max);
+        let step = (self.config.step * max / 100).max(1);
         let new_val = if up {
             (cur + step).min(max)
         } else {
@@ -69,7 +80,7 @@ impl BrightnessSettings {
                 ScrollDelta::Lines { y, .. } => y,
                 ScrollDelta::Pixels { y, .. } => y,
             };
-            let step = Self::step(max);
+            let step = (max / 100).max(1);
             let new = if y > 0.0 {
                 (current + step).min(max)
             } else {
@@ -109,8 +120,8 @@ impl BrightnessSettings {
                 }
                 Action::None
             }
-            Message::ConfigReloaded(format) => {
-                self.config = format;
+            Message::ConfigReloaded(config) => {
+                self.config = config;
                 Action::None
             }
         }
@@ -134,7 +145,7 @@ impl BrightnessSettings {
             let scroll_handler = Self::on_scroll(service.current.value(), service.max);
 
             format_indicator(
-                self.config,
+                self.config.indicator_format,
                 StaticIcon::Brightness,
                 Self::percent_text(service).into(),
                 IndicatorState::Normal,

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -1,6 +1,7 @@
 use crate::{
     components::{format_indicator, icons::StaticIcon, slider_control},
     config::SettingsFormat,
+    modules::settings::EventSource,
     services::{
         ReadOnlyService, Service, ServiceEvent,
         brightness::{BrightnessCommand, BrightnessService},
@@ -17,7 +18,7 @@ use iced::{
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(ServiceEvent<BrightnessService>),
-    Changed(remote_value::Message<u32>),
+    Changed(remote_value::Message<u32>, EventSource),
     MenuOpened,
     ConfigReloaded(BrightnessSettingsConfig),
 }
@@ -69,12 +70,17 @@ impl BrightnessSettings {
         } else {
             cur.saturating_sub(step)
         };
-        self.update(Message::Changed(remote_value::Message::RequestAndTimeout(
-            new_val,
-        )))
+        self.update(Message::Changed(
+            remote_value::Message::RequestAndTimeout(new_val),
+            EventSource::Irelevant,
+        ))
     }
 
-    fn on_scroll(current: u32, max: u32) -> impl Fn(ScrollDelta) -> Message {
+    fn on_scroll(
+        current: u32,
+        max: u32,
+        event_source: EventSource,
+    ) -> impl Fn(ScrollDelta) -> Message {
         move |delta| {
             let y = match delta {
                 ScrollDelta::Lines { y, .. } => y,
@@ -86,7 +92,7 @@ impl BrightnessSettings {
             } else {
                 current.saturating_sub(step)
             };
-            Message::Changed(remote_value::Message::RequestAndTimeout(new))
+            Message::Changed(remote_value::Message::RequestAndTimeout(new), event_source)
         }
     }
 
@@ -105,12 +111,17 @@ impl BrightnessSettings {
                 }
                 _ => Action::None,
             },
-            Message::Changed(message) => {
+            Message::Changed(message, event_source) => {
                 if let Some(service) = self.service.as_mut() {
                     if let Some(value) = message.value() {
                         let _ = service.command(BrightnessCommand(value));
                     }
-                    return Action::Command(service.current.update(message).map(Message::Changed));
+                    return Action::Command(
+                        service
+                            .current
+                            .update(message)
+                            .map(move |msg| Message::Changed(msg, event_source)),
+                    );
                 }
                 Action::None
             }
@@ -134,7 +145,7 @@ impl BrightnessSettings {
                 0..=service.max,
                 service.current.value(),
                 Message::Changed,
-                Self::on_scroll(service.current.value(), service.max),
+                Self::on_scroll(service.current.value(), service.max, EventSource::Irelevant),
             )
             .into()
         })
@@ -142,7 +153,8 @@ impl BrightnessSettings {
 
     pub fn brightness_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
-            let scroll_handler = Self::on_scroll(service.current.value(), service.max);
+            let scroll_handler =
+                Self::on_scroll(service.current.value(), service.max, EventSource::Irelevant);
 
             format_indicator(
                 self.config.indicator_format,

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     modules::settings::{
         audio::{AudioSettings, AudioSettingsConfig},
         bluetooth::{BluetoothSettings, BluetoothSettingsConfig},
-        brightness::BrightnessSettings,
+        brightness::{BrightnessSettings, BrightnessSettingsConfig},
         network::{NetworkSettings, NetworkSettingsConfig},
         power::{PowerSettings, PowerSettingsConfig},
     },
@@ -202,8 +202,12 @@ impl Settings {
                 config.audio_sources_more_cmd,
                 config.audio_indicator_format,
                 config.microphone_indicator_format,
+                config.audio_step,
             )),
-            brightness: BrightnessSettings::new(config.brightness_indicator_format),
+            brightness: BrightnessSettings::new(BrightnessSettingsConfig::new(
+                config.brightness_indicator_format,
+                config.brightness_step,
+            )),
             network: NetworkSettings::new(NetworkSettingsConfig::new(
                 config.wifi_more_cmd,
                 config.vpn_more_cmd,
@@ -516,6 +520,7 @@ impl Settings {
                         config.audio_sources_more_cmd,
                         config.audio_indicator_format,
                         config.microphone_indicator_format,
+                        config.audio_step,
                     )));
                 self.network.update(network::Message::ConfigReloaded(
                     NetworkSettingsConfig::new(
@@ -532,7 +537,10 @@ impl Settings {
                     ),
                 ));
                 self.brightness.update(brightness::Message::ConfigReloaded(
-                    config.brightness_indicator_format,
+                    BrightnessSettingsConfig::new(
+                        config.brightness_indicator_format,
+                        config.brightness_step,
+                    ),
                 ));
                 if config.remove_idle_btn {
                     self.idle_inhibitor = None;

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -113,6 +113,7 @@ pub enum Action {
 pub enum EventSource {
     VolumeIndicator,
     MicrophoneIndicator,
+    BrightnessIndicator,
     Irelevant,
 }
 
@@ -174,7 +175,9 @@ impl Settings {
 
     pub fn brightness_adjust(&mut self, up: bool) -> Action {
         match self.brightness.brightness_adjust(up) {
-            brightness::Action::Command(task) => Action::Command(task.map(Message::Brightness)),
+            brightness::Action::SourceTaggedCommand(task, event_source) => {
+                Action::SourceTaggedCommand(task.map(Message::Brightness), event_source)
+            }
             brightness::Action::None => Action::None,
         }
     }
@@ -354,7 +357,9 @@ impl Settings {
             },
             Message::Brightness(msg) => match self.brightness.update(msg) {
                 brightness::Action::None => Action::None,
-                brightness::Action::Command(task) => Action::Command(task.map(Message::Brightness)),
+                brightness::Action::SourceTaggedCommand(task, event_source) => {
+                    Action::SourceTaggedCommand(task.map(Message::Brightness), event_source)
+                }
             },
             Message::ToggleSubMenu(menu_type) => {
                 if self.sub_menu == Some(menu_type) {

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -102,10 +102,18 @@ pub enum Message {
 pub enum Action {
     None,
     Command(Task<Message>),
+    SourceTaggedCommand(Task<Message>, EventSource),
     CloseMenu(SurfaceId),
     RequestKeyboard(SurfaceId),
     ReleaseKeyboard(SurfaceId),
     ReleaseKeyboardWithCommand(SurfaceId, Task<Message>),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum EventSource {
+    VolumeIndicator,
+    MicrophoneIndicator,
+    Irelevant,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -138,7 +146,9 @@ impl Settings {
 
     pub fn volume_adjust(&mut self, up: bool) -> Action {
         match self.audio.volume_adjust(up) {
-            audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
+            audio::Action::SourceTaggedTask(task, event_source) => {
+                Action::SourceTaggedCommand(task.map(Message::Audio), event_source)
+            }
             _ => Action::None,
         }
     }
@@ -150,7 +160,9 @@ impl Settings {
 
     pub fn microphone_adjust(&mut self, up: bool) -> Action {
         match self.audio.microphone_adjust(up) {
-            audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
+            audio::Action::SourceTaggedTask(task, event_source) => {
+                Action::SourceTaggedCommand(task.map(Message::Audio), event_source)
+            }
             _ => Action::None,
         }
     }
@@ -273,7 +285,9 @@ impl Settings {
                     Action::None
                 }
                 audio::Action::CloseMenu(id) => Action::CloseMenu(id),
-                audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
+                audio::Action::SourceTaggedTask(task, event_source) => {
+                    Action::SourceTaggedCommand(task.map(Message::Audio), event_source)
+                }
             },
             Message::Network(msg) => match self.network.update(msg) {
                 network::Action::None => Action::None,

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -109,7 +109,7 @@ pub enum Action {
     ReleaseKeyboardWithCommand(SurfaceId, Task<Message>),
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy)]
 pub enum EventSource {
     VolumeIndicator,
     MicrophoneIndicator,

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -193,6 +193,18 @@ The default value is `Icon`.
 microphone_indicator_format = "IconAndPercentage"
 ```
 
+### Audio Step
+
+With the `audio_step` option you can customize how many steps source and sink volume changes when using
+ipc commands.
+
+The default value is 5. Valid values are in the range of 1 to 10.
+
+```toml
+[settings]
+audio_step = 1
+```
+
 ### Network Format
 
 With the `network_indicator_format` option you can customize the network connection indicator format.
@@ -226,6 +238,18 @@ The default value is `Icon`.
 ```toml
 [settings]
 brightness_indicator_format = "IconAndPercentage"
+```
+
+### Brightness Step
+
+With the `brightness_step` option you can customize how many steps screen brightness changes when using
+ipc commands.
+
+The default value is 5.	Valid values are in the	range of 1 to 10.
+
+```toml
+[settings]
+brightness_step = 1
 ```
 
 ## Peripheral Indicators


### PR DESCRIPTION
1. feature: add audio_step and brightness_step to config
2. feature: show OSD on volume and microphone indicator scrolling
3. feature: add sink/source mute on indicator right click if *_more_cmd not set.
4. feature: show OSD on brightness indicator scrolling

For feature No.1: There are three places where step is used:

1. Sliders on_scroll: Currently 5. In this PR I have fixed it to 1.
2. Indicators on_scroll: Currently 5. In this PR I have fixed it to 1.
3. IPC: In this PR it's read from config.

Part of #673

Sorry for being in the same PR but I just kept typing ...