### PR TITLE
build(deps): Use hyprland-rs master branch to fix crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -987,7 +987,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1727,8 +1727,7 @@ dependencies = [
 [[package]]
 name = "hyprland"
 version = "0.4.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62fc24052f578592af91e5c60da1893ba6aea266b6ab86ffb72a644cf213fea9"
+source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#330b8d3b6906817377dbcb161ce3e221c0414a40"
 dependencies = [
  "async-stream",
  "derive_more",
@@ -1745,8 +1744,7 @@ dependencies = [
 [[package]]
 name = "hyprland-macros"
 version = "0.4.0-beta.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31157e6ccefbad4b0cd7e549db6696691a70c11b108f26bf6bf76eef26af8c10"
+source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#330b8d3b6906817377dbcb161ce3e221c0414a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3384,7 +3382,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3714,7 +3712,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3771,7 +3769,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4327,7 +4325,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5310,7 +5308,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ chrono = { version = "0.4", default-features = false, features = [
   "serde",
   "unstable-locales",
 ] }
-hyprland = "0.4.0-beta.2"
+hyprland = { git = "https://github.com/hyprland-community/hyprland-rs", branch = "master" }
 serde = { version = "1.0", default-features = false, features = [] }
 sysinfo = { version = "0.37", features = ["linux-netdevs"] }
 tokio = { version = "1", default-features = false, features = ["net"] }


### PR DESCRIPTION
Switches `hyprland-rs` from a tagged release to the master branch to prevent crashes reported in #577 and #478