### PR TITLE
implement tooltip menus for quick settings indicators

### DIFF
--- a/docs/src/core/menu-system.md
+++ b/docs/src/core/menu-system.md
@@ -14,6 +14,12 @@ pub enum MenuType {
     MediaPlayer,
     SystemInfo,
     Tempo,
+    // Tooltip menus (opened on hover, not click)
+    AudioTooltip,
+    BluetoothTooltip,
+    WifiTooltip,
+    BatteryTooltip,
+    PeripheralBatteryTooltip(usize),
 }
 ```
 

--- a/docs/src/modules/settings-module.md
+++ b/docs/src/modules/settings-module.md
@@ -97,6 +97,13 @@ The Settings panel includes an idle inhibitor toggle that prevents the system fr
 
 The Settings module displays compact status indicators in the bar (audio, bluetooth, wifi, battery, peripheral battery). Hovering over these indicators shows a tooltip popup with detailed information.
 
+Tooltips can be enabled or disabled via the `enable_tooltips` setting inside `[settings]` (default: `true`). When disabled, hovering over indicators produces no tooltip popup.
+
+```toml
+[settings]
+enable_tooltips = false
+```
+
 ### Tooltip Menu Types
 
 Each indicator maps to a dedicated `MenuType` variant:

--- a/docs/src/modules/settings-module.md
+++ b/docs/src/modules/settings-module.md
@@ -92,3 +92,29 @@ These execute shell commands and display the result as a status indicator.
 ## Idle Inhibitor
 
 The Settings panel includes an idle inhibitor toggle that prevents the system from going to sleep. This uses the `IdleInhibitorManager` service, which interacts with systemd-logind's inhibit API.
+
+## Status Indicator Tooltips
+
+The Settings module displays compact status indicators in the bar (audio, bluetooth, wifi, battery, peripheral battery). Hovering over these indicators shows a tooltip popup with detailed information.
+
+### Tooltip Menu Types
+
+Each indicator maps to a dedicated `MenuType` variant:
+
+| Indicator | Menu Type | Content |
+|-----------|-----------|---------|
+| Audio / Microphone | `AudioTooltip` | Active sink and source device names |
+| Bluetooth | `BluetoothTooltip` | Connected peripheral devices with battery level and device-specific battery icon |
+| Network / VPN | `WifiTooltip` | Connected WiFi network name |
+| Battery | `BatteryTooltip` | Charge percentage, charging/discharging/full status, time remaining |
+| Peripheral Battery | `PeripheralBatteryTooltip(index)` | Device name, capacity percentage, and device-specific battery icon |
+
+### Hover Interaction
+
+Tooltips use the `PositionButton` hover events (`on_hover_with_position` / `on_unhover`). When the cursor enters an indicator, the module opens a tooltip menu positioned relative to the button. When the cursor leaves, the tooltip closes.
+
+Tooltips are suppressed when a non-tooltip menu (e.g., the Settings panel) is already open, to avoid conflicting popups.
+
+### Peripheral Battery Icons
+
+Bluetooth and peripheral battery tooltips use device-specific battery icons from `Peripheral::get_icon_state()` (e.g., `KeyboardBatteryCharging`, `MouseBatteryMedium`, `HeadphoneBatteryLow`). These icons encode both the device type and battery level in a single glyph.

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -161,6 +161,9 @@ weather_format = "{temp}°C"
 
 ```toml
 [settings]
+# Enable/disable hover tooltips on status indicators (audio, bluetooth, wifi, battery)
+enable_tooltips = true
+
 # Custom buttons in the settings panel
 [[settings.custom_buttons]]
 icon = "\u{f023}"

--- a/docs/src/widgets/position-button.md
+++ b/docs/src/widgets/position-button.md
@@ -29,6 +29,11 @@ impl PositionButton {
     pub fn on_scroll_up(self, msg: Message) -> Self;
     pub fn on_scroll_down(self, msg: Message) -> Self;
 
+    // Hover handlers (used for tooltip popups)
+    pub fn on_hover(self, msg: Message) -> Self;
+    pub fn on_hover_with_position(self, f: impl Fn(ButtonUIRef) -> Message) -> Self;
+    pub fn on_unhover(self, msg: Message) -> Self;
+
     // Styling
     pub fn padding(self, padding: impl Into<Padding>) -> Self;
     pub fn height(self, height: impl Into<Length>) -> Self;

--- a/i18n/en-US/ashell.ftl
+++ b/i18n/en-US/ashell.ftl
@@ -84,6 +84,10 @@ settings-power-profile-balanced = Balanced
 settings-power-profile-performance = Performance
 settings-power-profile-power-saver = Power Saver
 
+settings-power-status-charging = Charging
+settings-power-status-discharging = Discharging
+settings-power-status-full = Full
+
 ## Settings — idle inhibitor
 settings-idle-inhibitor = Idle Inhibitor
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -464,6 +464,12 @@ impl App {
                         self.outputs.release_keyboard(id),
                     ])
                 }
+                modules::settings::Action::OpenTooltipMenu(id, menu_type, ui_ref) => {
+                    self.outputs.toggle_menu(id, menu_type, ui_ref, false)
+                }
+                modules::settings::Action::CloseTooltipMenu(id, menu_type) => self
+                    .outputs
+                    .close_menu(id, Some(menu_type), self.general_config.enable_esc_key),
             },
             Message::OutputEvent(event) => match event {
                 OutputEvent::Added(info) => {
@@ -758,6 +764,17 @@ impl App {
                     MenuType::Tempo => {
                         self.menu_wrapper(id, self.tempo.menu_view().map(Message::Tempo), ui_ref)
                     }
+                    MenuType::AudioTooltip
+                    | MenuType::BluetoothTooltip
+                    | MenuType::WifiTooltip
+                    | MenuType::BatteryTooltip
+                    | MenuType::PeripheralBatteryTooltip(_) => self.menu_wrapper(
+                        id,
+                        self.settings
+                            .tooltip_view(&open_menu.menu_type)
+                            .map(Message::Settings),
+                        ui_ref,
+                    ),
                 }
             }
             Some(HasOutput::Menu(None)) => Row::new().into(),

--- a/src/app.rs
+++ b/src/app.rs
@@ -767,6 +767,7 @@ impl App {
                     MenuType::AudioTooltip
                     | MenuType::BluetoothTooltip
                     | MenuType::WifiTooltip
+                    | MenuType::VpnTooltip
                     | MenuType::BatteryTooltip
                     | MenuType::PeripheralBatteryTooltip(_) => self.menu_wrapper(
                         id,

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -19,6 +19,11 @@ pub enum MenuType {
     MediaPlayer,
     SystemInfo,
     Tempo,
+    AudioTooltip,
+    BluetoothTooltip,
+    WifiTooltip,
+    BatteryTooltip,
+    PeripheralBatteryTooltip(usize),
 }
 
 #[derive(Clone, Debug)]
@@ -92,13 +97,38 @@ impl Menu {
         request_keyboard: bool,
         output_id: Option<OutputId>,
     ) -> Task<Message> {
+        let menu_is_tooltip = matches!(
+            menu_type,
+            MenuType::AudioTooltip
+                | MenuType::BluetoothTooltip
+                | MenuType::WifiTooltip
+                | MenuType::BatteryTooltip
+                | MenuType::PeripheralBatteryTooltip(_)
+        );
         match &mut self.open {
             None => self.open(menu_type, button_ui_ref, request_keyboard, output_id),
-            Some(open) if open.menu_type == menu_type => self.close(),
-            Some(open) => {
-                open.menu_type = menu_type;
-                open.button_ui_ref = button_ui_ref;
+            Some(open)
+                if open.menu_type == menu_type
+                    && open.button_ui_ref.position == button_ui_ref.position =>
+            {
+                self.close()
+            }
+            Some(open)
+                if !matches!(
+                    open.menu_type,
+                    MenuType::AudioTooltip
+                        | MenuType::BluetoothTooltip
+                        | MenuType::WifiTooltip
+                        | MenuType::BatteryTooltip
+                        | MenuType::PeripheralBatteryTooltip(_)
+                ) && menu_is_tooltip =>
+            {
                 Task::none()
+            }
+            _ => {
+                let close_task = self.close();
+                let open_task = self.open(menu_type, button_ui_ref, request_keyboard, output_id);
+                Task::batch(vec![close_task, open_task])
             }
         }
     }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -22,6 +22,7 @@ pub enum MenuType {
     AudioTooltip,
     BluetoothTooltip,
     WifiTooltip,
+    VpnTooltip,
     BatteryTooltip,
     PeripheralBatteryTooltip(usize),
 }
@@ -102,16 +103,20 @@ impl Menu {
             MenuType::AudioTooltip
                 | MenuType::BluetoothTooltip
                 | MenuType::WifiTooltip
+                | MenuType::VpnTooltip
                 | MenuType::BatteryTooltip
                 | MenuType::PeripheralBatteryTooltip(_)
         );
         match &mut self.open {
             None => self.open(menu_type, button_ui_ref, request_keyboard, output_id),
-            Some(open)
-                if open.menu_type == menu_type
-                    && open.button_ui_ref.position == button_ui_ref.position =>
-            {
-                self.close()
+            Some(open) if open.menu_type == menu_type => {
+                if menu_is_tooltip {
+                    // For tooltips, just update the button reference without closing/reopening
+                    open.button_ui_ref = button_ui_ref;
+                    Task::none()
+                } else {
+                    self.close()
+                }
             }
             Some(open)
                 if !matches!(
@@ -119,10 +124,16 @@ impl Menu {
                     MenuType::AudioTooltip
                         | MenuType::BluetoothTooltip
                         | MenuType::WifiTooltip
+                        | MenuType::VpnTooltip
                         | MenuType::BatteryTooltip
                         | MenuType::PeripheralBatteryTooltip(_)
                 ) && menu_is_tooltip =>
             {
+                Task::none()
+            }
+            Some(open) if menu_is_tooltip => {
+                open.menu_type = menu_type;
+                open.button_ui_ref = button_ui_ref;
                 Task::none()
             }
             _ => {

--- a/src/components/position_button.rs
+++ b/src/components/position_button.rs
@@ -20,6 +20,11 @@ enum OnPress<'a, Message> {
     MessageWithPosition(Box<dyn Fn(ButtonUIRef) -> Message + 'a>),
 }
 
+enum OnHover<'a, Message> {
+    Message(Message),
+    MessageWithPosition(Box<dyn Fn(ButtonUIRef) -> Message + 'a>),
+}
+
 pub struct PositionButton<'a, Message, Theme = iced::Theme, Renderer = iced::Renderer>
 where
     Renderer: iced::core::Renderer,
@@ -30,6 +35,8 @@ where
     on_right_press: Option<OnPress<'a, Message>>,
     on_scroll_up: Option<OnPress<'a, Message>>,
     on_scroll_down: Option<OnPress<'a, Message>>,
+    on_hover: Option<OnHover<'a, Message>>,
+    on_unhover: Option<Message>,
     width: Length,
     height: Length,
     padding: Padding,
@@ -52,6 +59,8 @@ where
             on_right_press: None,
             on_scroll_up: None,
             on_scroll_down: None,
+            on_hover: None,
+            on_unhover: None,
             width: size.width.fluid(),
             height: size.height.fluid(),
             padding: DEFAULT_PADDING,
@@ -117,6 +126,24 @@ where
         self
     }
 
+    pub fn on_hover(mut self, on_hover: Message) -> Self {
+        self.on_hover = Some(OnHover::Message(on_hover));
+        self
+    }
+
+    pub fn on_hover_with_position(
+        mut self,
+        on_hover: impl Fn(ButtonUIRef) -> Message + 'a,
+    ) -> Self {
+        self.on_hover = Some(OnHover::MessageWithPosition(Box::new(on_hover)));
+        self
+    }
+
+    pub fn on_unhover(mut self, on_unhover: Message) -> Self {
+        self.on_unhover = Some(on_unhover);
+        self
+    }
+
     /// Sets whether the contents of the [`Button`] should be clipped on
     /// overflow.
     pub fn clip(mut self, clip: bool) -> Self {
@@ -156,6 +183,32 @@ where
                     viewport: (viewport.width, viewport.height),
                 };
                 shell.publish(on_press_with_position(ui_data));
+            }
+        }
+    }
+
+    fn publish_on_hover(
+        &self,
+        on_hover: &OnHover<'a, Message>,
+        layout: Layout<'_>,
+        viewport: &Rectangle,
+        shell: &mut Shell<'_, Message>,
+    ) where
+        Message: Clone,
+    {
+        match on_hover {
+            OnHover::Message(message) => {
+                shell.publish(message.clone());
+            }
+            OnHover::MessageWithPosition(on_hover_with_position) => {
+                let ui_data = ButtonUIRef {
+                    position: Point::new(
+                        layout.bounds().width / 2. + layout.position().x,
+                        layout.bounds().height / 2. + layout.position().y,
+                    ),
+                    viewport: (viewport.width, viewport.height),
+                };
+                shell.publish(on_hover_with_position(ui_data));
             }
         }
     }
@@ -372,10 +425,33 @@ where
                     }
                 }
             }
+            event::Event::Mouse(mouse::Event::CursorMoved { .. }) => {
+                let bounds = layout.bounds();
+                let is_over = cursor.is_over(bounds);
+                let state = tree.state.downcast_mut::<State>();
+                if is_over {
+                    if !state.is_hovered
+                        && let Some(on_hover) = self.on_hover.as_ref()
+                    {
+                        state.is_hovered = true;
+                        self.publish_on_hover(on_hover, layout, viewport, shell);
+                    }
+                } else if state.is_hovered {
+                    state.is_hovered = false;
+                    if let Some(on_unhover) = self.on_unhover.as_ref() {
+                        shell.publish(on_unhover.clone());
+                    }
+                }
+            }
             event::Event::Touch(touch::Event::FingerLost { .. })
             | event::Event::Mouse(mouse::Event::CursorLeft) => {
                 let state = tree.state.downcast_mut::<State>();
-                state.is_hovered = false;
+                if state.is_hovered {
+                    state.is_hovered = false;
+                    if let Some(on_unhover) = self.on_unhover.as_ref() {
+                        shell.publish(on_unhover.clone());
+                    }
+                }
                 state.is_pressed = false;
             }
             _ => {}
@@ -383,7 +459,8 @@ where
 
         // Reactive rendering: track hover state and request redraw on change
         let state = tree.state.downcast_mut::<State>();
-        let is_hovered = self.on_press.is_some() && cursor.is_over(layout.bounds());
+        let is_hovered =
+            (self.on_press.is_some() || self.on_hover.is_some()) && cursor.is_over(layout.bounds());
         if is_hovered != state.is_hovered {
             state.is_hovered = is_hovered;
             shell.request_redraw();
@@ -404,7 +481,7 @@ where
         let content_layout = layout.children().next().unwrap();
         let state = tree.state.downcast_ref::<State>();
 
-        let status = if self.on_press.is_none() {
+        let status = if self.on_press.is_none() && self.on_hover.is_none() {
             Status::Disabled
         } else if state.is_hovered {
             if state.is_pressed {

--- a/src/config.rs
+++ b/src/config.rs
@@ -574,6 +574,7 @@ pub struct SettingsModuleConfig {
     pub bluetooth_more_cmd: Option<String>,
     pub remove_airplane_btn: bool,
     pub remove_idle_btn: bool,
+    pub enable_tooltips: bool,
     pub indicators: Vec<SettingsIndicator>,
     #[serde(rename = "CustomButton")]
     pub custom_buttons: Vec<SettingsCustomButton>,
@@ -605,6 +606,7 @@ impl Default for SettingsModuleConfig {
             bluetooth_more_cmd: Default::default(),
             remove_airplane_btn: Default::default(),
             remove_idle_btn: Default::default(),
+            enable_tooltips: true,
             indicators: vec![
                 SettingsIndicator::IdleInhibitor,
                 SettingsIndicator::PowerProfile,
@@ -1158,7 +1160,7 @@ fn read_config(path: &Path) -> Result<Config, Box<dyn Error + Send>> {
 
     info!("Decoding config file {path:?}");
 
-    let res = toml::from_str(&content);
+    let res = toml::from_str::<Config>(&content);
 
     match res {
         Ok(config) => {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -240,7 +240,7 @@ impl App {
                 )
             }),
             ModuleName::Settings => Some((
-                self.settings.view().map(Message::Settings),
+                self.settings.view(id).map(Message::Settings),
                 Some(OnModulePress::ToggleMenu(MenuType::Settings)),
             )),
             ModuleName::Notifications => Some((

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -599,4 +599,16 @@ impl AudioSettings {
     pub fn subscription(&self) -> Subscription<Message> {
         AudioService::subscribe().map(Message::Event)
     }
+
+    pub fn active_sink_label(&self) -> Option<String> {
+        self.service
+            .as_ref()
+            .and_then(|s| s.active_sink().map(|d| d.description.clone()))
+    }
+
+    pub fn active_source_label(&self) -> Option<String> {
+        self.service
+            .as_ref()
+            .and_then(|s| s.active_source().map(|d| d.description.clone()))
+    }
 }

--- a/src/modules/settings/bluetooth.rs
+++ b/src/modules/settings/bluetooth.rs
@@ -202,8 +202,11 @@ impl BluetoothSettings {
                     service.state == BluetoothState::Active,
                     Message::Toggle,
                     Some(Message::OpenMore),
-                    Some((SubMenu::Bluetooth, sub_menu, Message::ToggleSubMenu))
-                        .filter(|_| service.state == BluetoothState::Active),
+                    (service.state == BluetoothState::Active).then_some((
+                        SubMenu::Bluetooth,
+                        sub_menu,
+                        Message::ToggleSubMenu,
+                    )),
                 ),
                 sub_menu
                     .filter(|menu_type| *menu_type == SubMenu::Bluetooth)
@@ -442,5 +445,19 @@ impl BluetoothSettings {
 
     pub fn subscription(&self) -> Subscription<Message> {
         BluetoothService::subscribe().map(Message::Event)
+    }
+
+    pub fn connected_devices_for_tooltip(&self) -> Vec<(String, Option<u8>)> {
+        self.service
+            .as_ref()
+            .map(|service| {
+                service
+                    .devices
+                    .iter()
+                    .filter(|d| d.connected)
+                    .map(|d| (d.name.clone(), d.battery))
+                    .collect()
+            })
+            .unwrap_or_default()
     }
 }

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -104,6 +104,7 @@ pub enum Message {
     AudioTooltipHover(ButtonUIRef, SurfaceId),
     BluetoothTooltipHover(ButtonUIRef, SurfaceId),
     WifiTooltipHover(ButtonUIRef, SurfaceId),
+    VpnTooltipHover(ButtonUIRef, SurfaceId),
     BatteryTooltipHover(ButtonUIRef, SurfaceId),
     PeripheralBatteryTooltipHover(ButtonUIRef, SurfaceId, usize),
     TooltipUnhover(SurfaceId, MenuType),
@@ -558,39 +559,22 @@ impl Settings {
                 Action::None
             }
             Message::AudioTooltipHover(ui_ref, id) => {
-                if self.enable_tooltips {
-                    Action::OpenTooltipMenu(id, MenuType::AudioTooltip, ui_ref)
-                } else {
-                    Action::None
-                }
+                Action::OpenTooltipMenu(id, MenuType::AudioTooltip, ui_ref)
             }
             Message::BluetoothTooltipHover(ui_ref, id) => {
-                if self.enable_tooltips {
-                    Action::OpenTooltipMenu(id, MenuType::BluetoothTooltip, ui_ref)
-                } else {
-                    Action::None
-                }
+                Action::OpenTooltipMenu(id, MenuType::BluetoothTooltip, ui_ref)
             }
             Message::WifiTooltipHover(ui_ref, id) => {
-                if self.enable_tooltips {
-                    Action::OpenTooltipMenu(id, MenuType::WifiTooltip, ui_ref)
-                } else {
-                    Action::None
-                }
+                Action::OpenTooltipMenu(id, MenuType::WifiTooltip, ui_ref)
+            }
+            Message::VpnTooltipHover(ui_ref, id) => {
+                Action::OpenTooltipMenu(id, MenuType::VpnTooltip, ui_ref)
             }
             Message::BatteryTooltipHover(ui_ref, id) => {
-                if self.enable_tooltips {
-                    Action::OpenTooltipMenu(id, MenuType::BatteryTooltip, ui_ref)
-                } else {
-                    Action::None
-                }
+                Action::OpenTooltipMenu(id, MenuType::BatteryTooltip, ui_ref)
             }
             Message::PeripheralBatteryTooltipHover(ui_ref, id, index) => {
-                if self.enable_tooltips {
-                    Action::OpenTooltipMenu(id, MenuType::PeripheralBatteryTooltip(index), ui_ref)
-                } else {
-                    Action::None
-                }
+                Action::OpenTooltipMenu(id, MenuType::PeripheralBatteryTooltip(index), ui_ref)
             }
             Message::TooltipUnhover(id, menu_type) => Action::CloseTooltipMenu(id, menu_type),
         }
@@ -819,20 +803,24 @@ impl Settings {
                     let peripherals = self.power.peripheral_indicators();
                     for (index, element) in peripherals.into_iter().enumerate() {
                         let element = element.map(Message::Power);
-                        row = row.push(
-                            position_button(element)
-                                .width(Length::Shrink)
-                                .height(Length::Shrink)
-                                .padding(0)
-                                .style(transparent_button_style)
-                                .on_hover_with_position(move |ui_ref| {
-                                    Message::PeripheralBatteryTooltipHover(ui_ref, id, index)
-                                })
-                                .on_unhover(Message::TooltipUnhover(
-                                    id,
-                                    MenuType::PeripheralBatteryTooltip(index),
-                                )),
-                        );
+                        if self.enable_tooltips {
+                            row = row.push(
+                                position_button(element)
+                                    .width(Length::Shrink)
+                                    .height(Length::Shrink)
+                                    .padding(0)
+                                    .style(transparent_button_style)
+                                    .on_hover_with_position(move |ui_ref| {
+                                        Message::PeripheralBatteryTooltipHover(ui_ref, id, index)
+                                    })
+                                    .on_unhover(Message::TooltipUnhover(
+                                        id,
+                                        MenuType::PeripheralBatteryTooltip(index),
+                                    )),
+                            );
+                        } else {
+                            row = row.push(element);
+                        }
                     }
                     None
                 }
@@ -843,20 +831,27 @@ impl Settings {
             };
 
             if let Some(element) = element {
-                let tooltip_config: Option<TooltipConfig> = match indicator {
-                    SettingsIndicator::Audio | SettingsIndicator::Microphone => {
-                        Some((Message::AudioTooltipHover, MenuType::AudioTooltip))
+                let tooltip_config: Option<TooltipConfig> = if self.enable_tooltips {
+                    match indicator {
+                        SettingsIndicator::Audio | SettingsIndicator::Microphone => {
+                            Some((Message::AudioTooltipHover, MenuType::AudioTooltip))
+                        }
+                        SettingsIndicator::Network => {
+                            Some((Message::WifiTooltipHover, MenuType::WifiTooltip))
+                        }
+                        SettingsIndicator::Vpn => {
+                            Some((Message::VpnTooltipHover, MenuType::VpnTooltip))
+                        }
+                        SettingsIndicator::Bluetooth => {
+                            Some((Message::BluetoothTooltipHover, MenuType::BluetoothTooltip))
+                        }
+                        SettingsIndicator::Battery => {
+                            Some((Message::BatteryTooltipHover, MenuType::BatteryTooltip))
+                        }
+                        _ => None,
                     }
-                    SettingsIndicator::Network | SettingsIndicator::Vpn => {
-                        Some((Message::WifiTooltipHover, MenuType::WifiTooltip))
-                    }
-                    SettingsIndicator::Bluetooth => {
-                        Some((Message::BluetoothTooltipHover, MenuType::BluetoothTooltip))
-                    }
-                    SettingsIndicator::Battery => {
-                        Some((Message::BatteryTooltipHover, MenuType::BatteryTooltip))
-                    }
-                    _ => None,
+                } else {
+                    None
                 };
 
                 if let Some((hover_msg, menu_type)) = tooltip_config {
@@ -910,17 +905,20 @@ impl Settings {
                 column.into()
             }
             MenuType::BluetoothTooltip => {
-                let peripherals = self.power.get_peripherals_for_tooltip();
-                if !peripherals.is_empty() {
-                    Column::with_capacity(peripherals.len())
-                        .extend(peripherals.into_iter().map(|p| {
-                            row![
-                                p.get_icon_state().to_text(),
-                                iced::widget::text(&p.name),
-                                iced::widget::text(format!("{}%", p.data.capacity as u32))
-                            ]
-                            .spacing(space.xs)
-                            .into()
+                let devices = self.bluetooth.connected_devices_for_tooltip();
+                if !devices.is_empty() {
+                    Column::with_capacity(devices.len())
+                        .extend(devices.into_iter().map(|(name, battery)| {
+                            if let Some(bat) = battery {
+                                row![
+                                    iced::widget::text(name),
+                                    iced::widget::text(format!("{}%", bat))
+                                ]
+                                .spacing(space.xs)
+                                .into()
+                            } else {
+                                row![iced::widget::text(name)].spacing(space.xs).into()
+                            }
                         }))
                         .spacing(space.xs)
                         .into()
@@ -931,6 +929,15 @@ impl Settings {
             MenuType::WifiTooltip => {
                 if let Some(label) = self.network.connected_wifi_label() {
                     row![StaticIcon::Wifi4.to_text(), iced::widget::text(label)]
+                        .spacing(space.xs)
+                        .into()
+                } else {
+                    Row::new().into()
+                }
+            }
+            MenuType::VpnTooltip => {
+                if let Some(label) = self.network.vpn_tooltip_label() {
+                    row![StaticIcon::Vpn.to_text(), iced::widget::text(label)]
                         .spacing(space.xs)
                         .into()
                 } else {

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -52,6 +52,7 @@ pub struct Settings {
     indicators: Vec<SettingsIndicator>,
     custom_buttons: Vec<SettingsCustomButton>,
     custom_buttons_status: HashMap<String, Option<bool>>,
+    enable_tooltips: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -236,6 +237,7 @@ impl Settings {
             custom_buttons: config.custom_buttons,
             custom_buttons_status: HashMap::new(),
             network_dialog_show_password: false,
+            enable_tooltips: config.enable_tooltips,
         }
     }
 
@@ -507,6 +509,7 @@ impl Settings {
                 Action::Command(custom_buttons_task)
             }
             Message::ConfigReloaded(config) => {
+                self.enable_tooltips = config.enable_tooltips;
                 self.lock_cmd = config.lock_cmd;
                 self.power
                     .update(power::Message::ConfigReloaded(PowerSettingsConfig::new(
@@ -555,19 +558,39 @@ impl Settings {
                 Action::None
             }
             Message::AudioTooltipHover(ui_ref, id) => {
-                Action::OpenTooltipMenu(id, MenuType::AudioTooltip, ui_ref)
+                if self.enable_tooltips {
+                    Action::OpenTooltipMenu(id, MenuType::AudioTooltip, ui_ref)
+                } else {
+                    Action::None
+                }
             }
             Message::BluetoothTooltipHover(ui_ref, id) => {
-                Action::OpenTooltipMenu(id, MenuType::BluetoothTooltip, ui_ref)
+                if self.enable_tooltips {
+                    Action::OpenTooltipMenu(id, MenuType::BluetoothTooltip, ui_ref)
+                } else {
+                    Action::None
+                }
             }
             Message::WifiTooltipHover(ui_ref, id) => {
-                Action::OpenTooltipMenu(id, MenuType::WifiTooltip, ui_ref)
+                if self.enable_tooltips {
+                    Action::OpenTooltipMenu(id, MenuType::WifiTooltip, ui_ref)
+                } else {
+                    Action::None
+                }
             }
             Message::BatteryTooltipHover(ui_ref, id) => {
-                Action::OpenTooltipMenu(id, MenuType::BatteryTooltip, ui_ref)
+                if self.enable_tooltips {
+                    Action::OpenTooltipMenu(id, MenuType::BatteryTooltip, ui_ref)
+                } else {
+                    Action::None
+                }
             }
             Message::PeripheralBatteryTooltipHover(ui_ref, id, index) => {
-                Action::OpenTooltipMenu(id, MenuType::PeripheralBatteryTooltip(index), ui_ref)
+                if self.enable_tooltips {
+                    Action::OpenTooltipMenu(id, MenuType::PeripheralBatteryTooltip(index), ui_ref)
+                } else {
+                    Action::None
+                }
             }
             Message::TooltipUnhover(id, menu_type) => Action::CloseTooltipMenu(id, menu_type),
         }

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -8,9 +8,10 @@ use tokio::time::timeout;
 
 use crate::{
     components::{
-        MenuSize,
-        icons::{DynamicIcon, StaticIcon, icon, icon_button},
-        password_dialog, quick_setting_button, sub_menu_wrapper,
+        ButtonUIRef, MenuSize,
+        icons::{DynamicIcon, Icon, StaticIcon, icon, icon_button},
+        menu::MenuType,
+        password_dialog, position_button, quick_setting_button, sub_menu_wrapper,
     },
     config::{Position, SettingsCustomButton, SettingsIndicator, SettingsModuleConfig},
     modules::settings::{
@@ -25,7 +26,7 @@ use crate::{
     theme::use_theme,
 };
 use iced::{
-    Element, Length, Subscription, SurfaceId, Task, Theme,
+    Border, Color, Element, Length, Shadow, Subscription, SurfaceId, Task, Theme, Vector,
     widget::{Column, Row, Space, container, row, space},
 };
 
@@ -34,6 +35,8 @@ mod bluetooth;
 pub(crate) mod brightness;
 pub(crate) mod network;
 mod power;
+
+type TooltipConfig = (fn(ButtonUIRef, SurfaceId) -> Message, MenuType);
 
 pub struct Settings {
     lock_cmd: Option<String>,
@@ -97,6 +100,12 @@ pub enum Message {
     CustomButtonsStatus(Vec<(String, Option<bool>)>),
     MenuOpened,
     ConfigReloaded(SettingsModuleConfig),
+    AudioTooltipHover(ButtonUIRef, SurfaceId),
+    BluetoothTooltipHover(ButtonUIRef, SurfaceId),
+    WifiTooltipHover(ButtonUIRef, SurfaceId),
+    BatteryTooltipHover(ButtonUIRef, SurfaceId),
+    PeripheralBatteryTooltipHover(ButtonUIRef, SurfaceId, usize),
+    TooltipUnhover(SurfaceId, MenuType),
 }
 
 pub enum Action {
@@ -106,6 +115,8 @@ pub enum Action {
     RequestKeyboard(SurfaceId),
     ReleaseKeyboard(SurfaceId),
     ReleaseKeyboardWithCommand(SurfaceId, Task<Message>),
+    OpenTooltipMenu(SurfaceId, MenuType, ButtonUIRef),
+    CloseTooltipMenu(SurfaceId, MenuType),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -543,6 +554,22 @@ impl Settings {
                 self.custom_buttons = config.custom_buttons;
                 Action::None
             }
+            Message::AudioTooltipHover(ui_ref, id) => {
+                Action::OpenTooltipMenu(id, MenuType::AudioTooltip, ui_ref)
+            }
+            Message::BluetoothTooltipHover(ui_ref, id) => {
+                Action::OpenTooltipMenu(id, MenuType::BluetoothTooltip, ui_ref)
+            }
+            Message::WifiTooltipHover(ui_ref, id) => {
+                Action::OpenTooltipMenu(id, MenuType::WifiTooltip, ui_ref)
+            }
+            Message::BatteryTooltipHover(ui_ref, id) => {
+                Action::OpenTooltipMenu(id, MenuType::BatteryTooltip, ui_ref)
+            }
+            Message::PeripheralBatteryTooltipHover(ui_ref, id, index) => {
+                Action::OpenTooltipMenu(id, MenuType::PeripheralBatteryTooltip(index), ui_ref)
+            }
+            Message::TooltipUnhover(id, menu_type) => Action::CloseTooltipMenu(id, menu_type),
         }
     }
 
@@ -721,104 +748,106 @@ impl Settings {
         .into()
     }
 
-    pub fn view<'a>(&'a self) -> Element<'a, Message> {
+    pub fn view<'a>(&'a self, id: SurfaceId) -> Element<'a, Message> {
         let space = use_theme(|t| t.space);
         let mut row = Row::with_capacity(self.indicators.len());
 
         for indicator in &self.indicators {
-            match indicator {
-                SettingsIndicator::IdleInhibitor => {
-                    if let Some(element) =
-                        self.idle_inhibitor
-                            .as_ref()
-                            .filter(|i| i.is_inhibited())
-                            .map(|_| {
-                                container(icon(IdleInhibitorManager::idle_inhibitor_icon(true)))
-                                    .style(|theme: &Theme| container::Style {
-                                        text_color: Some(theme.palette().danger),
-                                        ..Default::default()
-                                    })
+            let element: Option<Element<'a, Message>> = match indicator {
+                SettingsIndicator::IdleInhibitor => self
+                    .idle_inhibitor
+                    .as_ref()
+                    .filter(|i| i.is_inhibited())
+                    .map(|_| {
+                        container(icon(IdleInhibitorManager::idle_inhibitor_icon(true)))
+                            .style(|theme: &Theme| container::Style {
+                                text_color: Some(theme.palette().danger),
+                                ..Default::default()
                             })
-                    {
-                        row = row.push(element);
-                    }
-                }
-                SettingsIndicator::PowerProfile => {
-                    if let Some(element) = self
-                        .power
-                        .power_profile_indicator()
-                        .map(|e| e.map(Message::Power))
-                    {
-                        row = row.push(element);
-                    }
-                }
+                            .into()
+                    }),
+                SettingsIndicator::PowerProfile => self
+                    .power
+                    .power_profile_indicator()
+                    .map(|e| e.map(Message::Power)),
                 SettingsIndicator::Audio => {
-                    if let Some(element) =
-                        self.audio.sink_indicator().map(|e| e.map(Message::Audio))
-                    {
-                        row = row.push(element);
-                    }
+                    self.audio.sink_indicator().map(|e| e.map(Message::Audio))
                 }
-                SettingsIndicator::Network => {
-                    if let Some(element) = self
-                        .network
-                        .connection_indicator()
-                        .map(|e| e.map(Message::Network))
-                    {
-                        row = row.push(element);
-                    }
-                }
-                SettingsIndicator::Vpn => {
-                    if let Some(element) = self
-                        .network
-                        .vpn_indicator()
-                        .map(|e| e.map(Message::Network))
-                    {
-                        row = row.push(element);
-                    }
-                }
-                SettingsIndicator::Bluetooth => {
-                    if let Some(element) = self
-                        .bluetooth
-                        .bluetooth_indicator()
-                        .map(|e| e.map(Message::Bluetooth))
-                    {
-                        row = row.push(element);
-                    }
-                }
+                SettingsIndicator::Network => self
+                    .network
+                    .connection_indicator()
+                    .map(|e| e.map(Message::Network)),
+                SettingsIndicator::Vpn => self
+                    .network
+                    .vpn_indicator()
+                    .map(|e| e.map(Message::Network)),
+                SettingsIndicator::Bluetooth => self
+                    .bluetooth
+                    .bluetooth_indicator()
+                    .map(|e| e.map(Message::Bluetooth)),
                 SettingsIndicator::Microphone => {
-                    if let Some(element) =
-                        self.audio.source_indicator().map(|e| e.map(Message::Audio))
-                    {
-                        row = row.push(element);
-                    }
+                    self.audio.source_indicator().map(|e| e.map(Message::Audio))
                 }
-                SettingsIndicator::Battery => {
-                    if let Some(element) = self
-                        .power
-                        .battery_indicator()
-                        .map(|e| e.map(Message::Power))
-                    {
-                        row = row.push(element);
-                    }
-                }
+                SettingsIndicator::Battery => self
+                    .power
+                    .battery_indicator()
+                    .map(|e| e.map(Message::Power)),
                 SettingsIndicator::PeripheralBattery => {
-                    if let Some(element) = self
-                        .power
-                        .peripheral_indicators()
-                        .map(|e| e.map(Message::Power))
-                    {
-                        row = row.push(element);
+                    let peripherals = self.power.peripheral_indicators();
+                    for (index, element) in peripherals.into_iter().enumerate() {
+                        let element = element.map(Message::Power);
+                        row = row.push(
+                            position_button(element)
+                                .width(Length::Shrink)
+                                .height(Length::Shrink)
+                                .padding(0)
+                                .style(transparent_button_style)
+                                .on_hover_with_position(move |ui_ref| {
+                                    Message::PeripheralBatteryTooltipHover(ui_ref, id, index)
+                                })
+                                .on_unhover(Message::TooltipUnhover(
+                                    id,
+                                    MenuType::PeripheralBatteryTooltip(index),
+                                )),
+                        );
                     }
+                    None
                 }
-                SettingsIndicator::Brightness => {
-                    if let Some(element) = self
-                        .brightness
-                        .brightness_indicator()
-                        .map(|e| e.map(Message::Brightness))
-                    {
-                        row = row.push(element);
+                SettingsIndicator::Brightness => self
+                    .brightness
+                    .brightness_indicator()
+                    .map(|e| e.map(Message::Brightness)),
+            };
+
+            if let Some(element) = element {
+                let tooltip_config: Option<TooltipConfig> = match indicator {
+                    SettingsIndicator::Audio | SettingsIndicator::Microphone => {
+                        Some((Message::AudioTooltipHover, MenuType::AudioTooltip))
                     }
+                    SettingsIndicator::Network | SettingsIndicator::Vpn => {
+                        Some((Message::WifiTooltipHover, MenuType::WifiTooltip))
+                    }
+                    SettingsIndicator::Bluetooth => {
+                        Some((Message::BluetoothTooltipHover, MenuType::BluetoothTooltip))
+                    }
+                    SettingsIndicator::Battery => {
+                        Some((Message::BatteryTooltipHover, MenuType::BatteryTooltip))
+                    }
+                    _ => None,
+                };
+
+                if let Some((hover_msg, menu_type)) = tooltip_config {
+                    row = row.push(
+                        position_button(element)
+                            .width(Length::Shrink)
+                            .height(Length::Shrink)
+                            .padding(0)
+                            .style(transparent_button_style)
+                            .on_hover_with_position(move |ui_ref| hover_msg(ui_ref, id))
+                            .on_unhover(Message::TooltipUnhover(id, menu_type)),
+                    );
+                } else {
+                    row = row.push(element);
                 }
             }
         }
@@ -834,6 +863,110 @@ impl Settings {
             self.network.subscription().map(Message::Network),
             self.bluetooth.subscription().map(Message::Bluetooth),
         ])
+    }
+
+    pub fn tooltip_view<'a>(&'a self, menu_type: &MenuType) -> Element<'a, Message> {
+        let space = use_theme(|t| t.space);
+        match menu_type {
+            MenuType::AudioTooltip => {
+                let sink = self.audio.active_sink_label();
+                let source = self.audio.active_source_label();
+                let mut column = Column::new().spacing(space.xs);
+                if let Some(sink) = sink {
+                    column = column.push(
+                        row![StaticIcon::Speaker3.to_text(), iced::widget::text(sink)]
+                            .spacing(space.xs),
+                    );
+                }
+                if let Some(source) = source {
+                    column = column.push(
+                        row![StaticIcon::Mic1.to_text(), iced::widget::text(source)]
+                            .spacing(space.xs),
+                    );
+                }
+                column.into()
+            }
+            MenuType::BluetoothTooltip => {
+                let peripherals = self.power.get_peripherals_for_tooltip();
+                if !peripherals.is_empty() {
+                    Column::with_capacity(peripherals.len())
+                        .extend(peripherals.into_iter().map(|p| {
+                            row![
+                                p.get_icon_state().to_text(),
+                                iced::widget::text(&p.name),
+                                iced::widget::text(format!("{}%", p.data.capacity as u32))
+                            ]
+                            .spacing(space.xs)
+                            .into()
+                        }))
+                        .spacing(space.xs)
+                        .into()
+                } else {
+                    Row::new().into()
+                }
+            }
+            MenuType::WifiTooltip => {
+                if let Some(label) = self.network.connected_wifi_label() {
+                    row![StaticIcon::Wifi4.to_text(), iced::widget::text(label)]
+                        .spacing(space.xs)
+                        .into()
+                } else {
+                    Row::new().into()
+                }
+            }
+            MenuType::BatteryTooltip => {
+                if let Some((capacity, status_label, details)) = self.power.battery_tooltip_info() {
+                    let mut r = Row::new()
+                        .push(StaticIcon::Battery4.to_text())
+                        .push(iced::widget::text(format!("{capacity}%")))
+                        .push(iced::widget::text(status_label))
+                        .spacing(space.xs);
+                    if !details.is_empty() {
+                        r = r.push(iced::widget::text(details));
+                    }
+                    r.into()
+                } else {
+                    Row::new().into()
+                }
+            }
+            MenuType::PeripheralBatteryTooltip(index) => {
+                if let Some((name, capacity, device_icon)) =
+                    self.power.peripheral_battery_tooltip_info(*index)
+                {
+                    row![
+                        device_icon.to_text(),
+                        iced::widget::text(name),
+                        iced::widget::text(format!("{capacity}%"))
+                    ]
+                    .spacing(space.xs)
+                    .into()
+                } else {
+                    Row::new().into()
+                }
+            }
+            _ => Row::new().into(),
+        }
+    }
+}
+
+fn transparent_button_style(
+    theme: &Theme,
+    _status: iced::widget::button::Status,
+) -> iced::widget::button::Style {
+    iced::widget::button::Style {
+        background: None,
+        border: Border {
+            color: Color::TRANSPARENT,
+            width: 0.,
+            radius: 0.into(),
+        },
+        shadow: Shadow {
+            color: Color::TRANSPARENT,
+            offset: Vector::default(),
+            blur_radius: 0.,
+        },
+        text_color: theme.palette().text,
+        snap: true,
     }
 }
 

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -387,8 +387,11 @@ impl NetworkSettings {
                         service.wifi_enabled,
                         Message::ToggleWiFi,
                         Some(Message::OpenMore),
-                        Some((SubMenu::Wifi, sub_menu, Message::ToggleWifiMenu))
-                            .filter(|_| service.wifi_enabled),
+                        service.wifi_enabled.then_some((
+                            SubMenu::Wifi,
+                            sub_menu,
+                            Message::ToggleWifiMenu,
+                        )),
                     ),
                     sub_menu
                         .filter(|menu_type| *menu_type == SubMenu::Wifi)
@@ -689,6 +692,27 @@ impl NetworkSettings {
                 ActiveConnectionInfo::WiFi { name, .. } => Some(name.clone()),
                 _ => None,
             })
+        })
+    }
+
+    pub fn vpn_tooltip_label(&self) -> Option<String> {
+        self.service.as_ref().and_then(|service| {
+            let active_vpns: Vec<_> = service
+                .active_connections
+                .iter()
+                .filter_map(|c| match c {
+                    ActiveConnectionInfo::Vpn { name, .. } => Some(name.clone()),
+                    _ => None,
+                })
+                .collect();
+
+            if active_vpns.is_empty() {
+                None
+            } else if active_vpns.len() == 1 {
+                Some(active_vpns[0].clone())
+            } else {
+                Some(format!("{} VPNs connected", active_vpns.len()))
+            }
         })
     }
 }

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -682,4 +682,13 @@ impl NetworkSettings {
             StaticIcon::AirplaneOff
         }
     }
+
+    pub fn connected_wifi_label(&self) -> Option<String> {
+        self.service.as_ref().and_then(|service| {
+            service.active_connections.iter().find_map(|c| match c {
+                ActiveConnectionInfo::WiFi { name, .. } => Some(name.clone()),
+                _ => None,
+            })
+        })
+    }
 }

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -9,10 +9,7 @@ use crate::{
     config::{PeripheralIndicators, SettingsFormat},
     services::{
         ReadOnlyService, Service, ServiceEvent,
-        upower::{
-            BatteryData, BatteryStatus, Peripheral, PowerProfile, PowerProfileCommand,
-            UPowerService,
-        },
+        upower::{BatteryData, BatteryStatus, PowerProfile, PowerProfileCommand, UPowerService},
     },
     t,
     theme::use_theme,
@@ -487,24 +484,6 @@ impl PowerSettings {
                 (capacity, status_label, details)
             })
         })
-    }
-
-    pub fn get_peripherals_for_tooltip(&self) -> Vec<&Peripheral> {
-        let kinds_filter = match &self.config.peripheral_indicators {
-            PeripheralIndicators::All => None,
-            PeripheralIndicators::Specific(kinds) => Some(kinds.as_slice()),
-        };
-
-        self.service
-            .as_ref()
-            .map(|service| {
-                service
-                    .peripherals
-                    .iter()
-                    .filter(|p| kinds_filter.is_none_or(|kinds| kinds.contains(&p.kind)))
-                    .collect()
-            })
-            .unwrap_or_default()
     }
 
     pub fn peripheral_battery_tooltip_info(

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -10,7 +10,7 @@ use crate::{
     services::{
         ReadOnlyService, Service, ServiceEvent,
         upower::{
-            BatteryData, BatteryStatus, PeripheralDeviceKind, PowerProfile, PowerProfileCommand,
+            BatteryData, BatteryStatus, Peripheral, PowerProfile, PowerProfileCommand,
             UPowerService,
         },
     },
@@ -234,85 +234,65 @@ impl PowerSettings {
             })
     }
 
-    pub fn peripheral_indicators<'a>(&self) -> Option<Element<'a, Message>> {
+    pub fn peripheral_indicators<'a>(&self) -> Vec<Element<'a, Message>> {
         let space = use_theme(|t| t.space);
-        let get_indicators = |kinds: Option<&[PeripheralDeviceKind]>| {
-            self.service
-                .as_ref()
-                .filter(|p| {
-                    !p.peripherals.is_empty()
-                        && kinds.is_none_or(|kinds| {
-                            p.peripherals.iter().any(|p| kinds.contains(&p.kind))
-                        })
-                })
-                .map(|service| {
-                    let mut row = Row::with_capacity(service.peripherals.len())
-                        .spacing(space.xxs)
-                        .align_y(Alignment::Center);
-
-                    for p in service.peripherals.iter() {
-                        row = row.push({
-                            if kinds.as_ref().is_none_or(|kinds| kinds.contains(&p.kind)) {
-                                let state = p.data.get_indicator_state();
-
-                                Some(
-                                    container(match self.config.peripheral_battery_format {
-                                        SettingsFormat::Icon => {
-                                            convert::Into::<Element<'a, Message>>::into(icon(
-                                                p.get_icon_state(),
-                                            ))
-                                        }
-                                        SettingsFormat::Percentage => row!(
-                                            icon(p.kind.get_icon()),
-                                            text(format!("{}%", p.data.capacity))
-                                        )
-                                        .spacing(space.xxs)
-                                        .align_y(Alignment::Center)
-                                        .into(),
-                                        SettingsFormat::IconAndPercentage => row!(
-                                            icon(p.get_icon_state()),
-                                            text(format!("{}%", p.data.capacity))
-                                        )
-                                        .spacing(space.xxs)
-                                        .align_y(Alignment::Center)
-                                        .into(),
-                                        SettingsFormat::Time => {
-                                            text(format_time_for_battery(&p.data)).into()
-                                        }
-                                        SettingsFormat::IconAndTime => row!(
-                                            icon(p.get_icon_state()),
-                                            text(format_time_for_battery(&p.data))
-                                        )
-                                        .spacing(space.xxs)
-                                        .align_y(Alignment::Center)
-                                        .into(),
-                                    })
-                                    .style(
-                                        move |theme: &Theme| container::Style {
-                                            text_color: Some(match state {
-                                                IndicatorState::Success => theme.palette().success,
-                                                IndicatorState::Danger => theme.palette().danger,
-                                                _ => theme.palette().text,
-                                            }),
-                                            ..Default::default()
-                                        },
-                                    ),
-                                )
-                            } else {
-                                None
-                            }
-                        });
-                    }
-
-                    row
-                })
+        let kinds_filter = match &self.config.peripheral_indicators {
+            PeripheralIndicators::All => None,
+            PeripheralIndicators::Specific(kinds) => Some(kinds.as_slice()),
         };
 
-        match &self.config.peripheral_indicators {
-            PeripheralIndicators::All => get_indicators(None),
-            PeripheralIndicators::Specific(kinds) => get_indicators(Some(kinds)),
-        }
-        .map(|r| r.into())
+        let Some(service) = self.service.as_ref().filter(|p| {
+            !p.peripherals.is_empty()
+                && kinds_filter
+                    .is_none_or(|kinds| p.peripherals.iter().any(|p| kinds.contains(&p.kind)))
+        }) else {
+            return Vec::new();
+        };
+
+        service
+            .peripherals
+            .iter()
+            .filter(|p| kinds_filter.is_none_or(|kinds| kinds.contains(&p.kind)))
+            .map(|p| {
+                let state = p.data.get_indicator_state();
+                container(match self.config.peripheral_battery_format {
+                    SettingsFormat::Icon => {
+                        convert::Into::<Element<'a, Message>>::into(icon(p.get_icon_state()))
+                    }
+                    SettingsFormat::Percentage => row!(
+                        icon(p.kind.get_icon()),
+                        text(format!("{}%", p.data.capacity))
+                    )
+                    .spacing(space.xxs)
+                    .align_y(Alignment::Center)
+                    .into(),
+                    SettingsFormat::IconAndPercentage => row!(
+                        icon(p.get_icon_state()),
+                        text(format!("{}%", p.data.capacity))
+                    )
+                    .spacing(space.xxs)
+                    .align_y(Alignment::Center)
+                    .into(),
+                    SettingsFormat::Time => text(format_time_for_battery(&p.data)).into(),
+                    SettingsFormat::IconAndTime => row!(
+                        icon(p.get_icon_state()),
+                        text(format_time_for_battery(&p.data))
+                    )
+                    .spacing(space.xxs)
+                    .align_y(Alignment::Center)
+                    .into(),
+                })
+                .style(move |theme: &Theme| container::Style {
+                    text_color: Some(match state {
+                        IndicatorState::Success => theme.palette().success,
+                        IndicatorState::Danger => theme.palette().danger,
+                        _ => theme.palette().text,
+                    }),
+                    ..Default::default()
+                })
+                .into()
+            })
+            .collect()
     }
 
     pub fn battery_indicator<'a>(&self) -> Option<Element<'a, Message>> {
@@ -488,5 +468,54 @@ impl PowerSettings {
 
     pub fn subscription(&self) -> Subscription<Message> {
         UPowerService::subscribe().map(Message::Event)
+    }
+
+    pub fn battery_tooltip_info(&self) -> Option<(u32, String, String)> {
+        self.service.as_ref().and_then(|service| {
+            service.system_battery.map(|battery| {
+                let capacity = battery.capacity as u32;
+                let status_label = match battery.status {
+                    BatteryStatus::Charging(_) => t!("settings-power-status-charging"),
+                    BatteryStatus::Discharging(_) => t!("settings-power-status-discharging"),
+                    BatteryStatus::Full => t!("settings-power-status-full"),
+                };
+                let details = if battery.capacity < 95 {
+                    format_time_for_battery(&battery)
+                } else {
+                    String::new()
+                };
+                (capacity, status_label, details)
+            })
+        })
+    }
+
+    pub fn get_peripherals_for_tooltip(&self) -> Vec<&Peripheral> {
+        let kinds_filter = match &self.config.peripheral_indicators {
+            PeripheralIndicators::All => None,
+            PeripheralIndicators::Specific(kinds) => Some(kinds.as_slice()),
+        };
+
+        self.service
+            .as_ref()
+            .map(|service| {
+                service
+                    .peripherals
+                    .iter()
+                    .filter(|p| kinds_filter.is_none_or(|kinds| kinds.contains(&p.kind)))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn peripheral_battery_tooltip_info(
+        &self,
+        index: usize,
+    ) -> Option<(String, u32, StaticIcon)> {
+        self.service.as_ref().and_then(|service| {
+            service.peripherals.get(index).map(|p| {
+                let capacity = p.data.capacity as u32;
+                (p.name.clone(), capacity, p.get_icon_state())
+            })
+        })
     }
 }

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -382,7 +382,7 @@ impl NetworkDbus<'_> {
                         let path = path.clone();
                         async move {
                             let value = val.get().await.unwrap_or_default();
-                            debug!("Strength changed value: {}, {}", &ssid, value);
+                            debug!("Strength changed value: {}, {}", ssid, value);
                             NetworkEvent::Strength((Some(path.clone()), ssid.clone(), value))
                         }
                     })

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -521,7 +521,7 @@ impl TrayService {
                             let name = name.clone();
                             let menu_proxy = item.menu_proxy.clone();
                             move |_| {
-                                debug!("layout update event name {}", &name);
+                                debug!("layout update event name {}", name);
 
                                 let name = name.clone();
                                 let menu_proxy = menu_proxy.clone();

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -68,6 +68,8 @@ max_notifications = 10
 show_bodies = true
 
 [settings]
+# Optional: disable hover tooltips on status indicators
+# enable_tooltips = false
 lock_cmd = "playerctl --all-players pause; nixGL hyprlock &"
 audio_sinks_more_cmd = "pavucontrol -t 3"
 audio_sources_more_cmd = "pavucontrol -t 4"


### PR DESCRIPTION
Added hover-based tooltips for the status indicators in the bar. the issue with the built-in tool tips is that they can't be outside of the bar. When you hover over icons like audio, bluetooth, wifi, battery, or peripheral battery, a small popup now appears showing more detailed information.

related to #128 
closes #557 


https://github.com/user-attachments/assets/db5403b6-4d41-41b7-95ee-df2facb19021


this is just some basic stuff that @clotodex was requesting for a long time. 
