### PR TITLE
feature: OSD for indicators

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -13,7 +13,7 @@ use crate::{
         media_player::MediaPlayer,
         notifications::Notifications,
         privacy::Privacy,
-        settings::{self, Settings, audio},
+        settings::{self, Settings},
         system_info::SystemInfo,
         tempo::Tempo,
         tray::TrayModule,
@@ -21,7 +21,7 @@ use crate::{
         window_title::WindowTitle,
         workspaces::Workspaces,
     },
-    osd::{self, Osd, OsdKind},
+    osd::{self, Osd},
     outputs::{HasOutput, Outputs},
     services::ReadOnlyService,
     theme::{AshellTheme, backdrop_color, darken_color, init_theme, use_theme},
@@ -230,85 +230,6 @@ impl App {
         use_theme(|t| t.scale_factor)
     }
 
-    /// Build OSD display info (kind, normalised value, muted) for the given
-    /// IPC command, reading current state from the Settings services.
-    fn osd_info_for(&self, cmd: &IpcCommand) -> Option<(OsdKind, f32, bool)> {
-        fn normalise(cur: u32, max: u32) -> f32 {
-            if max > 0 {
-                cur as f32 / max as f32
-            } else {
-                0.0
-            }
-        }
-
-        match cmd {
-            IpcCommand::VolumeUp { .. } | IpcCommand::VolumeDown { .. } => {
-                // Use slider value — it has the optimistic RequestAndTimeout update,
-                // which was computed from real_sink_volume in volume_adjust().
-                let vol = self.settings.audio().current_sink_volume().unwrap_or(0);
-                let muted = self.settings.audio().is_sink_muted().unwrap_or(false);
-                Some((
-                    OsdKind::Volume,
-                    normalise(vol, audio::AudioSettings::vol_max()),
-                    muted,
-                ))
-            }
-            IpcCommand::VolumeToggleMute { .. } => {
-                let vol = self.settings.audio().real_sink_volume().unwrap_or(0);
-                // Invert: the toggle was just sent but PulseAudio hasn't
-                // round-tripped yet, so the current state is stale.
-                let muted = !self.settings.audio().is_sink_muted().unwrap_or(false);
-                Some((
-                    OsdKind::Volume,
-                    normalise(vol, audio::AudioSettings::vol_max()),
-                    muted,
-                ))
-            }
-            IpcCommand::MicrophoneUp { .. } | IpcCommand::MicrophoneDown { .. } => {
-                // Use slider value — it has the optimistic RequestAndTimeout update,
-                // which was computed from real_source_volume in microphone_adjust().
-                let vol = self.settings.audio().current_source_volume().unwrap_or(0);
-                let muted = self.settings.audio().is_source_muted().unwrap_or(false);
-                Some((
-                    OsdKind::Microphone,
-                    normalise(vol, audio::AudioSettings::mic_max()),
-                    muted,
-                ))
-            }
-            IpcCommand::MicrophoneToggleMute { .. } => {
-                let vol = self.settings.audio().real_source_volume().unwrap_or(0);
-                // Invert: the toggle was just sent but PulseAudio hasn't
-                // round-tripped yet, so the current state is stale.
-                let muted = !self.settings.audio().is_source_muted().unwrap_or(false);
-                Some((
-                    OsdKind::Microphone,
-                    normalise(vol, audio::AudioSettings::mic_max()),
-                    muted,
-                ))
-            }
-            IpcCommand::BrightnessUp { .. } | IpcCommand::BrightnessDown { .. } => self
-                .settings
-                .brightness()
-                .current_brightness()
-                .map(|(cur, max)| (OsdKind::Brightness, normalise(cur, max), false)),
-            IpcCommand::ToggleAirplaneMode { .. } => {
-                // After toggle: the new state is the opposite of current.
-                // For toggles, `muted` carries the active/enabled state; `value` is unused.
-                let active = !self.settings.network().is_airplane_mode().unwrap_or(false);
-                Some((OsdKind::Airplane, 0.0, active))
-            }
-            IpcCommand::ToggleIdleInhibitor { .. } => {
-                if let Some(idle_inhibitor) = self.settings.idle_inhibitor() {
-                    let active = idle_inhibitor.is_inhibited();
-                    Some((OsdKind::IdleInhibitor, 0.0, active))
-                } else {
-                    None
-                }
-            }
-            IpcCommand::ToggleVisibility => None,
-        }
-    }
-
     pub fn update(&mut self, message: Message) -> Task<Message> {
         match message {
             Message::ConfigChanged(config) => {
@@ -451,6 +372,21 @@ impl App {
             Message::Settings(message) => match self.settings.update(message) {
                 modules::settings::Action::None => Task::none(),
                 modules::settings::Action::Command(task) => task.map(Message::Settings),
+                modules::settings::Action::Response(task, osd) => {
+                    let mut tasks = vec![];
+                    if let Some(task) = task {
+                        tasks.push(task.map(Message::Settings));
+                    }
+                    if self.osd.config().enabled
+                        && !self.outputs.menu_is_open()
+                        && let Some(osd) = osd
+                        && let osd::Action::Show(timer) = self.osd.update(osd::Message::Show(osd))
+                    {
+                        tasks.push(timer.map(Message::Osd));
+                        tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
+                    }
+                    Task::batch(tasks)
+                }
                 modules::settings::Action::CloseMenu(id) => {
                     self.outputs
                         .close_menu(id, None, self.general_config.enable_esc_key)
@@ -562,23 +498,20 @@ impl App {
                     IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
                     IpcCommand::ToggleVisibility => unreachable!(),
                 };
-                if let settings::Action::Command(task) = action {
-                    tasks.push(task.map(Message::Settings));
-                }
-
-                // Show OSD overlay if enabled.
-                if self.osd.config().enabled && !cmd.no_osd() {
-                    let osd_info = self.osd_info_for(&cmd);
-
-                    if let Some((kind, value, muted)) = osd_info
-                        && let osd::Action::Show(timer) =
-                            self.osd.update(osd::Message::Show { kind, value, muted })
+                if let settings::Action::Response(task, osd) = action {
+                    if let Some(task) = task {
+                        tasks.push(task.map(Message::Settings));
+                    }
+                    // Show OSD overlay if enabled.
+                    if self.osd.config().enabled
+                        && !cmd.no_osd()
+                        && let Some(osd) = osd
+                        && let osd::Action::Show(timer) = self.osd.update(osd::Message::Show(osd))
                     {
                         tasks.push(timer.map(Message::Osd));
                         tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
                     }
                 }
-
                 Task::batch(tasks)
             }
             Message::Osd(msg) => match self.osd.update(msg) {

--- a/src/components/slider_control.rs
+++ b/src/components/slider_control.rs
@@ -15,7 +15,7 @@ pub struct SliderControl<'a, Msg> {
     icon: IconKind,
     range: RangeInclusive<u32>,
     value: u32,
-    on_change: Box<dyn Fn(remote_value::Message<u32>) -> Msg + 'a>,
+    on_change: Box<dyn Fn(remote_value::Message<u32>, bool) -> Msg + 'a>,
     on_scroll: Box<dyn Fn(ScrollDelta) -> Msg + 'a>,
     on_icon_press: Option<Msg>,
     on_icon_right_press: Option<Msg>,
@@ -26,7 +26,7 @@ pub fn slider_control<'a, Msg: 'static + Clone>(
     icon: impl Into<IconKind>,
     range: RangeInclusive<u32>,
     value: u32,
-    on_change: impl Fn(remote_value::Message<u32>) -> Msg + 'a,
+    on_change: impl Fn(remote_value::Message<u32>, bool) -> Msg + 'a,
     on_scroll: impl Fn(ScrollDelta) -> Msg + 'a,
 ) -> SliderControl<'a, Msg> {
     SliderControl {
@@ -82,7 +82,7 @@ impl<'a, Msg: 'static + Clone> From<SliderControl<'a, Msg>> for Element<'a, Msg>
                 slider(ctrl.range, ctrl.value, remote_value::Message::Request)
                     .on_release(remote_value::Message::Timeout),
             )
-            .map(ctrl.on_change),
+            .map(move |msg| (ctrl.on_change)(msg, false)),
         )
         .on_scroll(ctrl.on_scroll);
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -548,9 +548,13 @@ pub struct SettingsModuleConfig {
     pub peripheral_expanded_by_default: bool,
     pub audio_indicator_format: SettingsFormat,
     pub microphone_indicator_format: SettingsFormat,
+    #[serde(deserialize_with = "step_deserializer")]
+    pub audio_step: u32,
     pub network_indicator_format: SettingsFormat,
     pub bluetooth_indicator_format: SettingsFormat,
     pub brightness_indicator_format: SettingsFormat,
+    #[serde(deserialize_with = "step_deserializer")]
+    pub brightness_step: u32,
     #[serde(default, deserialize_with = "empty_string_as_none")]
     pub audio_sinks_more_cmd: Option<String>,
     #[serde(default, deserialize_with = "empty_string_as_none")]
@@ -566,6 +570,27 @@ pub struct SettingsModuleConfig {
     pub indicators: Vec<SettingsIndicator>,
     #[serde(rename = "CustomButton")]
     pub custom_buttons: Vec<SettingsCustomButton>,
+}
+
+fn step_deserializer<'de, D>(deserializer: D) -> Result<u32, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let v = u32::deserialize(deserializer)?;
+
+    if v < 1 {
+        return Err(serde::de::Error::custom(
+            "Audio step must be greater than 0",
+        ));
+    }
+
+    if v > 10 {
+        return Err(serde::de::Error::custom(
+            "Audio step cannot be greater than 10",
+        ));
+    }
+
+    Ok(v)
 }
 
 impl Default for SettingsModuleConfig {
@@ -584,9 +609,11 @@ impl Default for SettingsModuleConfig {
             peripheral_expanded_by_default: false,
             audio_indicator_format: SettingsFormat::Icon,
             microphone_indicator_format: SettingsFormat::Icon,
+            audio_step: 5,
             network_indicator_format: SettingsFormat::Icon,
             bluetooth_indicator_format: SettingsFormat::Icon,
             brightness_indicator_format: SettingsFormat::Icon,
+            brightness_step: 5,
             audio_sinks_more_cmd: Default::default(),
             audio_sources_more_cmd: Default::default(),
             wifi_more_cmd: Default::default(),

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -6,6 +6,7 @@ use crate::{
         slider_control, styled_button,
     },
     config::SettingsFormat,
+    osd,
     services::{
         ReadOnlyService, Service, ServiceEvent,
         audio::{AudioCommand, AudioService, ChannelVolumesExt, DevicePortType, Port},
@@ -29,10 +30,10 @@ pub enum Message {
     Event(ServiceEvent<AudioService>),
     DefaultSinkChanged(String, Option<String>),
     DefaultSourceChanged(String, Option<String>),
-    ToggleSinkMute,
-    SinkVolumeChanged(remote_value::Message<u32>),
-    ToggleSourceMute,
-    SourceVolumeChanged(remote_value::Message<u32>),
+    ToggleSinkMute(bool),
+    SinkVolumeChanged(remote_value::Message<u32>, bool),
+    ToggleSourceMute(bool),
+    SourceVolumeChanged(remote_value::Message<u32>, bool),
     SinksMore(SurfaceId),
     SourcesMore(SurfaceId),
     OpenMore,
@@ -44,7 +45,7 @@ pub enum Message {
 
 pub enum Action {
     None,
-    Task(Task<Message>),
+    Response(Option<Task<Message>>, Option<osd::OsdMessage>),
     ToggleSinksMenu,
     ToggleSourcesMenu,
     CloseMenu(SurfaceId),
@@ -104,20 +105,10 @@ impl AudioSettings {
         }
     }
 
-    pub fn current_sink_volume(&self) -> Option<u32> {
-        self.service.as_ref().map(|s| s.sink_slider.value())
-    }
-
     pub fn real_sink_volume(&self) -> Option<u32> {
         self.service
             .as_ref()
             .and_then(|s| s.active_sink().map(|d| d.volume.get_volume()))
-    }
-
-    pub fn is_sink_muted(&self) -> Option<bool> {
-        self.service
-            .as_ref()
-            .and_then(|s| s.active_sink().map(|d| d.is_mute))
     }
 
     pub fn vol_max() -> u32 {
@@ -136,14 +127,15 @@ impl AudioSettings {
         };
         self.update(Message::SinkVolumeChanged(
             remote_value::Message::RequestAndTimeout(new_vol),
+            true,
         ))
     }
 
     pub fn toggle_mute(&mut self) -> Action {
-        self.update(Message::ToggleSinkMute)
+        self.update(Message::ToggleSinkMute(true))
     }
 
-    pub fn speaker_icon(muted: bool, normalised: f32) -> StaticIcon {
+    pub fn speaker_icon(normalised: f32, muted: bool) -> StaticIcon {
         if muted {
             StaticIcon::Speaker0
         } else {
@@ -155,20 +147,10 @@ impl AudioSettings {
         }
     }
 
-    pub fn current_source_volume(&self) -> Option<u32> {
-        self.service.as_ref().map(|s| s.source_slider.value())
-    }
-
     pub fn real_source_volume(&self) -> Option<u32> {
         self.service
             .as_ref()
             .and_then(|s| s.active_source().map(|d| d.volume.get_volume()))
-    }
-
-    pub fn is_source_muted(&self) -> Option<bool> {
-        self.service
-            .as_ref()
-            .and_then(|s| s.active_source().map(|d| d.is_mute))
     }
 
     pub fn mic_max() -> u32 {
@@ -187,11 +169,12 @@ impl AudioSettings {
         };
         self.update(Message::SourceVolumeChanged(
             remote_value::Message::RequestAndTimeout(new_vol),
+            true,
         ))
     }
 
     pub fn microphone_toggle_mute(&mut self) -> Action {
-        self.update(Message::ToggleSourceMute)
+        self.update(Message::ToggleSourceMute(true))
     }
 
     pub fn microphone_icon(muted: bool) -> StaticIcon {
@@ -226,22 +209,40 @@ impl AudioSettings {
                 }
                 ServiceEvent::Error(_) => Action::None,
             },
-            Message::ToggleSinkMute => {
+            Message::ToggleSinkMute(show_osd) => {
                 if let Some(service) = self.service.as_mut() {
                     let _ = service.command(AudioCommand::ToggleSinkMute);
-                }
-                Action::None
-            }
-            Message::SinkVolumeChanged(message) => {
-                if let Some(service) = self.service.as_mut() {
-                    if let Some(value) = message.value() {
-                        let _ = service.command(AudioCommand::SinkVolume(value));
+                    if show_osd {
+                        let osd = osd::OsdMessage::Volume {
+                            value: service.sink_slider.value() as f32 / Volume::NORMAL.0 as f32,
+                            muted: !service.active_sink().map(|d| d.is_mute).unwrap_or(false),
+                        };
+                        return Action::Response(None, Some(osd));
                     }
-                    return Action::Task(
-                        service
-                            .sink_slider
-                            .update(message)
-                            .map(Message::SinkVolumeChanged),
+                }
+                Action::Response(None, None)
+            }
+            Message::SinkVolumeChanged(message, show_osd) => {
+                if let Some(service) = self.service.as_mut()
+                    && let Some(value) = message.value()
+                {
+                    let _ = service.command(AudioCommand::SinkVolume(value));
+                    let osd = if show_osd && message != remote_value::Message::ShowReceived {
+                        Some(osd::OsdMessage::Volume {
+                            value: value as f32 / Volume::NORMAL.0 as f32,
+                            muted: service.active_sink().map(|d| d.is_mute).unwrap_or(false),
+                        })
+                    } else {
+                        None
+                    };
+                    return Action::Response(
+                        Some(
+                            service
+                                .sink_slider
+                                .update(message)
+                                .map(move |msg| Message::SinkVolumeChanged(msg, show_osd)),
+                        ),
+                        osd,
                     );
                 }
                 Action::None
@@ -252,22 +253,40 @@ impl AudioSettings {
                 }
                 Action::None
             }
-            Message::ToggleSourceMute => {
+            Message::ToggleSourceMute(show_osd) => {
                 if let Some(service) = self.service.as_mut() {
                     let _ = service.command(AudioCommand::ToggleSourceMute);
-                }
-                Action::None
-            }
-            Message::SourceVolumeChanged(message) => {
-                if let Some(service) = self.service.as_mut() {
-                    if let Some(value) = message.value() {
-                        let _ = service.command(AudioCommand::SourceVolume(value));
+                    if show_osd {
+                        let osd = osd::OsdMessage::Microphone {
+                            value: service.source_slider.value() as f32 / Volume::NORMAL.0 as f32,
+                            muted: !service.active_source().map(|d| d.is_mute).unwrap_or(false),
+                        };
+                        return Action::Response(None, Some(osd));
                     }
-                    return Action::Task(
-                        service
-                            .source_slider
-                            .update(message)
-                            .map(Message::SourceVolumeChanged),
+                }
+                Action::Response(None, None)
+            }
+            Message::SourceVolumeChanged(message, show_osd) => {
+                if let Some(service) = self.service.as_mut()
+                    && let Some(value) = message.value()
+                {
+                    let _ = service.command(AudioCommand::SourceVolume(value));
+                    let osd = if show_osd && message != remote_value::Message::ShowReceived {
+                        Some(osd::OsdMessage::Microphone {
+                            value: value as f32 / Volume::NORMAL.0 as f32,
+                            muted: service.active_source().map(|d| d.is_mute).unwrap_or(false),
+                        })
+                    } else {
+                        None
+                    };
+                    return Action::Response(
+                        Some(
+                            service
+                                .source_slider
+                                .update(message)
+                                .map(move |msg| Message::SourceVolumeChanged(msg, show_osd)),
+                        ),
+                        osd,
                     );
                 }
                 Action::None
@@ -322,7 +341,7 @@ impl AudioSettings {
                 service.active_sink().map(|sink| {
                     let vol = service.sink_slider.value();
                     let norm = vol as f32 / Self::vol_max() as f32;
-                    (service, Self::speaker_icon(sink.is_mute, norm))
+                    (service, Self::speaker_icon(norm, sink.is_mute))
                 })
             })
             .map(|(service, icon_type)| {
@@ -333,8 +352,11 @@ impl AudioSettings {
                     Self::vol_text(volume).into(),
                     IndicatorState::Normal,
                 )
-                .on_right_press(Message::OpenMore)
-                .on_scroll(Self::on_scroll(volume, Message::SinkVolumeChanged))
+                .on_right_press(match self.config.sinks_more_cmd {
+                    Some(_) => Message::OpenSourceMore,
+                    None => Message::ToggleSinkMute(true),
+                })
+                .on_scroll(Self::on_scroll(volume, Message::SinkVolumeChanged, true))
                 .into()
             })
     }
@@ -355,8 +377,11 @@ impl AudioSettings {
                     Self::vol_text(volume).into(),
                     IndicatorState::Normal,
                 )
-                .on_right_press(Message::OpenSourceMore)
-                .on_scroll(Self::on_scroll(volume, Message::SourceVolumeChanged))
+                .on_right_press(match self.config.sinks_more_cmd {
+                    Some(_) => Message::OpenMore,
+                    None => Message::ToggleSourceMute(true),
+                })
+                .on_scroll(Self::on_scroll(volume, Message::SourceVolumeChanged, true))
                 .into()
             })
     }
@@ -370,7 +395,7 @@ impl AudioSettings {
                 Self::audio_slider(
                     SliderType::Sink,
                     s.is_mute,
-                    Message::ToggleSinkMute,
+                    Message::ToggleSinkMute(false),
                     &service.sink_slider,
                     &Message::SinkVolumeChanged,
                     if service.has_multiple_sinks() {
@@ -385,7 +410,7 @@ impl AudioSettings {
                 Self::audio_slider(
                     SliderType::Source,
                     s.is_mute,
-                    Message::ToggleSourceMute,
+                    Message::ToggleSourceMute(false),
                     &service.source_slider,
                     &Message::SourceVolumeChanged,
                     if service.has_multiple_sources() {
@@ -489,7 +514,7 @@ impl AudioSettings {
         is_mute: bool,
         toggle_mute: Message,
         volume: &'a Remote<u32>,
-        volume_changed: &'a dyn Fn(remote_value::Message<u32>) -> Message,
+        volume_changed: &'a dyn Fn(remote_value::Message<u32>, bool) -> Message,
         with_submenu: Option<(Option<SubMenu>, Message)>,
     ) -> Element<'a, Message> {
         let mute_icon = if is_mute {
@@ -509,7 +534,7 @@ impl AudioSettings {
             Volume::MUTED.0..=Volume::NORMAL.0,
             volume.value(),
             volume_changed,
-            Self::on_scroll(volume.value(), volume_changed),
+            Self::on_scroll(volume.value(), volume_changed, false),
         )
         .on_icon_press(toggle_mute)
         .on_icon_right_press(match slider_type {
@@ -528,9 +553,9 @@ impl AudioSettings {
         ctrl.into()
     }
 
-    fn on_scroll<F>(cur_volume: u32, make_msg: F) -> impl Fn(ScrollDelta) -> Message
+    fn on_scroll<F>(cur_volume: u32, make_msg: F, show_osd: bool) -> impl Fn(ScrollDelta) -> Message
     where
-        F: Fn(remote_value::Message<u32>) -> Message,
+        F: Fn(remote_value::Message<u32>, bool) -> Message,
     {
         move |delta| {
             let y = match delta {
@@ -542,7 +567,10 @@ impl AudioSettings {
             } else {
                 cur_volume.saturating_sub(VOL_PERCENT)
             };
-            make_msg(remote_value::Message::RequestAndTimeout(new_volume))
+            make_msg(
+                remote_value::Message::RequestAndTimeout(new_volume),
+                show_osd,
+            )
         }
     }
 

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -57,6 +57,7 @@ pub struct AudioSettingsConfig {
     pub sources_more_cmd: Option<String>,
     pub indicator_format: SettingsFormat,
     pub microphone_indicator_format: SettingsFormat,
+    pub step: u32,
 }
 
 impl AudioSettingsConfig {
@@ -65,12 +66,14 @@ impl AudioSettingsConfig {
         sources_more_cmd: Option<String>,
         indicator_format: SettingsFormat,
         microphone_indicator_format: SettingsFormat,
+        step: u32,
     ) -> Self {
         Self {
             sinks_more_cmd,
             sources_more_cmd,
             indicator_format,
             microphone_indicator_format,
+            step,
         }
     }
 }
@@ -125,7 +128,7 @@ impl AudioSettings {
         let Some(cur) = self.real_sink_volume() else {
             return Action::None;
         };
-        let step = 5 * VOL_PERCENT;
+        let step = self.config.step * VOL_PERCENT;
         let new_vol = if up {
             (cur + step).min(Self::vol_max())
         } else {
@@ -176,7 +179,7 @@ impl AudioSettings {
         let Some(cur) = self.real_source_volume() else {
             return Action::None;
         };
-        let step = 5 * VOL_PERCENT;
+        let step = self.config.step * VOL_PERCENT;
         let new_vol = if up {
             (cur + step).min(Self::mic_max())
         } else {
@@ -534,11 +537,10 @@ impl AudioSettings {
                 ScrollDelta::Lines { y, .. } => y,
                 ScrollDelta::Pixels { y, .. } => y,
             };
-            let step = 5 * VOL_PERCENT;
             let new_volume = if y > 0.0 {
-                (cur_volume + step).min(Volume::NORMAL.0)
+                (cur_volume + VOL_PERCENT).min(Volume::NORMAL.0)
             } else {
-                cur_volume.saturating_sub(step)
+                cur_volume.saturating_sub(VOL_PERCENT)
             };
             make_msg(remote_value::Message::RequestAndTimeout(new_volume))
         }

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -1,12 +1,12 @@
 use crate::{
     components::{format_indicator, icons::StaticIcon, slider_control},
     config::SettingsFormat,
+    osd,
     services::{
         ReadOnlyService, Service, ServiceEvent,
         brightness::{BrightnessCommand, BrightnessService},
     },
-    utils::IndicatorState,
-    utils::remote_value,
+    utils::{IndicatorState, remote_value},
 };
 use iced::{
     Element, Subscription, Task,
@@ -17,14 +17,14 @@ use iced::{
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(ServiceEvent<BrightnessService>),
-    Changed(remote_value::Message<u32>),
+    Changed(remote_value::Message<u32>, bool),
     MenuOpened,
     ConfigReloaded(BrightnessSettingsConfig),
 }
 
 pub enum Action {
     None,
-    Command(Task<Message>),
+    Command(Task<Message>, Option<osd::OsdMessage>),
 }
 
 #[derive(Debug, Clone)]
@@ -69,12 +69,13 @@ impl BrightnessSettings {
         } else {
             cur.saturating_sub(step)
         };
-        self.update(Message::Changed(remote_value::Message::RequestAndTimeout(
-            new_val,
-        )))
+        self.update(Message::Changed(
+            remote_value::Message::RequestAndTimeout(new_val),
+            true,
+        ))
     }
 
-    fn on_scroll(current: u32, max: u32) -> impl Fn(ScrollDelta) -> Message {
+    fn on_scroll(current: u32, max: u32, show_osd: bool) -> impl Fn(ScrollDelta) -> Message {
         move |delta| {
             let y = match delta {
                 ScrollDelta::Lines { y, .. } => y,
@@ -86,7 +87,7 @@ impl BrightnessSettings {
             } else {
                 current.saturating_sub(step)
             };
-            Message::Changed(remote_value::Message::RequestAndTimeout(new))
+            Message::Changed(remote_value::Message::RequestAndTimeout(new), show_osd)
         }
     }
 
@@ -105,12 +106,25 @@ impl BrightnessSettings {
                 }
                 _ => Action::None,
             },
-            Message::Changed(message) => {
-                if let Some(service) = self.service.as_mut() {
-                    if let Some(value) = message.value() {
-                        let _ = service.command(BrightnessCommand(value));
-                    }
-                    return Action::Command(service.current.update(message).map(Message::Changed));
+            Message::Changed(message, show_osd) => {
+                if let Some(service) = self.service.as_mut()
+                    && let Some(value) = message.value()
+                {
+                    let _ = service.command(BrightnessCommand(value));
+                    let osd = if show_osd && message != remote_value::Message::ShowReceived {
+                        Some(osd::OsdMessage::Brightness {
+                            value: value as f32 / service.max as f32,
+                        })
+                    } else {
+                        None
+                    };
+                    return Action::Command(
+                        service
+                            .current
+                            .update(message)
+                            .map(move |msg| Message::Changed(msg, show_osd)),
+                        osd,
+                    );
                 }
                 Action::None
             }
@@ -134,7 +148,7 @@ impl BrightnessSettings {
                 0..=service.max,
                 service.current.value(),
                 Message::Changed,
-                Self::on_scroll(service.current.value(), service.max),
+                Self::on_scroll(service.current.value(), service.max, false),
             )
             .into()
         })
@@ -142,7 +156,7 @@ impl BrightnessSettings {
 
     pub fn brightness_indicator<'a>(&'a self) -> Option<Element<'a, Message>> {
         self.service.as_ref().map(|service| {
-            let scroll_handler = Self::on_scroll(service.current.value(), service.max);
+            let scroll_handler = Self::on_scroll(service.current.value(), service.max, true);
 
             format_indicator(
                 self.config.indicator_format,

--- a/src/modules/settings/brightness.rs
+++ b/src/modules/settings/brightness.rs
@@ -19,7 +19,7 @@ pub enum Message {
     Event(ServiceEvent<BrightnessService>),
     Changed(remote_value::Message<u32>),
     MenuOpened,
-    ConfigReloaded(SettingsFormat),
+    ConfigReloaded(BrightnessSettingsConfig),
 }
 
 pub enum Action {
@@ -27,13 +27,28 @@ pub enum Action {
     Command(Task<Message>),
 }
 
+#[derive(Debug, Clone)]
+pub struct BrightnessSettingsConfig {
+    pub indicator_format: SettingsFormat,
+    pub step: u32,
+}
+
+impl BrightnessSettingsConfig {
+    pub fn new(indicator_format: SettingsFormat, step: u32) -> Self {
+        Self {
+            indicator_format,
+            step,
+        }
+    }
+}
+
 pub struct BrightnessSettings {
-    config: SettingsFormat,
+    config: BrightnessSettingsConfig,
     service: Option<BrightnessService>,
 }
 
 impl BrightnessSettings {
-    pub fn new(config: SettingsFormat) -> Self {
+    pub fn new(config: BrightnessSettingsConfig) -> Self {
         Self {
             config,
             service: None,
@@ -44,15 +59,11 @@ impl BrightnessSettings {
         self.service.as_ref().map(|s| (s.current.value(), s.max))
     }
 
-    fn step(max: u32) -> u32 {
-        (5 * max / 100).max(1)
-    }
-
     pub fn brightness_adjust(&mut self, up: bool) -> Action {
         let Some((cur, max)) = self.current_brightness() else {
             return Action::None;
         };
-        let step = Self::step(max);
+        let step = (self.config.step * max / 100).max(1);
         let new_val = if up {
             (cur + step).min(max)
         } else {
@@ -69,7 +80,7 @@ impl BrightnessSettings {
                 ScrollDelta::Lines { y, .. } => y,
                 ScrollDelta::Pixels { y, .. } => y,
             };
-            let step = Self::step(max);
+            let step = (max / 100).max(1);
             let new = if y > 0.0 {
                 (current + step).min(max)
             } else {
@@ -109,8 +120,8 @@ impl BrightnessSettings {
                 }
                 Action::None
             }
-            Message::ConfigReloaded(format) => {
-                self.config = format;
+            Message::ConfigReloaded(config) => {
+                self.config = config;
                 Action::None
             }
         }
@@ -134,7 +145,7 @@ impl BrightnessSettings {
             let scroll_handler = Self::on_scroll(service.current.value(), service.max);
 
             format_indicator(
-                self.config,
+                self.config.indicator_format,
                 StaticIcon::Brightness,
                 Self::percent_text(service).into(),
                 IndicatorState::Normal,

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -16,7 +16,7 @@ use crate::{
     modules::settings::{
         audio::{AudioSettings, AudioSettingsConfig},
         bluetooth::{BluetoothSettings, BluetoothSettingsConfig},
-        brightness::BrightnessSettings,
+        brightness::{BrightnessSettings, BrightnessSettingsConfig},
         network::{NetworkSettings, NetworkSettingsConfig},
         power::{PowerSettings, PowerSettingsConfig},
     },
@@ -202,8 +202,12 @@ impl Settings {
                 config.audio_sources_more_cmd,
                 config.audio_indicator_format,
                 config.microphone_indicator_format,
+                config.audio_step,
             )),
-            brightness: BrightnessSettings::new(config.brightness_indicator_format),
+            brightness: BrightnessSettings::new(BrightnessSettingsConfig::new(
+                config.brightness_indicator_format,
+                config.brightness_step,
+            )),
             network: NetworkSettings::new(NetworkSettingsConfig::new(
                 config.wifi_more_cmd,
                 config.vpn_more_cmd,
@@ -516,6 +520,7 @@ impl Settings {
                         config.audio_sources_more_cmd,
                         config.audio_indicator_format,
                         config.microphone_indicator_format,
+                        config.audio_step,
                     )));
                 self.network.update(network::Message::ConfigReloaded(
                     NetworkSettingsConfig::new(
@@ -532,7 +537,10 @@ impl Settings {
                     ),
                 ));
                 self.brightness.update(brightness::Message::ConfigReloaded(
-                    config.brightness_indicator_format,
+                    BrightnessSettingsConfig::new(
+                        config.brightness_indicator_format,
+                        config.brightness_step,
+                    ),
                 ));
                 if config.remove_idle_btn {
                     self.idle_inhibitor = None;

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -20,6 +20,7 @@ use crate::{
         network::{NetworkSettings, NetworkSettingsConfig},
         power::{PowerSettings, PowerSettingsConfig},
     },
+    osd,
     services::idle_inhibitor::IdleInhibitorManager,
     t,
     theme::use_theme,
@@ -102,6 +103,7 @@ pub enum Message {
 pub enum Action {
     None,
     Command(Task<Message>),
+    Response(Option<Task<Message>>, Option<osd::OsdMessage>),
     CloseMenu(SurfaceId),
     RequestKeyboard(SurfaceId),
     ReleaseKeyboard(SurfaceId),
@@ -120,64 +122,74 @@ pub enum SubMenu {
 }
 
 impl Settings {
-    pub fn audio(&self) -> &AudioSettings {
-        &self.audio
-    }
-
-    pub fn brightness(&self) -> &BrightnessSettings {
-        &self.brightness
-    }
-
-    pub fn network(&self) -> &NetworkSettings {
-        &self.network
-    }
-
-    pub fn idle_inhibitor(&self) -> &Option<IdleInhibitorManager> {
-        &self.idle_inhibitor
-    }
-
     pub fn volume_adjust(&mut self, up: bool) -> Action {
         match self.audio.volume_adjust(up) {
-            audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
+            audio::Action::Response(task, osd) => match task {
+                Some(task) => Action::Response(Some(task.map(Message::Audio)), osd),
+                None => Action::Response(None, osd),
+            },
             _ => Action::None,
         }
     }
 
     pub fn toggle_mute(&mut self) -> Action {
-        self.audio.toggle_mute();
-        Action::None
+        match self.audio.toggle_mute() {
+            audio::Action::Response(task, osd) => match task {
+                Some(task) => Action::Response(Some(task.map(Message::Audio)), osd),
+                None => Action::Response(None, osd),
+            },
+            _ => Action::None,
+        }
     }
 
     pub fn microphone_adjust(&mut self, up: bool) -> Action {
         match self.audio.microphone_adjust(up) {
-            audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
+            audio::Action::Response(task, osd) => match task {
+                Some(task) => Action::Response(Some(task.map(Message::Audio)), osd),
+                None => Action::Response(None, osd),
+            },
             _ => Action::None,
         }
     }
 
     pub fn microphone_toggle_mute(&mut self) -> Action {
-        self.audio.microphone_toggle_mute();
-        Action::None
+        match self.audio.microphone_toggle_mute() {
+            audio::Action::Response(task, osd) => match task {
+                Some(task) => Action::Response(Some(task.map(Message::Audio)), osd),
+                None => Action::Response(None, osd),
+            },
+            _ => Action::None,
+        }
     }
 
     pub fn brightness_adjust(&mut self, up: bool) -> Action {
         match self.brightness.brightness_adjust(up) {
-            brightness::Action::Command(task) => Action::Command(task.map(Message::Brightness)),
+            brightness::Action::Command(task, osd) => {
+                Action::Response(Some(task.map(Message::Brightness)), osd)
+            }
             brightness::Action::None => Action::None,
         }
     }
 
     pub fn toggle_airplane(&mut self) -> Action {
-        match self.network.update(network::Message::ToggleAirplaneMode) {
-            network::Action::CloseSubMenu(task) => Action::Command(task.map(Message::Network)),
-            network::Action::Command(task) => Action::Command(task.map(Message::Network)),
-            _ => Action::None,
-        }
+        let action = match self.network.update(network::Message::ToggleAirplaneMode) {
+            network::Action::CloseSubMenu(task) => Some(task.map(Message::Network)),
+            network::Action::Command(task) => Some(task.map(Message::Network)),
+            _ => None,
+        };
+        let osd = osd::OsdMessage::Airplane {
+            active: !self.network.is_airplane_mode().unwrap_or(false),
+        };
+        Action::Response(action, Some(osd))
     }
 
     pub fn toggle_idle_inhibitor(&mut self) -> Action {
         if let Some(idle_inhibitor) = &mut self.idle_inhibitor {
             idle_inhibitor.toggle();
+            let osd = osd::OsdMessage::IdleInhibitor {
+                active: idle_inhibitor.is_inhibited(),
+            };
+            return Action::Response(None, Some(osd));
         }
         Action::None
     }
@@ -273,7 +285,10 @@ impl Settings {
                     Action::None
                 }
                 audio::Action::CloseMenu(id) => Action::CloseMenu(id),
-                audio::Action::Task(task) => Action::Command(task.map(Message::Audio)),
+                audio::Action::Response(task, osd) => match task {
+                    Some(task) => Action::Response(Some(task.map(Message::Audio)), osd),
+                    None => Action::Response(None, osd),
+                },
             },
             Message::Network(msg) => match self.network.update(msg) {
                 network::Action::None => Action::None,
@@ -340,7 +355,9 @@ impl Settings {
             },
             Message::Brightness(msg) => match self.brightness.update(msg) {
                 brightness::Action::None => Action::None,
-                brightness::Action::Command(task) => Action::Command(task.map(Message::Brightness)),
+                brightness::Action::Command(task, osd) => {
+                    Action::Response(Some(task.map(Message::Brightness)), osd)
+                }
             },
             Message::ToggleSubMenu(menu_type) => {
                 if self.sub_menu == Some(menu_type) {

--- a/src/osd.rs
+++ b/src/osd.rs
@@ -18,33 +18,22 @@ use crate::{
 
 pub struct Osd {
     config: OsdConfig,
-    state: Option<OsdState>,
+    message: Option<OsdMessage>,
     timeout_handle: Option<iced::task::Handle>,
 }
 
-struct OsdState {
-    kind: OsdKind,
-    /// Normalised value in 0.0..=1.0
-    value: f32,
-    muted: bool,
-}
-
 #[derive(Debug, Clone, Copy)]
-pub enum OsdKind {
-    Volume,
-    Microphone,
-    Brightness,
-    Airplane,
-    IdleInhibitor,
+pub enum OsdMessage {
+    Volume { value: f32, muted: bool },
+    Microphone { value: f32, muted: bool },
+    Brightness { value: f32 },
+    Airplane { active: bool },
+    IdleInhibitor { active: bool },
 }
 
 #[derive(Debug, Clone)]
 pub enum Message {
-    Show {
-        kind: OsdKind,
-        value: f32,
-        muted: bool,
-    },
+    Show(OsdMessage),
     Hide,
     ConfigReloaded(OsdConfig),
 }
@@ -62,7 +51,7 @@ impl Osd {
     pub fn new(config: OsdConfig) -> Self {
         Self {
             config,
-            state: None,
+            message: None,
             timeout_handle: None,
         }
     }
@@ -73,8 +62,8 @@ impl Osd {
 
     pub fn update(&mut self, message: Message) -> Action {
         match message {
-            Message::Show { kind, value, muted } => {
-                self.state = Some(OsdState { kind, value, muted });
+            Message::Show(message) => {
+                self.message = Some(message);
 
                 if let Some(handle) = self.timeout_handle.take() {
                     handle.abort();
@@ -94,7 +83,7 @@ impl Osd {
             }
 
             Message::Hide => {
-                self.state = None;
+                self.message = None;
                 if let Some(handle) = self.timeout_handle.take() {
                     handle.abort();
                 }
@@ -109,66 +98,72 @@ impl Osd {
     }
 
     pub fn view(&self) -> Element<'_, Message> {
-        let Some(state) = &self.state else {
-            return row![].into();
-        };
+        if let Some(message) = self.message {
+            let (space, font_size, radius) = use_theme(|t| (t.space, t.font_size, t.radius));
 
-        let (space, font_size, radius) = use_theme(|t| (t.space, t.font_size, t.radius));
-
-        let icon = match state.kind {
-            OsdKind::Volume => AudioSettings::speaker_icon(state.muted, state.value),
-            OsdKind::Microphone => AudioSettings::microphone_icon(state.muted),
-            OsdKind::Brightness => StaticIcon::Brightness,
-            OsdKind::Airplane => NetworkSettings::airplane_mode_icon(state.muted),
-            OsdKind::IdleInhibitor => IdleInhibitorManager::idle_inhibitor_icon(state.muted),
-        };
-
-        let detail: Element<'_, Message> = match state.kind {
-            OsdKind::Volume | OsdKind::Microphone | OsdKind::Brightness => {
-                let mut bar = progress_bar(0.0..=1.0, state.value)
-                    .length(160.0)
-                    .girth(8.0);
-                if state.muted {
-                    bar = bar.style(progress_bar::secondary);
+            let icon = match message {
+                OsdMessage::Volume { value, muted } => AudioSettings::speaker_icon(value, muted),
+                OsdMessage::Microphone { muted, .. } => AudioSettings::microphone_icon(muted),
+                OsdMessage::Brightness { .. } => StaticIcon::Brightness,
+                OsdMessage::Airplane { active } => NetworkSettings::airplane_mode_icon(active),
+                OsdMessage::IdleInhibitor { active } => {
+                    IdleInhibitorManager::idle_inhibitor_icon(active)
                 }
-                container(bar).center_x(Length::Fill).into()
-            }
-            OsdKind::Airplane | OsdKind::IdleInhibitor => {
-                // For toggles, `muted` carries the active/enabled state.
-                let state_key = if state.muted { "on" } else { "off" };
-                let label = match state.kind {
-                    OsdKind::Airplane => t!("osd-airplane-toggle", state = state_key),
-                    OsdKind::IdleInhibitor => t!("osd-idle-inhibitor-toggle", state = state_key),
-                    _ => unreachable!(),
-                };
-                container(text(label)).center_x(Length::Fill).into()
-            }
-        };
+            };
 
-        let content = row![
-            container(icon.to_text().size(font_size.xxl)).center_x(font_size.xxl),
-            detail,
-        ]
-        .spacing(space.sm)
-        .align_y(Alignment::Center);
+            let detail: Element<'_, Message> = match message {
+                OsdMessage::Volume { value, muted } | OsdMessage::Microphone { value, muted } => {
+                    let mut bar = progress_bar(0.0..=1.0, value).length(160.0).girth(8.0);
+                    if muted {
+                        bar = bar.style(progress_bar::secondary);
+                    }
+                    container(bar).center_x(Length::Fill).into()
+                }
+                OsdMessage::Brightness { value } => {
+                    let bar = progress_bar(0.0..=1.0, value).length(160.0).girth(8.0);
+                    container(bar).center_x(Length::Fill).into()
+                }
+                OsdMessage::Airplane { active } | OsdMessage::IdleInhibitor { active } => {
+                    // For toggles, `muted` carries the active/enabled state.
+                    let state_key = if active { "on" } else { "off" };
+                    let label = match message {
+                        OsdMessage::Airplane { .. } => t!("osd-airplane-toggle", state = state_key),
+                        OsdMessage::IdleInhibitor { .. } => {
+                            t!("osd-idle-inhibitor-toggle", state = state_key)
+                        }
+                        _ => unreachable!(),
+                    };
+                    container(text(label)).center_x(Length::Fill).into()
+                }
+            };
 
-        container(content)
-            .padding([space.sm, space.md])
-            .style(move |t: &Theme| container::Style {
-                background: Some(t.palette().background.into()),
-                border: Border::default()
-                    .width(1)
-                    .color(t.extended_palette().background.weakest.color)
-                    .rounded(radius.xl),
-                text_color: Some(match (state.kind, state.muted) {
-                    (OsdKind::IdleInhibitor, true) => t.palette().danger,
-                    (OsdKind::Airplane, true) => t.palette().danger,
-                    _ => t.palette().text,
-                }),
-                ..Default::default()
-            })
-            .center_x(Length::Fill)
-            .center_y(Length::Fill)
-            .into()
+            let content = row![
+                container(icon.to_text().size(font_size.xxl)).center_x(font_size.xxl),
+                detail,
+            ]
+            .spacing(space.sm)
+            .align_y(Alignment::Center);
+
+            container(content)
+                .padding([space.sm, space.md])
+                .style(move |t: &Theme| container::Style {
+                    background: Some(t.palette().background.into()),
+                    border: Border::default()
+                        .width(1)
+                        .color(t.extended_palette().background.weakest.color)
+                        .rounded(radius.xl),
+                    text_color: Some(match message {
+                        OsdMessage::IdleInhibitor { active: true } => t.palette().danger,
+                        OsdMessage::Airplane { active: true } => t.palette().danger,
+                        _ => t.palette().text,
+                    }),
+                    ..Default::default()
+                })
+                .center_x(Length::Fill)
+                .center_y(Length::Fill)
+                .into()
+        } else {
+            row![].into()
+        }
     }
 }

--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -218,13 +218,7 @@ impl AudioService {
     pub fn update_source_volume(&mut self) {
         let volume = self
             .active_source()
-            .map(|source| {
-                if source.is_mute {
-                    0
-                } else {
-                    source.volume.get_volume()
-                }
-            })
+            .map(|source| source.volume.get_volume())
             .unwrap_or_default();
         self.source_slider.receive(volume);
     }
@@ -232,13 +226,7 @@ impl AudioService {
     pub fn update_sink_volume(&mut self) {
         let volume = self
             .active_sink()
-            .map(|sink| {
-                if sink.is_mute {
-                    0
-                } else {
-                    sink.volume.get_volume()
-                }
-            })
+            .map(|sink| sink.volume.get_volume())
             .unwrap_or_default();
         self.sink_slider.receive(volume);
     }

--- a/src/utils/remote_value.rs
+++ b/src/utils/remote_value.rs
@@ -68,7 +68,7 @@ where
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Message<Value> {
     /// Emitted during user interaction
     Request(Value),

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -193,6 +193,18 @@ The default value is `Icon`.
 microphone_indicator_format = "IconAndPercentage"
 ```
 
+### Audio Step
+
+With the `audio_step` option you can customize how many steps source and sink volume changes when using
+ipc commands.
+
+The default value is 5. Valid values are in the range of 1 to 10.
+
+```toml
+[settings]
+audio_step = 1
+```
+
 ### Network Format
 
 With the `network_indicator_format` option you can customize the network connection indicator format.
@@ -226,6 +238,18 @@ The default value is `Icon`.
 ```toml
 [settings]
 brightness_indicator_format = "IconAndPercentage"
+```
+
+### Brightness Step
+
+With the `brightness_step` option you can customize how many steps screen brightness changes when using
+ipc commands.
+
+The default value is 5.	Valid values are in the	range of 1 to 10.
+
+```toml
+[settings]
+brightness_step = 1
 ```
 
 ## Peripheral Indicators


### PR DESCRIPTION
1. Adds OSD for volume, microphone and brightness indicator on_scroll.
2. Adds mute on right click on volume and microphone indicators.
3. Refactors OSD so mute is not used for everything.
4. Fix for bug in AudioService where it misrepresents actual volume as 0 when muted.