### PR TITLE
tempo: add click-to-toggle location visibility for screenshot protection

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -22,7 +22,7 @@ use iced::{
     core::svg::Handle,
     futures::SinkExt,
     stream::channel,
-    widget::{Column, Row, Svg, column, container, row, scrollable, svg, text},
+    widget::{Column, MouseArea, Row, Svg, column, container, row, scrollable, svg, text},
 };
 use itertools::izip;
 use log::{debug, warn};
@@ -39,6 +39,7 @@ pub enum Message {
     CycleTimezone(TimezoneDirection),
     SetTimezone(usize),
     ConfigReloaded(TempoModuleConfig),
+    ToggleLocationVisibility,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -59,6 +60,7 @@ pub struct Tempo {
     location: Option<Location>,
     current_format_index: usize,
     current_timezone_index: usize,
+    location_visible: bool,
 }
 
 impl Tempo {
@@ -71,6 +73,7 @@ impl Tempo {
             location: None,
             current_format_index: 0,
             current_timezone_index: 0,
+            location_visible: true,
         }
     }
 
@@ -159,6 +162,10 @@ impl Tempo {
                 }
 
                 self.config = new_config;
+                Action::None
+            }
+            Message::ToggleLocationVisibility => {
+                self.location_visible = !self.location_visible;
                 Action::None
             }
         }
@@ -462,10 +469,40 @@ impl Tempo {
         let units = unit_system();
         let temp = units.temperature_symbol();
         let wind = units.wind_speed_symbol();
+        let location_visible = self.location_visible;
         self.weather_data
             .as_ref()
             .zip(self.location.as_ref())
             .map(|(data, location)| {
+                let inner_element: Element<'a, Message> = if location_visible {
+                    text(format!(
+                        "{}{} - {}",
+                        location.city,
+                        if location.region_name.is_empty() {
+                            String::new()
+                        } else {
+                            format!(", {}", location.region_name)
+                        },
+                        data.current.time.format("%R")
+                    ))
+                    .size(font_size.sm)
+                    .into()
+                } else {
+                    container(text("•••••").size(font_size.sm))
+                        .style(move |theme: &Theme| container::Style {
+                            background: Some(Background::Color(
+                                theme.extended_palette().background.strong.color,
+                            )),
+                            border: Border::default().rounded(radius.sm),
+                            ..Default::default()
+                        })
+                        .into()
+                };
+
+                let location_element: Element<'a, Message> = MouseArea::new(inner_element)
+                    .on_press(Message::ToggleLocationVisibility)
+                    .into();
+
                 column!(
                     container(
                         row!(
@@ -473,17 +510,7 @@ impl Tempo {
                                 .height(font_size.xxl)
                                 .width(Length::Shrink),
                             column!(
-                                text(format!(
-                                    "{}{} - {}",
-                                    location.city,
-                                    if location.region_name.is_empty() {
-                                        String::new()
-                                    } else {
-                                        format!(", {}", location.region_name)
-                                    },
-                                    data.current.time.format("%R")
-                                ))
-                                .size(font_size.sm),
+                                location_element,
                                 text(weather_description(data.current.weather_code)),
                                 row!(
                                     text(format!("{}{temp}", data.current.temperature_2m)),

--- a/website/docs/configuration/modules/tempo.md
+++ b/website/docs/configuration/modules/tempo.md
@@ -144,6 +144,16 @@ weather_location = "Current"
   access.
 - If an API call fails the module keeps showing the last successful reading and logs a warning.
 
+## Screenshot protection
+
+The tempo module provides privacy protection for your location in the weather menu. By default, the **location is visible**.
+
+To protect your privacy when taking screenshots:
+- **Click on the location text** to blur it (shows as "•••••")
+- **Click again** to reveal the location
+
+This user-controlled toggle ensures you can quickly hide your location before taking a screenshot.
+
 ## Tips
 
 1. Include seconds in `clock_format` (e.g., `%T`) only if you need them—the module automatically increases the refresh


### PR DESCRIPTION
I had my PR 
https://github.com/MalpenZibo/ashell/pull/718
and seen this 
https://github.com/MalpenZibo/ashell/pull/667
It just happens that we share the screen or make screen shots. 

Therefore, I added this simple minimum PR. 

Users can click the location text to blur it, which replaces the name with placeholders, and click it again to reveal the location. This functionality was implemented using the `MouseArea` widget for straightforward click detection and state management.

<img width="470" height="562" alt="image" src="https://github.com/user-attachments/assets/179442f0-dd4f-44a7-8838-69170d17acc0" />
