### PR TITLE
feat(tray): left/right click behavior

### DIFF
--- a/src/components/position_button.rs
+++ b/src/components/position_button.rs
@@ -99,6 +99,14 @@ where
         self
     }
 
+    pub fn on_right_press_with_position(
+        mut self,
+        on_right_press: impl Fn(ButtonUIRef) -> Message + 'a,
+    ) -> Self {
+        self.on_right_press = Some(OnPress::MessageWithPosition(Box::new(on_right_press)));
+        self
+    }
+
     pub fn on_scroll_up(mut self, on_scroll_up: Message) -> Self {
         self.on_scroll_up = Some(OnPress::Message(on_scroll_up));
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -439,11 +439,9 @@ impl Default for NotificationsModuleConfig {
     }
 }
 
-#[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[derive(Deserialize, Clone, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum TrayClickAction {
-    #[default]
-    None,
     Open,
     Menu,
 }
@@ -452,7 +450,7 @@ pub enum TrayClickAction {
 #[serde(default)]
 pub struct TrayModuleConfig {
     pub blocklist: Vec<RegexCfg>,
-    pub right_click: TrayClickAction,
+    pub right_click: Option<TrayClickAction>,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -439,9 +439,20 @@ impl Default for NotificationsModuleConfig {
     }
 }
 
+#[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum TrayClickAction {
+    #[default]
+    None,
+    Open,
+    Menu,
+}
+
 #[derive(Deserialize, Clone, Debug, Default)]
+#[serde(default)]
 pub struct TrayModuleConfig {
     pub blocklist: Vec<RegexCfg>,
+    pub right_click: TrayClickAction,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -43,7 +43,7 @@ pub struct TrayModule {
     service: Option<TrayService>,
     submenus: Vec<i32>,
     blocklist: Vec<crate::config::RegexCfg>,
-    right_click: TrayClickAction,
+    right_click: Option<TrayClickAction>,
 }
 
 impl TrayModule {
@@ -239,13 +239,11 @@ impl TrayModule {
 
                                 let mut btn = position_button(icon_content);
                                 btn = match &self.right_click {
-                                    TrayClickAction::None => {
-                                        btn.on_press_with_position(toggle_menu.clone())
-                                    }
-                                    TrayClickAction::Open => btn
+                                    None => btn.on_press_with_position(toggle_menu.clone()),
+                                    Some(TrayClickAction::Open) => btn
                                         .on_press_with_position(toggle_menu.clone())
                                         .on_right_press(open_app.clone()),
-                                    TrayClickAction::Menu => btn
+                                    Some(TrayClickAction::Menu) => btn
                                         .on_press(open_app.clone())
                                         .on_right_press_with_position(toggle_menu.clone()),
                                 };

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -5,7 +5,7 @@ use crate::{
         ButtonHierarchy, ButtonKind, ButtonUIRef, IconPosition, MenuSize, position_button,
         styled_button,
     },
-    config::TrayModuleConfig,
+    config::{TrayClickAction, TrayModuleConfig},
     services::{
         ReadOnlyService, Service, ServiceEvent,
         tray::{
@@ -28,6 +28,7 @@ pub enum Message {
     ToggleSubmenu(i32),
     MenuSelected(String, i32),
     MenuOpened(String),
+    Activate(String),
 }
 
 pub enum Action {
@@ -42,6 +43,7 @@ pub struct TrayModule {
     service: Option<TrayService>,
     submenus: Vec<i32>,
     blocklist: Vec<crate::config::RegexCfg>,
+    right_click: TrayClickAction,
 }
 
 impl TrayModule {
@@ -50,6 +52,7 @@ impl TrayModule {
             service: None,
             submenus: Vec::new(),
             blocklist: config.blocklist.clone(),
+            right_click: config.right_click,
         }
     }
 
@@ -113,6 +116,17 @@ impl TrayModule {
 
                 Action::None
             }
+            Message::Activate(name) => match self.service.as_mut() {
+                Some(service) => {
+                    debug!("Tray item activate: {name}");
+                    Action::TrayMenuCommand(
+                        service
+                            .command(TrayCommand::Activate(name))
+                            .map(|event| Message::Event(Box::new(event))),
+                    )
+                }
+                _ => Action::None,
+            },
         }
     }
 
@@ -207,26 +221,37 @@ impl TrayModule {
                             .iter()
                             .filter(|item| !self.is_blocklisted(&item.name))
                             .map(|item| {
+                                let name = item.name.to_owned();
                                 let button_style = button_style.clone();
-                                position_button(match &item.icon {
-                                    Some(TrayIcon::Image(handle)) => Into::<Element<_>>::into(
-                                        Image::new(handle.clone())
-                                            .height(Length::Fixed(font_size.md - 2.0)),
-                                    ),
-                                    Some(TrayIcon::Svg(handle)) => Into::<Element<_>>::into(
-                                        Svg::new(handle.clone())
-                                            .height(Length::Fixed(font_size.md + 2.))
-                                            .width(Length::Fixed(font_size.md + 2.))
-                                            .content_fit(iced::ContentFit::Cover),
-                                    ),
+                                let icon_content: Element<'_, Message> = match &item.icon {
+                                    Some(TrayIcon::Image(handle)) => Image::new(handle.clone())
+                                        .height(Length::Fixed(font_size.md - 2.0))
+                                        .into(),
+                                    Some(TrayIcon::Svg(handle)) => Svg::new(handle.clone())
+                                        .height(Length::Fixed(font_size.md + 2.))
+                                        .width(Length::Fixed(font_size.md + 2.))
+                                        .content_fit(iced::ContentFit::Cover)
+                                        .into(),
                                     _ => icon(StaticIcon::Point).into(),
-                                })
-                                .on_press_with_position(move |button_ui_ref| {
-                                    Message::ToggleMenu(item.name.to_owned(), id, button_ui_ref)
-                                })
-                                .padding(space.xxs)
-                                .style(move |t, s| button_style(t, s))
-                                .into()
+                                };
+                                let open_app = Message::Activate(name.clone());
+                                let toggle_menu = move |r| Message::ToggleMenu(name.clone(), id, r);
+
+                                let mut btn = position_button(icon_content);
+                                btn = match &self.right_click {
+                                    TrayClickAction::None => {
+                                        btn.on_press_with_position(toggle_menu.clone())
+                                    }
+                                    TrayClickAction::Open => btn
+                                        .on_press_with_position(toggle_menu.clone())
+                                        .on_right_press(open_app.clone()),
+                                    TrayClickAction::Menu => btn
+                                        .on_press(open_app.clone())
+                                        .on_right_press_with_position(toggle_menu.clone()),
+                                };
+                                btn.padding(space.xxs)
+                                    .style(move |t, s| button_style(t, s))
+                                    .into()
                             })
                             .collect::<Vec<_>>(),
                     )

--- a/src/services/tray/dbus.rs
+++ b/src/services/tray/dbus.rs
@@ -242,6 +242,8 @@ pub trait StatusNotifierItem {
 
     #[zbus(property)]
     fn menu(&self) -> zbus::Result<OwnedObjectPath>;
+
+    fn activate(&self, x: i32, y: i32) -> zbus::Result<()>;
 }
 
 #[derive(Clone, Debug, Type)]

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -690,6 +690,7 @@ impl ReadOnlyService for TrayService {
 #[derive(Debug, Clone)]
 pub enum TrayCommand {
     MenuSelected(String, i32),
+    Activate(String),
 }
 
 impl Service for TrayService {
@@ -717,6 +718,23 @@ impl Service for TrayService {
                             )),
                             _ => ServiceEvent::Update(TrayEvent::None),
                         },
+                    )
+                } else {
+                    Task::none()
+                }
+            }
+            TrayCommand::Activate(name) => {
+                let item = self.data.iter().find(|item| item.name == name);
+                if let Some(item) = item {
+                    Task::perform(
+                        {
+                            let proxy = item.item_proxy.clone();
+                            async move {
+                                debug!("Activate tray item {name}");
+                                let _ = proxy.activate(0, 0).await;
+                            }
+                        },
+                        |_| ServiceEvent::Update(TrayEvent::None),
                     )
                 } else {
                     Task::none()

--- a/website/docs/configuration/modules/tray.md
+++ b/website/docs/configuration/modules/tray.md
@@ -14,6 +14,14 @@ You can filter which tray icons are displayed using the `blocklist` option. If a
 
 **Note**: Matching is done against the tray item's name using regex patterns.
 
+## Click Behavior
+
+You can configure what happens when right-clicking a tray icon using `right_click`. The left click behavior is automatically set to the complement.
+
+- `"none"` — no right click action; left click opens the context menu (default)
+- `"open"` — right click activates the application (e.g. show/raise its window); left click opens the context menu
+- `"menu"` — right click opens the context menu; left click activates the application
+
 ## Examples
 
 **Hide multiple applications by pattern:**
@@ -23,6 +31,13 @@ You can filter which tray icons are displayed using the `blocklist` option. If a
 blocklist = ["spotify", "^org\\.gnome\\."]
 ```
 
+**Right click to open the context menu (left click opens app):**
+
+```toml
+[tray]
+right_click = "menu"
+```
+
 ## Default Configuration
 
 The default configuration is:
@@ -30,4 +45,5 @@ The default configuration is:
 ```toml
 [tray]
 blocklist = []
+right_click = "none"
 ```

--- a/website/docs/configuration/modules/tray.md
+++ b/website/docs/configuration/modules/tray.md
@@ -16,9 +16,8 @@ You can filter which tray icons are displayed using the `blocklist` option. If a
 
 ## Click Behavior
 
-You can configure what happens when right-clicking a tray icon using `right_click`. The left click behavior is automatically set to the complement.
+You can configure what happens when right-clicking a tray icon using `right_click`. The left click behavior is automatically set to the complement. If omitted, only left click is active and opens the context menu.
 
-- `"none"` — no right click action; left click opens the context menu (default)
 - `"open"` — right click activates the application (e.g. show/raise its window); left click opens the context menu
 - `"menu"` — right click opens the context menu; left click activates the application
 
@@ -45,5 +44,4 @@ The default configuration is:
 ```toml
 [tray]
 blocklist = []
-right_click = "none"
 ```


### PR DESCRIPTION
Closes https://github.com/MalpenZibo/ashell/issues/492

## Change description

This PR adds support for configuring the left- and right-click behavior for tray items. We can now either:
- show the context menu (like before)
- open the application (new)

## To consider (deprecated section, [see conclusion](https://github.com/MalpenZibo/ashell/pull/729#issuecomment-4423174918))

⚠️ I took the liberty of changing the default for left-clicking tray items. It now opens the application instead of opening the context menu. The context menu is now bound to right-click by default.

I felt it was an OK change to make because:
- Left-clicking workspace icons already switches the workspace, and so switching to an app with left-clicking tray icons feels similar.
- Context menus often open on right-click.
- I've introduced new config properties so users can specify their preference.
- The documentation includes an example on how to switch the buttons.

However, I understand this is mostly subjective and likely a matter of personal preference. I'm happy to revert that part. Please let me know if you consider this unwanted and would like to revert the default left-click behavior to its previous state.