### PR TITLE
Fix double-subscription crash when Settings module is enabled

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -757,6 +757,25 @@ impl App {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
+        use crate::config::{ModuleDef, ModuleName};
+
+        let mut all_modules = self
+            .general_config
+            .modules
+            .left
+            .iter()
+            .chain(&self.general_config.modules.center)
+            .chain(&self.general_config.modules.right);
+
+        let settings_in_module_list = all_modules
+            .any(|module_def| matches!(module_def, ModuleDef::Single(ModuleName::Settings)));
+
+        let settings_subscription = if settings_in_module_list {
+            Subscription::none()
+        } else {
+            self.settings.subscription().map(Message::Settings)
+        };
+
         Subscription::batch(vec![
             Subscription::batch(self.modules_subscriptions(&self.general_config.modules.left)),
             Subscription::batch(self.modules_subscriptions(&self.general_config.modules.center)),
@@ -791,9 +810,9 @@ impl App {
                         }
                     })
             }),
-            // Always subscribe to audio/brightness services so OSD works
-            // even when the Settings module isn't in the module list.
-            self.settings.subscription().map(Message::Settings),
+            // Only subscribe explicitly if Settings is NOT in the module list
+            // (if it is in the module list, modules_subscriptions already subscribes)
+            settings_subscription,
             crate::ipc::subscription().map(|cmd| match cmd {
                 IpcCommand::ToggleVisibility => Message::ToggleVisibility,
                 other => Message::IpcOsdCommand(other),


### PR DESCRIPTION
There was a bug in `src/app.rs` in the `subscription()` method. 
When Settings was in the module list, the code would subscribe to Settings' underlying D-Bus services (UPower, PulseAudio, NetworkManager) twice: 
once through `self.modules_subscriptions()`, and again explicitly at the end of `Subscription::batch()` for OSD support. 
This double-subscription could corrupt D-Bus proxy state and cause segmentation faults. The fix checks if Settings is in any module list and only adds the explicit subscription when it's not present, eliminating the duplicate while maintaining OSD functionality.

Related to #727.