### PR TITLE
fix(logging): added file size of 10MB as an additional criterion for …

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -28,6 +28,7 @@ const NERD_FONT_MONO: &[u8] =
     include_bytes!("../target/generated/SymbolsNerdFontMono-Regular-Subset.ttf");
 const CUSTOM_FONT: &[u8] = include_bytes!("../assets/AshellCustomIcon-Regular.otf");
 const HEIGHT: f64 = 34.;
+const TMP_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -85,7 +86,7 @@ fn main() -> iced::Result {
     .log_to_file(FileSpec::default().directory("/tmp/ashell"))
     .duplicate_to_stdout(flexi_logger::Duplicate::All)
     .rotate(
-        Criterion::Age(Age::Day),
+        Criterion::AgeOrSize(Age::Day, TMP_FILE_SIZE),
         Naming::Timestamps,
         Cleanup::KeepLogFiles(7),
     );


### PR DESCRIPTION
…log file 

`/tmp/` reaches capacity due to insufficient criterion for log file rotation. This can be observed by running `watch -n2 'du -sh /tmp/ashell/*.log 2>/dev/null | sort -rh | head -5'` with the default config. 

