### PR TITLE
workspaces: make button width scale to fit names

### DIFF
--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -444,27 +444,14 @@ impl Workspaces {
                                         .align_y(alignment::Vertical::Center),
                                 )
                                 .style(theme.workspace_button_style(empty, color))
-                                .padding(if w.id < 0 {
-                                    match w.displayed {
-                                        Displayed::Active => [0.0, theme.space.md],
-                                        Displayed::Visible => [0.0, theme.space.sm],
-                                        Displayed::Hidden => [0.0, theme.space.xs],
-                                    }
-                                } else {
-                                    [0.0, 0.0]
-                                })
+                                .padding([0.0, theme.space.xxs])
                                 .on_press(if w.id > 0 {
                                     Message::ChangeWorkspace(w.id)
                                 } else {
                                     Message::ToggleSpecialWorkspace(w.id)
                                 })
-                                .width(match (w.id < 0, &w.displayed) {
-                                    (true, _) => Length::Shrink,
-                                    (_, Displayed::Active) => Length::Fixed(theme.space.xl),
-                                    (_, Displayed::Visible) => Length::Fixed(theme.space.lg),
-                                    (_, Displayed::Hidden) => Length::Fixed(theme.space.md),
-                                })
                                 .height(theme.space.md)
+                                .width(Length::Shrink)
                                 .into(),
                             )
                         } else {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -443,7 +443,7 @@ impl Workspaces {
                                         .align_x(alignment::Horizontal::Center)
                                         .align_y(alignment::Vertical::Center),
                                 )
-                                .style(theme.workspace_button_style(empty, color))
+                                .style(theme.workspace_button_style(empty, color, w.displayed == Displayed::Active))
                                 .padding([0.0, theme.space.xxs])
                                 .on_press(if w.id > 0 {
                                     Message::ChangeWorkspace(w.id)

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -625,6 +625,7 @@ impl AshellTheme {
         &self,
         is_empty: bool,
         colors: Option<Option<AppearanceColor>>,
+        active: bool,
     ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
         let radius_lg = self.radius.lg;
         move |theme: &Theme, status: Status| {
@@ -654,63 +655,40 @@ impl AshellTheme {
                     )
                 },
             );
-            let mut base = button::Style {
-                background: Some(Background::Color(if is_empty {
-                    theme.extended_palette().background.weak.color
+
+            let base = button::Style {
+                background: Some(Background::Color(if active {
+                    fg_color
                 } else {
                     bg_color
                 })),
                 border: Border {
                     width: if is_empty { 1.0 } else { 0.0 },
-                    color: bg_color,
+                    color: if active { fg_color } else { bg_color },
                     radius: radius_lg.into(),
                 },
                 text_color: if is_empty {
                     theme.extended_palette().background.weak.text
+                } else if active {
+                    bg_color
                 } else {
                     fg_color
                 },
                 ..button::Style::default()
             };
+            let mut base = base;
             match status {
                 Status::Active => base,
                 Status::Hovered => {
-                    let (bg_color, fg_color) = colors.map_or_else(
-                        || {
-                            (
-                                theme.extended_palette().background.strong.color,
-                                theme.palette().text,
-                            )
-                        },
-                        |c| {
-                            c.map_or_else(
-                                || {
-                                    (
-                                        theme.extended_palette().primary.strong.color,
-                                        theme.extended_palette().primary.strong.text,
-                                    )
-                                },
-                                |c| {
-                                    let color = palette::Primary::generate(
-                                        c.get_base(),
-                                        theme.palette().background,
-                                        c.get_text().unwrap_or_else(|| theme.palette().text),
-                                    );
-                                    (color.strong.color, color.strong.text)
-                                },
-                            )
-                        },
-                    );
-
-                    base.background = Some(Background::Color(if is_empty {
+                    base.background = Some(Background::Color(if is_empty || active {
                         theme.extended_palette().background.strong.color
                     } else {
-                        bg_color
+                        theme.extended_palette().background.strong.color
                     }));
                     base.text_color = if is_empty {
-                        theme.extended_palette().background.weak.text
+                        theme.palette().text
                     } else {
-                        fg_color
+                        theme.extended_palette().background.strong.text
                     };
                     base
                 }


### PR DESCRIPTION
I bind a keyboard shortcut <kbd>Super</kbd> + <kbd>R</kbd> to set the name of each space, and I generally set the names to those of the projects I'm working on. In current ashell releases this results in overlapping text as soon as names are over 1-2 characters in length.

Make the workspace buttons width shrink to fit the workspace names, and differentiate between them with colours rather than borders.

<img width="305" height="90" alt="image" src="https://github.com/user-attachments/assets/e310ca2e-6c97-40b0-8e6f-1b4f54633236" />
