### PR TITLE
Replace generic `unwrap()` with `expect()` in network backends

### DIFF
--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -163,8 +163,8 @@ impl super::NetworkBackend for NetworkDbus<'_> {
             debug!("Activating VPN: {connection:?}");
             self.activate_connection(
                 connection,
-                OwnedObjectPath::try_from("/").unwrap(),
-                OwnedObjectPath::try_from("/").unwrap(),
+                OwnedObjectPath::try_from("/").expect("D-Bus root path is always valid"),
+                OwnedObjectPath::try_from("/").expect("D-Bus root path is always valid"),
             )
             .await?;
         } else {

--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -216,7 +216,8 @@ impl super::NetworkBackend for IwdDbus<'_> {
 
         // If password is provided, register a new agent to handle it
         if let Some(p) = password {
-            let path = OwnedObjectPath::try_from("/ashell/pwagent/main").unwrap();
+            let path = OwnedObjectPath::try_from("/ashell/pwagent/main")
+                .expect("hardcoded valid D-Bus object path");
 
             match agent_manager.unregister_agent(&path).await {
                 Ok(_) => info!("Successfully unregistered agent at {path}"),


### PR DESCRIPTION
And providing meaningful error messages for hardcoded D-Bus object paths.