### PR TITLE
fix(tempo): swap temperature order to max/min in daily forecast

### DIFF
--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -682,8 +682,8 @@ impl Tempo {
                                             row!(
                                                 text(format!(
                                                     "{}{temp}/{}{temp}",
-                                                    temp_min.round(),
-                                                    temp_max.round()
+                                                    temp_max.round(),
+                                                    temp_min.round()
                                                 ))
                                                 .width(Length::Shrink),
                                                 row!(


### PR DESCRIPTION
Standard weather convention displays high temperature first
(max) followed by low temperature (min). The tempo module
was showing min/max order which is inconsistent with other
weather services.

closes https://github.com/MalpenZibo/ashell/issues/737

<img width="416" height="285" alt="image" src="https://github.com/user-attachments/assets/1beeb4b2-5098-41c2-8573-7c4d339788ee" />
