### PR TITLE
feat(tempo): display weather update time in current timezone

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -166,7 +166,7 @@ impl Tempo {
 
     pub fn view(&'_ self) -> Element<'_, Message> {
         let space = use_theme(|t| t.space);
-        let display_text = self.time_str(self.current_format(), self.current_timezone_index);
+        let display_text = self.time_str(self.current_format(), self.current_timezone_index, None);
 
         Row::with_capacity(2)
             .push(self.weather_indicator())
@@ -176,10 +176,16 @@ impl Tempo {
             .into()
     }
 
-    fn time_str(&'_ self, format: &str, timezone_index: usize) -> String {
+    fn time_str(
+        &'_ self,
+        format: &str,
+        timezone_index: usize,
+        utc_datetime: Option<NaiveDateTime>,
+    ) -> String {
         // %Z prints timezone abbreviations; other specifiers (e.g., %z/%:z) only need numeric offsets https://docs.rs/chrono/latest/chrono/format/strftime/index.html#fn6
         let format_requests_name = format.contains("%Z");
         let utc_now = self.date.with_timezone(&Utc);
+        let naive_utc = utc_datetime.unwrap_or_else(|| utc_now.naive_utc());
         let locale = chrono_locale();
 
         self.config
@@ -189,7 +195,7 @@ impl Tempo {
                 if !format_requests_name && let Ok(offset) = tz_name.parse::<FixedOffset>() {
                     return Some(
                         offset
-                            .from_utc_datetime(&utc_now.naive_utc())
+                            .from_utc_datetime(&naive_utc)
                             .format_localized(format, locale)
                             .to_string(),
                     );
@@ -197,7 +203,7 @@ impl Tempo {
 
                 if let Ok(tz) = tz_name.parse::<Tz>() {
                     return Some(
-                        tz.from_utc_datetime(&utc_now.naive_utc())
+                        tz.from_utc_datetime(&naive_utc)
                             .format_localized(format, locale)
                             .to_string(),
                     );
@@ -205,7 +211,12 @@ impl Tempo {
 
                 None
             })
-            .unwrap_or_else(|| self.date.format_localized(format, locale).to_string())
+            .unwrap_or_else(|| {
+                Local
+                    .from_utc_datetime(&naive_utc)
+                    .format_localized(format, locale)
+                    .to_string()
+            })
     }
 
     pub fn weather_indicator(&'_ self) -> Option<Element<'_, Message>> {
@@ -409,8 +420,12 @@ impl Tempo {
                 .map(|(index, tz_name)| {
                     if self.current_timezone_index == index {
                         container(
-                            text(format!("{}: {}", tz_name, self.time_str("%d %h %R", index)))
-                                .wrapping(text::Wrapping::Word),
+                            text(format!(
+                                "{}: {}",
+                                tz_name,
+                                self.time_str("%d %h %R", index, None)
+                            ))
+                            .wrapping(text::Wrapping::Word),
                         )
                         .padding([theme.space.xxs, theme.space.sm])
                         .width(Length::Fill)
@@ -420,10 +435,14 @@ impl Tempo {
                         })
                         .into()
                     } else {
-                        styled_button(format!("{}: {}", tz_name, self.time_str("%d %h %R", index)))
-                            .width(Length::Fill)
-                            .on_press(Message::SetTimezone(index))
-                            .into()
+                        styled_button(format!(
+                            "{}: {}",
+                            tz_name,
+                            self.time_str("%d %h %R", index, None)
+                        ))
+                        .width(Length::Fill)
+                        .on_press(Message::SetTimezone(index))
+                        .into()
                     }
                 })
                 .collect::<Vec<Element<'a, Message>>>(),
@@ -481,7 +500,11 @@ impl Tempo {
                                     } else {
                                         format!(", {}", location.region_name)
                                     },
-                                    data.current.time.format("%R")
+                                    self.time_str(
+                                        "%R",
+                                        self.current_timezone_index,
+                                        Some(data.current.time)
+                                    )
                                 ))
                                 .size(font_size.sm),
                                 text(weather_description(data.current.weather_code)),


### PR DESCRIPTION
The last update time from open-meteo is returned in UTC (e.g., [current Paris weather](https://api.open-meteo.com/v1/forecast?latitude=48.8575&longitude=2.3514&current=weather_code)). This PR displays the last update time from open-meteo in your currently selected timezone.