### PR TITLE
feat(workspaces): highlight workspaces with urgent windows

### DIFF
--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -31,12 +31,14 @@ pub struct UiWorkspace {
     pub monitor: String,
     pub displayed: Displayed,
     pub windows: u16,
+    pub has_urgent: bool,
 }
 
 #[derive(Debug, Clone)]
 struct VirtualDesktop {
     pub active: bool,
     pub windows: u16,
+    pub has_urgent: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -100,6 +102,7 @@ fn calculate_ui_workspaces(
                     Displayed::Hidden
                 },
                 windows: w.windows,
+                has_urgent: w.has_urgent,
             });
         }
     }
@@ -115,12 +118,14 @@ fn calculate_ui_workspaces(
             if let Some(vdesk) = virtual_desktops.get_mut(&vdesk_id) {
                 vdesk.windows += w.windows;
                 vdesk.active = vdesk.active || is_active;
+                vdesk.has_urgent = vdesk.has_urgent || w.has_urgent;
             } else {
                 virtual_desktops.insert(
                     vdesk_id,
                     VirtualDesktop {
                         active: is_active,
                         windows: w.windows,
+                        has_urgent: w.has_urgent,
                     },
                 );
             }
@@ -146,6 +151,7 @@ fn calculate_ui_workspaces(
                     Displayed::Hidden
                 },
                 windows: vdesk.windows,
+                has_urgent: vdesk.has_urgent,
             });
         });
     } else {
@@ -177,6 +183,7 @@ fn calculate_ui_workspaces(
                     (false, false) => Displayed::Hidden,
                 },
                 windows: w.windows,
+                has_urgent: w.has_urgent,
             });
         }
     }
@@ -219,6 +226,7 @@ fn calculate_ui_workspaces(
                 monitor: "".to_string(),
                 displayed: Displayed::Hidden,
                 windows: 0,
+                has_urgent: false,
             });
         }
     }
@@ -419,6 +427,7 @@ impl Workspaces {
 
                         if show {
                             let empty = w.windows == 0;
+                            let urgent = w.has_urgent;
                             let color_index = if self.config.enable_virtual_desktops {
                                 Some(w.id as i128)
                             } else {
@@ -443,6 +452,7 @@ impl Workspaces {
                                     (true, _) => None,
                                     (_, Displayed::Active) => Some(theme.space.xl),
                                     (_, Displayed::Visible) => Some(theme.space.lg),
+                                    (_, Displayed::Hidden) if urgent => Some(theme.space.lg),
                                     (_, Displayed::Hidden) => Some(theme.space.md),
                                 };
                                 let name = w.name.clone();
@@ -472,7 +482,11 @@ impl Workspaces {
                                                         .align_x(alignment::Horizontal::Center)
                                                         .align_y(alignment::Vertical::Center),
                                                 )
-                                                .style(theme.workspace_button_style(empty, color))
+                                                .style(
+                                                    theme.workspace_button_style(
+                                                        empty, urgent, color,
+                                                    ),
+                                                )
                                                 .padding(padding)
                                                 .on_press(on_press.clone())
                                                 .width(Length::Fixed(w))
@@ -489,7 +503,7 @@ impl Workspaces {
                                             .align_x(alignment::Horizontal::Center)
                                             .align_y(alignment::Vertical::Center),
                                     )
-                                    .style(theme.workspace_button_style(empty, color))
+                                    .style(theme.workspace_button_style(empty, urgent, color))
                                     .padding(padding)
                                     .on_press(on_press)
                                     .width(Length::Fixed(tw))
@@ -500,7 +514,7 @@ impl Workspaces {
                                             .align_x(alignment::Horizontal::Center)
                                             .align_y(alignment::Vertical::Center),
                                     )
-                                    .style(theme.workspace_button_style(empty, color))
+                                    .style(theme.workspace_button_style(empty, urgent, color))
                                     .padding(padding)
                                     .on_press(on_press)
                                     .width(Length::Shrink)

--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -159,6 +159,7 @@ fn fetch_full_state(internal_state: &HyprInternalState) -> Result<CompositorStat
             monitor_id: w.monitor_id,
             windows: w.windows,
             is_special: w.id < 0,
+            has_urgent: false,
         })
         .collect();
 

--- a/src/services/compositor/niri.rs
+++ b/src/services/compositor/niri.rs
@@ -203,11 +203,13 @@ fn map_state(niri: &EventStreamState) -> CompositorState {
                 }),
                 windows: 0,
                 is_special: false,
+                has_urgent: w.is_urgent,
             }
         })
         .collect();
 
-    // Calculate window counts
+    // Calculate window counts; also propagate per-window urgency to workspaces
+    // since older niri versions may only emit window-level urgency events.
     for win in niri.windows.windows.values() {
         if let Some(ws_id) = win.workspace_id {
             // Resolve Niri Workspace ID (u64) -> Visual Index (u8) -> Generic ID (i32)
@@ -215,6 +217,9 @@ fn map_state(niri: &EventStreamState) -> CompositorState {
                 && let Some(generic_ws) = workspaces.iter_mut().find(|w| w.id == ws.id as i32)
             {
                 generic_ws.windows += 1;
+                if win.is_urgent {
+                    generic_ws.has_urgent = true;
+                }
             }
         }
     }

--- a/src/services/compositor/types.rs
+++ b/src/services/compositor/types.rs
@@ -7,6 +7,7 @@ pub struct CompositorWorkspace {
     pub monitor_id: Option<i128>,
     pub windows: u16,
     pub is_special: bool,
+    pub has_urgent: bool,
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -624,6 +624,7 @@ impl AshellTheme {
     pub fn workspace_button_style(
         &self,
         is_empty: bool,
+        is_urgent: bool,
         colors: Option<Option<AppearanceColor>>,
     ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
         let radius_lg = self.radius.lg;
@@ -654,18 +655,23 @@ impl AshellTheme {
                     )
                 },
             );
+            let urgent_color = theme.palette().danger;
             let mut base = button::Style {
-                background: Some(Background::Color(if is_empty {
+                background: Some(Background::Color(if is_urgent && is_empty {
+                    urgent_color
+                } else if is_empty {
                     theme.extended_palette().background.weak.color
                 } else {
                     bg_color
                 })),
                 border: Border {
-                    width: if is_empty { 1.0 } else { 0.0 },
-                    color: bg_color,
+                    width: if is_urgent || is_empty { 1.0 } else { 0.0 },
+                    color: if is_urgent { urgent_color } else { bg_color },
                     radius: radius_lg.into(),
                 },
-                text_color: if is_empty {
+                text_color: if is_urgent && is_empty {
+                    theme.extended_palette().danger.base.text
+                } else if is_empty {
                     theme.extended_palette().background.weak.text
                 } else {
                     fg_color
@@ -702,12 +708,16 @@ impl AshellTheme {
                         },
                     );
 
-                    base.background = Some(Background::Color(if is_empty {
+                    base.background = Some(Background::Color(if is_urgent && is_empty {
+                        theme.extended_palette().danger.strong.color
+                    } else if is_empty {
                         theme.extended_palette().background.strong.color
                     } else {
                         bg_color
                     }));
-                    base.text_color = if is_empty {
+                    base.text_color = if is_urgent && is_empty {
+                        theme.extended_palette().danger.strong.text
+                    } else if is_empty {
                         theme.extended_palette().background.weak.text
                     } else {
                         fg_color

--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -117,6 +117,12 @@ enabled.
 enable_virtual_desktops = true
 ```
 
+## Urgent Workspace Highlighting
+
+On Niri, when a window on a non-focused workspace requests attention, that
+workspace is highlighted with the danger palette color until you visit it.
+Hyprland support is not implemented yet.
+
 ## Workspace Scrolling Direction
 
 You can use the `invert_scroll_direction` field to choose whether to invert the scrolling direction for mice and trackpads:


### PR DESCRIPTION
Plumbs a has_urgent flag through CompositorWorkspace and UiWorkspace and renders urgent workspaces with a danger-colored border (solid danger background when empty). Hidden urgent workspaces are widened so the highlight stays visible. Niri populates the flag from its workspace and window urgency state; Hyprland is left as a no-op for now (its IPC has no per-client urgent field, so it would need separate event tracking).