### PR TITLE
Add configurable mouse event handlers to CustomModule

### DIFF
--- a/docs/src/modules/module-registry.md
+++ b/docs/src/modules/module-registry.md
@@ -31,30 +31,41 @@ The return type is `Option<(Element, Option<OnModulePress>)>`:
 
 ## OnModulePress
 
-Defines what happens when a user clicks a module:
+Defines what happens when a user clicks or interacts with a module:
 
 ```rust
 pub enum OnModulePress {
-    // Emit a specific message on click
+    // Emit a specific message on left-click
     Action(Box<Message>),
 
-    // Toggle a popup menu
+    // Toggle a popup menu on left-click
     ToggleMenu(MenuType),
 
-    // Toggle menu + right-click and scroll handlers
+    // Toggle menu with right-click and scroll event handlers
     ToggleMenuWithExtra {
         menu_type: MenuType,
         on_right_press: Option<Box<Message>>,
         on_scroll_up: Option<Box<Message>>,
         on_scroll_down: Option<Box<Message>>,
     },
+
+    // Execute arbitrary commands (for custom modules without menus)
+    CustomAction {
+        on_press: Box<Message>,
+        on_right_press: Option<Box<Message>>,
+        on_middle_press: Option<Box<Message>>,
+        on_scroll_up: Option<Box<Message>>,
+        on_scroll_down: Option<Box<Message>>,
+    },
 }
 ```
 
-For example, the Tempo module uses `ToggleMenuWithExtra` to:
-- Left-click: Open the calendar/weather menu
-- Right-click: Cycle the time format
-- Scroll: Cycle through timezones
+### Usage Notes
+
+- **`Action`**: Simple left-click handler, no menu.
+- **`ToggleMenu`**: Left-click opens/closes a popup menu.
+- **`ToggleMenuWithExtra`**: For modules with a menu that also need right-click or scroll handlers (e.g., Tempo: left-click opens calendar, right-click cycles time format, scroll cycles timezones). Middle-click is not supported in this variant.
+- **`CustomAction`**: For custom modules (or any module) that need multiple mouse buttons and scroll events without a menu. Supports left-click, right-click, middle-click, scroll up, and scroll down.
 
 ## get_module_subscription
 

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -193,19 +193,19 @@ format = "{artist} - {title}"
 
 ## Custom Modules
 
+Custom modules allow you to create arbitrary modules with custom commands and icons.
+
 ```toml
 [[CustomModule]]
-name = "mymodule"
-type = "Text"                   # "Text" or "Button"
-cmd = "echo Hello"
-interval = 5
-format = "Result: {}"
-
-[[CustomModule]]
-name = "launcher"
-type = "Button"
-icon = "\u{f0e7}"
-on_click = "rofi -show drun"
+name = "volume"
+type = "Button"                        # "Text" or "Button"
+icon = "\u{f026}"                      # Nerd Font icon
+command = "pactl get-sink-volume @DEFAULT_SINK@"  # Left-click command
+on_right_click = "pactl set-sink-mute @DEFAULT_SINK@ toggle"
+on_middle_click = "pavucontrol"
+on_scroll_up = "pactl set-sink-volume @DEFAULT_SINK@ +5%"
+on_scroll_down = "pactl set-sink-volume @DEFAULT_SINK@ -5%"
+listen_cmd = "pactl subscribe"         # Optional: stream JSON updates
 ```
 
 Custom module fields:
@@ -213,16 +213,25 @@ Custom module fields:
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
 | `name` | String | Yes | Unique identifier |
-| `type` | `"Text"` \| `"Button"` | No | Display mode |
-| `cmd` | String | No | Command to execute for display text |
-| `on_click` | String | No | Command on click (Button type) |
-| `icon` | String | No | Icon character |
-| `interval` | u64 | No | Refresh interval in seconds |
-| `format` | String | No | Output format string |
+| `type` | `"Text"` \| `"Button"` | No | Display mode (default: `"Button"`) |
+| `icon` | String | No | Nerd Font icon character |
+| `command` | String | No | Command to execute on left-click (Button type) |
+| `on_right_click` | String | No | Command on right-click |
+| `on_middle_click` | String | No | Command on middle-click |
+| `on_scroll_up` | String | No | Command on scroll up |
+| `on_scroll_down` | String | No | Command on scroll down |
+| `listen_cmd` | String | No | Command that outputs JSON lines for dynamic updates |
+| `icons` | Map | No | Regex → icon mapping for dynamic icons |
+| `alert` | String (regex) | No | Regex to show alert indicator |
+
+The `listen_cmd` output must be JSON lines with `text` and `alt` fields:
+```json
+{"text": "50%", "alt": "volume"}
+```
 
 Reference a custom module in the layout as `"Custom:name"`:
 
 ```toml
 [modules]
-right = ["Custom:mymodule", "Settings"]
+right = ["Custom:volume", "Settings"]
 ```

--- a/docs/src/widgets/overview.md
+++ b/docs/src/widgets/overview.md
@@ -1,24 +1,24 @@
 # Widgets Overview
 
-ashell includes three custom iced widgets in `src/widgets/` that provide functionality not available in iced's built-in widget set.
+ashell includes custom widgets in `src/components/` that provide functionality not available in iced's built-in widget set.
 
 ## Custom Widgets
 
 | Widget | File | Purpose |
 |--------|------|---------|
-| [Centerbox](centerbox.md) | `widgets/centerbox.rs` | Three-column layout that keeps the center truly centered |
-| [PositionButton](position-button.md) | `widgets/position_button.rs` | Button that reports its screen position on press |
-| [MenuWrapper](menu-wrapper.md) | `widgets/menu_wrapper.rs` | Menu container with backdrop and click-outside-to-close |
+| [Centerbox](centerbox.md) | `components/centerbox.rs` | Three-column layout that keeps the center truly centered |
+| [PositionButton](position-button.md) | `components/position_button.rs` | Button that reports its screen position on press |
+| [MenuWrapper](menu-wrapper.md) | `components/menu_wrapper.rs` | Menu container with backdrop and click-outside-to-close |
 
 ## ButtonUIRef
 
-Defined in `widgets/mod.rs`, this type carries a button's screen position and size:
+Defined in `components/mod.rs`, this type carries a button's screen position and viewport info:
 
 ```rust
 #[derive(Debug, Clone, Default)]
 pub struct ButtonUIRef {
     pub position: Point,
-    pub size: Size,
+    pub viewport: (f32, f32),
 }
 ```
 

--- a/docs/src/widgets/position-button.md
+++ b/docs/src/widgets/position-button.md
@@ -1,6 +1,6 @@
 # PositionButton
 
-`src/widgets/position_button.rs`
+`src/components/position_button.rs`
 
 ## Purpose
 
@@ -25,7 +25,10 @@ impl PositionButton {
     // Right-click handler
     pub fn on_right_press(self, msg: Message) -> Self;
 
-    // Scroll handlers
+    // Middle-click handler
+    pub fn on_middle_press(self, msg: Message) -> Self;
+
+    // Scroll handlers (explicit up/down, not a generic scroll event)
     pub fn on_scroll_up(self, msg: Message) -> Self;
     pub fn on_scroll_down(self, msg: Message) -> Self;
 
@@ -41,12 +44,18 @@ impl PositionButton {
 }
 ```
 
+## Notes
+
+- Scroll events are explicit: separate `on_scroll_up` and `on_scroll_down` handlers. There is no generic "scroll" event.
+- For custom modules, these handlers map directly to `on_scroll_up` / `on_scroll_down` config fields.
+- Middle-click (`on_middle_press`) is primarily used by `CustomAction` (custom modules without menus). `ToggleMenuWithExtra` does not include middle-click support.
+
 ## ButtonUIRef
 
 ```rust
 pub struct ButtonUIRef {
-    pub position: Point,    // Screen coordinates of the button's top-left corner
-    pub size: Size,         // Width and height of the button
+    pub position: Point,    // Screen coordinates of the button's center
+    pub viewport: (f32, f32), // Width and height of the screen
 }
 ```
 

--- a/src/components/module_item.rs
+++ b/src/components/module_item.rs
@@ -4,7 +4,7 @@ use iced::{Alignment, Element, Length, widget::container};
 use super::ButtonUIRef;
 
 /// Builder for a bar module item: content wrapped in a position_button
-/// with optional press, right-press, scroll-up, and scroll-down handlers.
+/// with optional press, right-press, middle-press, scroll-up, and scroll-down handlers.
 ///
 /// When no press handler is set, renders as a plain container.
 pub struct ModuleItem<'a, Msg> {
@@ -12,6 +12,7 @@ pub struct ModuleItem<'a, Msg> {
     on_press: Option<Msg>,
     on_press_with_position: Option<Box<dyn Fn(ButtonUIRef) -> Msg + 'a>>,
     on_right_press: Option<Msg>,
+    on_middle_press: Option<Msg>,
     on_scroll_up: Option<Msg>,
     on_scroll_down: Option<Msg>,
 }
@@ -22,6 +23,7 @@ pub fn module_item<'a, Msg: 'static + Clone>(content: Element<'a, Msg>) -> Modul
         on_press: None,
         on_press_with_position: None,
         on_right_press: None,
+        on_middle_press: None,
         on_scroll_up: None,
         on_scroll_down: None,
     }
@@ -40,6 +42,11 @@ impl<'a, Msg: 'static + Clone> ModuleItem<'a, Msg> {
 
     pub fn on_right_press(mut self, msg: Msg) -> Self {
         self.on_right_press = Some(msg);
+        self
+    }
+
+    pub fn on_middle_press(mut self, msg: Msg) -> Self {
+        self.on_middle_press = Some(msg);
         self
     }
 
@@ -80,6 +87,9 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
 
             if let Some(msg) = item.on_right_press {
                 button = button.on_right_press(msg);
+            }
+            if let Some(msg) = item.on_middle_press {
+                button = button.on_middle_press(msg);
             }
             if let Some(msg) = item.on_scroll_up {
                 button = button.on_scroll_up(msg);

--- a/src/components/position_button.rs
+++ b/src/components/position_button.rs
@@ -33,6 +33,7 @@ where
     content: Element<'a, Message, Theme, Renderer>,
     on_press: Option<OnPress<'a, Message>>,
     on_right_press: Option<OnPress<'a, Message>>,
+    on_middle_press: Option<OnPress<'a, Message>>,
     on_scroll_up: Option<OnPress<'a, Message>>,
     on_scroll_down: Option<OnPress<'a, Message>>,
     on_hover: Option<OnHover<'a, Message>>,
@@ -57,6 +58,7 @@ where
             content,
             on_press: None,
             on_right_press: None,
+            on_middle_press: None,
             on_scroll_up: None,
             on_scroll_down: None,
             on_hover: None,
@@ -113,6 +115,11 @@ where
         on_right_press: impl Fn(ButtonUIRef) -> Message + 'a,
     ) -> Self {
         self.on_right_press = Some(OnPress::MessageWithPosition(Box::new(on_right_press)));
+        self
+    }
+
+    pub fn on_middle_press(mut self, on_middle_press: Message) -> Self {
+        self.on_middle_press = Some(OnPress::Message(on_middle_press));
         self
     }
 
@@ -219,6 +226,7 @@ struct State {
     is_hovered: bool,
     is_pressed: bool,
     is_right_pressed: bool,
+    is_middle_pressed: bool,
     is_focused: bool,
 }
 
@@ -337,6 +345,18 @@ where
                     return;
                 }
             }
+            event::Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Middle))
+                if self.on_middle_press.is_some() =>
+            {
+                let bounds = layout.bounds();
+
+                if cursor.is_over(bounds) {
+                    let state = tree.state.downcast_mut::<State>();
+                    state.is_middle_pressed = true;
+                    shell.capture_event();
+                    return;
+                }
+            }
             event::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
             | event::Event::Touch(touch::Event::FingerLifted { .. }) => {
                 if let Some(on_press) = self.on_press.as_ref() {
@@ -367,6 +387,24 @@ where
 
                         if cursor.is_over(bounds) {
                             self.publish_on_press(on_right_press, layout, viewport, shell);
+                        }
+
+                        shell.capture_event();
+                        return;
+                    }
+                }
+            }
+            event::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Middle)) => {
+                if let Some(on_middle_press) = self.on_middle_press.as_ref() {
+                    let state = tree.state.downcast_mut::<State>();
+
+                    if state.is_middle_pressed {
+                        state.is_middle_pressed = false;
+
+                        let bounds = layout.bounds();
+
+                        if cursor.is_over(bounds) {
+                            self.publish_on_press(on_middle_press, layout, viewport, shell);
                         }
 
                         shell.capture_event();
@@ -453,6 +491,7 @@ where
                     }
                 }
                 state.is_pressed = false;
+                state.is_middle_pressed = false;
             }
             _ => {}
         }
@@ -538,7 +577,7 @@ where
     ) -> mouse::Interaction {
         let is_mouse_over = cursor.is_over(layout.bounds());
 
-        if is_mouse_over && self.on_press.is_some() {
+        if is_mouse_over && (self.on_press.is_some() || self.on_middle_press.is_some()) {
             mouse::Interaction::Pointer
         } else {
             mouse::Interaction::default()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1170,6 +1170,18 @@ pub struct CustomModuleDef {
     /// Display type: Button (clickable) or Text (display only)
     #[serde(default)]
     pub r#type: CustomModuleType,
+    /// command to run on right-click
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub on_right_click: Option<String>,
+    /// command to run on middle-click
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub on_middle_click: Option<String>,
+    /// command to run on scroll up
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub on_scroll_up: Option<String>,
+    /// command to run on scroll down
+    #[serde(default, deserialize_with = "empty_string_as_none")]
+    pub on_scroll_down: Option<String>,
     // .. appearance etc
 }
 

--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -27,7 +27,7 @@ use tokio::{
 
 #[derive(Debug, Clone)]
 pub struct Custom {
-    config: CustomModuleDef,
+    pub config: CustomModuleDef,
     data: CustomListenData,
 }
 
@@ -40,6 +40,10 @@ pub struct CustomListenData {
 #[derive(Debug, Clone)]
 pub enum Message {
     LaunchCommand,
+    LaunchRightClickCommand,
+    LaunchMiddleClickCommand,
+    LaunchScrollUpCommand,
+    LaunchScrollDownCommand,
     Update(CustomListenData),
 }
 
@@ -86,6 +90,26 @@ impl Custom {
         match msg {
             Message::LaunchCommand => {
                 if let Some(cmd) = &self.config.command {
+                    execute_command(cmd);
+                }
+            }
+            Message::LaunchRightClickCommand => {
+                if let Some(cmd) = &self.config.on_right_click {
+                    execute_command(cmd);
+                }
+            }
+            Message::LaunchMiddleClickCommand => {
+                if let Some(cmd) = &self.config.on_middle_click {
+                    execute_command(cmd);
+                }
+            }
+            Message::LaunchScrollUpCommand => {
+                if let Some(cmd) = &self.config.on_scroll_up {
+                    execute_command(cmd);
+                }
+            }
+            Message::LaunchScrollDownCommand => {
+                if let Some(cmd) = &self.config.on_scroll_down {
                     execute_command(cmd);
                 }
             }

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -32,6 +32,13 @@ pub enum OnModulePress {
         on_scroll_up: Option<Box<Message>>,
         on_scroll_down: Option<Box<Message>>,
     },
+    CustomAction {
+        on_press: Box<Message>,
+        on_right_press: Option<Box<Message>>,
+        on_middle_press: Option<Box<Message>>,
+        on_scroll_up: Option<Box<Message>>,
+        on_scroll_down: Option<Box<Message>>,
+    },
 }
 
 impl App {
@@ -118,6 +125,27 @@ impl App {
                             item = item.on_scroll_down(*msg);
                         }
                     }
+                    OnModulePress::CustomAction {
+                        on_press,
+                        on_right_press,
+                        on_middle_press,
+                        on_scroll_up,
+                        on_scroll_down,
+                    } => {
+                        item = item.on_press(*on_press);
+                        if let Some(msg) = on_right_press {
+                            item = item.on_right_press(*msg);
+                        }
+                        if let Some(msg) = on_middle_press {
+                            item = item.on_middle_press(*msg);
+                        }
+                        if let Some(msg) = on_scroll_up {
+                            item = item.on_scroll_up(*msg);
+                        }
+                        if let Some(msg) = on_scroll_down {
+                            item = item.on_scroll_down(*msg);
+                        }
+                    }
                 }
                 item.into()
             }
@@ -167,10 +195,57 @@ impl App {
                 let action = match custom.module_type() {
                     crate::config::CustomModuleType::Text => None,
                     crate::config::CustomModuleType::Button => {
-                        Some(OnModulePress::Action(Box::new(Message::Custom(
-                            name.clone(),
-                            custom_module::Message::LaunchCommand,
-                        ))))
+                        let name = name.clone();
+                        Some(OnModulePress::CustomAction {
+                            on_press: Box::new(Message::Custom(
+                                name.clone(),
+                                custom_module::Message::LaunchCommand,
+                            )),
+                            on_right_press: custom
+                                .config
+                                .on_right_click
+                                .as_ref()
+                                .map(|_| {
+                                    Message::Custom(
+                                        name.clone(),
+                                        custom_module::Message::LaunchRightClickCommand,
+                                    )
+                                })
+                                .map(Box::new),
+                            on_middle_press: custom
+                                .config
+                                .on_middle_click
+                                .as_ref()
+                                .map(|_| {
+                                    Message::Custom(
+                                        name.clone(),
+                                        custom_module::Message::LaunchMiddleClickCommand,
+                                    )
+                                })
+                                .map(Box::new),
+                            on_scroll_up: custom
+                                .config
+                                .on_scroll_up
+                                .as_ref()
+                                .map(|_| {
+                                    Message::Custom(
+                                        name.clone(),
+                                        custom_module::Message::LaunchScrollUpCommand,
+                                    )
+                                })
+                                .map(Box::new),
+                            on_scroll_down: custom
+                                .config
+                                .on_scroll_down
+                                .as_ref()
+                                .map(|_| {
+                                    Message::Custom(
+                                        name,
+                                        custom_module::Message::LaunchScrollDownCommand,
+                                    )
+                                })
+                                .map(Box::new),
+                        })
                     }
                 };
                 (

--- a/website/docs/configuration/modules/custom_module.md
+++ b/website/docs/configuration/modules/custom_module.md
@@ -33,10 +33,13 @@ To define a custom module, use the following fields:
 - `type` _(optional)_: Display type. Can be `Button` (clickable, default) or `Text` (display only).
 - `icon`: Icon displayed in the status bar (for `button` type).
 - `command`: Command to execute when the module is clicked (for `button` type). Empty or whitespace-only values are treated as unset.
-- `listen_cmd` _(optional)_: Command to run in the background to update the module’s display. Empty or whitespace-only values are treated as unset.
-- `icons` _(optional)_: Regex-to-icon mapping to change the icon based on the `listen_cmd` output (for `button` type`). The first matching regex wins; since the mappings are stored as a map, the evaluation order is not guaranteed. Prefer mutually exclusive regexes or keep patterns precise to avoid ambiguous matches.
-- `alert` _(optional)_: Regex to trigger a red alert dot on the icon when
-  matched in the `listen_cmd` output (for `button` type).
+- `on_right_click` _(optional)_: Command to execute on right-click.
+- `on_middle_click` _(optional)_: Command to execute on middle-click.
+- `on_scroll_up` _(optional)_: Command to execute when scrolling up over the module.
+- `on_scroll_down` _(optional)_: Command to execute when scrolling down over the module.
+- `listen_cmd` _(optional)_: Command to run in the background to update the module's display. Empty or whitespace-only values are treated as unset.
+- `icons` _(optional)_: Regex-to-icon mapping to change the icon based on the `listen_cmd` output (for `button` type). The first matching regex wins; since the mappings are stored as a map, the evaluation order is not guaranteed. Prefer mutually exclusive regexes or keep patterns precise to avoid ambiguous matches.
+- `alert` _(optional)_: Regex to trigger a red alert dot on the icon when matched in the `listen_cmd` output (for `button` type).
 
 ---
 
@@ -144,17 +147,18 @@ listen_cmd = "sh -c 'while true; do echo \"{\\\"text\\\": \\\"$(date +\"%H:%M\")
 
 ### Button Module with Icon (Interactive)
 
-Button modules display an icon and/or text with a click action:
+Button modules display an icon and/or text with a click action. They also support right-click, middle-click, and scroll events:
 
 ```toml
 [[CustomModule]]
-name = "CustomNotifications"
+name = "volume"
 type = "Button"
-icon = ""
-command = "swaync-client -t -sw"
-listen_cmd = "swaync-client -swb"
-icons.'dnd.*' = ""
-alert = ".*notification"
+icon = ""
+command = "pactl get-sink-volume @DEFAULT_SINK@"
+on_right_click = "pactl set-sink-mute @DEFAULT_SINK@ toggle"
+on_middle_click = "pavucontrol"
+on_scroll_up = "pactl set-sink-volume @DEFAULT_SINK@ +5%"
+on_scroll_down = "pactl set-sink-volume @DEFAULT_SINK@ -5%"
 ```
 
 ### Button Module with Icon Only


### PR DESCRIPTION
This PR adds more ways to interact with custom modules in ashell. 
You can now set different commands for right-click, middle-click, and scrolling up or down directly on the module button itself. 

related to https://github.com/MalpenZibo/ashell/issues/324 even if the solution for this issue was a different one.

+ fixed/updated a bit of the docs (before release we will have to go through them again and check)