### PR TITLE
Feat/Media Player Toolbar Cover

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -627,6 +627,8 @@ pub enum MediaPlayerFormat {
     Icon,
     #[default]
     IconAndTitle,
+    Cover,
+    CoverAndTitle
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -628,7 +628,7 @@ pub enum MediaPlayerFormat {
     #[default]
     IconAndTitle,
     Cover,
-    CoverAndTitle
+    CoverAndTitle,
 }
 
 #[derive(Deserialize, Clone, Debug)]

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -237,7 +237,8 @@ impl MediaPlayer {
         self.service.as_ref().and_then(|s| {
             s.players().first().map(|player| {
                 let title =
-                    (self.config.indicator_format == MediaPlayerFormat::IconAndTitle).then(|| {
+                    (self.config.indicator_format == MediaPlayerFormat::IconAndTitle
+                        || self.config.indicator_format == MediaPlayerFormat::CoverAndTitle).then(|| {
                         container(
                             text(self.get_title(player))
                                 .wrapping(text::Wrapping::None)
@@ -246,7 +247,32 @@ impl MediaPlayer {
                         .clip(true)
                     });
 
-                row![icon(StaticIcon::MusicNote)]
+
+                let cover : Element<'_, _> = if matches!(
+                    self.config.indicator_format,
+                    MediaPlayerFormat::Cover | MediaPlayerFormat::CoverAndTitle
+                ) {
+                    let img = player
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.art_url.as_ref())
+                        .and_then(|url| s.get_cover(url));
+
+                    match img {
+                        Some(handle) => container(
+                            image(handle)
+                                .filter_method(image::FilterMethod::Linear),
+                        )
+                        .padding([space.xxs / 2.0, 0.0])
+                        .into(),
+
+                        None => icon(StaticIcon::MusicNote).into(),
+                    }
+                } else {
+                    icon(StaticIcon::MusicNote).into()
+                };
+                
+                row![cover]
                     .push(title)
                     .align_y(Vertical::Center)
                     .spacing(space.xs)

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -236,19 +236,20 @@ impl MediaPlayer {
         let (space, font_size) = use_theme(|theme| (theme.space, theme.font_size));
         self.service.as_ref().and_then(|s| {
             s.players().first().map(|player| {
-                let title =
-                    (self.config.indicator_format == MediaPlayerFormat::IconAndTitle
-                        || self.config.indicator_format == MediaPlayerFormat::CoverAndTitle).then(|| {
-                        container(
-                            text(self.get_title(player))
-                                .wrapping(text::Wrapping::None)
-                                .size(font_size.sm),
-                        )
-                        .clip(true)
-                    });
+                let title = matches!(
+                    self.config.indicator_format,
+                    MediaPlayerFormat::IconAndTitle | MediaPlayerFormat::CoverAndTitle
+                )
+                .then(|| {
+                    container(
+                        text(self.get_title(player))
+                            .wrapping(text::Wrapping::None)
+                            .size(font_size.sm),
+                    )
+                    .clip(true)
+                });
 
-
-                let cover : Element<'_, _> = if matches!(
+                let cover: Element<'_, _> = if matches!(
                     self.config.indicator_format,
                     MediaPlayerFormat::Cover | MediaPlayerFormat::CoverAndTitle
                 ) {
@@ -259,19 +260,18 @@ impl MediaPlayer {
                         .and_then(|url| s.get_cover(url));
 
                     match img {
-                        Some(handle) => container(
-                            image(handle)
-                                .filter_method(image::FilterMethod::Linear),
-                        )
-                        .padding([space.xxs / 2.0, 0.0])
-                        .into(),
+                        Some(handle) => {
+                            container(image(handle).filter_method(image::FilterMethod::Linear))
+                                .padding([space.xxs / 2.0, 0.0])
+                                .into()
+                        }
 
                         None => icon(StaticIcon::MusicNote).into(),
                     }
                 } else {
                     icon(StaticIcon::MusicNote).into()
                 };
-                
+
                 row![cover]
                     .push(title)
                     .align_y(Vertical::Center)

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -14,12 +14,14 @@ using the `max_title_length` field (default: `100`).
 The tray indicator can show either the media icon alone or the icon together with
 the current title. Configure this with the `indicator_format` field:
 
-| Value          | Description                                                |
-| -------------- | ---------------------------------------------------------- |
-| `Icon`         | Displays only the media icon in the status bar.            |
-| `IconAndTitle` | Displays the icon followed by the current title (default). |
+| Value          | Description                                                                                                  |
+| -------------- | ------------------------------------------------------------------------------------------------------------ |
+| `Icon`         | Displays only the media icon in the status bar.                                                              |
+| `IconAndTitle` | Displays the icon followed by the current title (default).                                                   |
+| `Cover`        | Displays cover art when available; otherwise falls back to the media icon.                                   |
+| `CoverAndTitle`| Displays cover art followed by the current title; if cover art is unavailable, falls back to icon and title. |
 
-Use `Icon` if you want a compact indicator or have limited space.
+Use `Icon` or `Cover` if you want a compact indicator or have limited space.
 
 ## Menu
 


### PR DESCRIPTION
Added support for displaying album cover art in the media player toolbar indicator.
<img width="69" height="52" alt="Cover" src="https://github.com/user-attachments/assets/f90750b3-83ab-480b-a8d0-2bae9ff3faf6" />
<img width="407" height="57" alt="CoverAndTitle" src="https://github.com/user-attachments/assets/36a953e4-e585-45db-a861-d0c5292aff6c" />
The following values have been added to the media player configuration field: 
| Value          | Description                                                                                                  |
| -------------- | ------------------------------------------------------------------------------------------------------------ |
| `Cover`        | Displays cover art when available; otherwise falls back to the media icon.                                   |
| `CoverAndTitle`| Displays cover art followed by the current title; if cover art is unavailable, falls back to icon and title. |
