### PR TITLE
fix: replace unwrap on connection id lookup with safe chaining

### DIFF
--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -781,15 +781,21 @@ impl NetworkSettingsDbus<'_> {
                 .await?;
 
             let s = connection.get_settings().await?;
-            let id = s["connection"]
-                .get("id")
-                .map(|v| match v.deref() {
-                    Value::Str(v) => v.to_string(),
-                    _ => "".to_string(),
-                })
-                .unwrap();
-            if id == name {
+            let id = s
+                .get("connection")
+                .and_then(|c| c.get("id"))
+                .and_then(|v| match v.deref() {
+                    Value::Str(v) => Some(v.to_string()),
+                    _ => {
+                        debug!("connection settings 'id' field is not a string");
+                        None
+                    }
+                });
+            if id.as_deref() == Some(name) {
                 return Ok(Some(connection.inner().path().to_owned().into()));
+            }
+            if id.is_none() {
+                debug!("skipping connection with missing or invalid 'id' field");
             }
         }
 


### PR DESCRIPTION
The `find_connection` function used `s[connection].get(id).unwrap()` which panics if either the 'connection' section or 'id' key is missing. Replaced with `s.get().and_then()` pattern consistent with existing code. Connections without an id are skipped rather than crashing.