### PR TITLE
fix: Use XDG_RUNTIME_DIR to store logs

### DIFF
--- a/docs/src/contributing/common-tasks.md
+++ b/docs/src/contributing/common-tasks.md
@@ -91,4 +91,4 @@ log_level = "warn,ashell::modules::my_module=debug"
 1. Start ashell: `make start`
 2. Edit `~/.config/ashell/config.toml` in another terminal
 3. Save — changes should appear immediately
-4. Check logs if changes don't apply: `tail -f /tmp/ashell/*.log`
+4. Check logs if changes don't apply: `tail -f $XDG_RUNTIME_DIR/ashell/*.log`

--- a/docs/src/contributing/testing-and-debugging.md
+++ b/docs/src/contributing/testing-and-debugging.md
@@ -6,10 +6,10 @@ ashell does not currently have an automated test suite. Testing is done manually
 
 ## Debugging with Logs
 
-ashell writes logs to `/tmp/ashell/`. To watch logs in real time:
+ashell writes logs to `$XDG_RUNTIME_DIR/ashell/`. To watch logs in real time:
 
 ```bash
-tail -f /tmp/ashell/*.log
+tail -f $XDG_RUNTIME_DIR/ashell/*.log
 ```
 
 ### Adjusting Log Level
@@ -39,7 +39,7 @@ In debug builds (`cargo build` without `--release`), all logs are also printed t
 Check logs for initialization errors:
 
 ```bash
-grep -i "error\|failed\|panic" /tmp/ashell/*.log
+grep -i "error\|failed\|panic" $XDG_RUNTIME_DIR/ashell/*.log
 ```
 
 ### D-Bus Issues

--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -62,7 +62,7 @@ The default config path is `~/.config/ashell/config.toml`.
 
 ## Logging
 
-ashell uses [flexi_logger](https://docs.rs/flexi_logger) and writes logs to `/tmp/ashell/`.
+ashell uses [flexi_logger](https://docs.rs/flexi_logger) and writes logs to `$XDG_RUNTIME_DIR/ashell/`.
 
 - Log files rotate daily and are kept for 7 days.
 - In debug builds, logs are also printed to stdout.
@@ -72,7 +72,7 @@ ashell uses [flexi_logger](https://docs.rs/flexi_logger) and writes logs to `/tm
 To watch logs in real time:
 
 ```bash
-tail -f /tmp/ashell/*.log
+tail -f $XDG_RUNTIME_DIR/ashell/*.log
 ```
 
 ## IPC Socket

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -140,8 +140,10 @@ pub fn socket_path() -> PathBuf {
         None => [
             std::env::temp_dir(),
             PathBuf::from(format!("ashell-{uid}.sock")),
-        ]
-    }.iter().collect()
+        ],
+    }
+    .iter()
+    .collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -13,6 +13,8 @@ use anyhow::{Context, Result, anyhow};
 use clap::Subcommand;
 use iced::Subscription;
 
+use crate::xdg;
+
 /// Maximum bytes to read from a client connection.
 const MAX_REQUEST_LEN: u64 = 4096;
 
@@ -132,11 +134,14 @@ impl FromStr for IpcCommand {
 }
 
 pub fn socket_path() -> PathBuf {
-    if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
-        return PathBuf::from(dir).join("ashell.sock");
-    }
     let uid = unsafe { libc::getuid() };
-    PathBuf::from(format!("/tmp/ashell-{uid}.sock"))
+    match xdg::get_runtime_dir() {
+        Some(dir) => [dir, PathBuf::from("ashell.sock")],
+        None => [
+            std::env::temp_dir(),
+            PathBuf::from(format!("ashell-{uid}.sock")),
+        ]
+    }.iter().collect()
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -131,12 +131,12 @@ impl FromStr for IpcCommand {
     }
 }
 
-pub fn socket_path() -> Result<PathBuf> {
+pub fn socket_path() -> PathBuf {
     if let Some(dir) = std::env::var_os("XDG_RUNTIME_DIR") {
-        return Ok(PathBuf::from(dir).join("ashell.sock"));
+        return PathBuf::from(dir).join("ashell.sock");
     }
     let uid = unsafe { libc::getuid() };
-    Ok(PathBuf::from(format!("/tmp/ashell-{uid}.sock")))
+    PathBuf::from(format!("/tmp/ashell-{uid}.sock"))
 }
 
 // ---------------------------------------------------------------------------
@@ -145,7 +145,7 @@ pub fn socket_path() -> Result<PathBuf> {
 
 /// Run the IPC client: connect to the daemon, send a command, print the response.
 pub fn run_client(cmd: &IpcCommand) -> Result<()> {
-    let path = socket_path()?;
+    let path = socket_path();
     let mut stream = UnixStream::connect(&path)
         .with_context(|| format!("connect to {} — is ashell running?", path.display()))?;
 
@@ -187,7 +187,7 @@ enum ListenerError {
 /// remove the file or bind a new listener — otherwise we'd orphan the
 /// primary's fd and break `ashell msg` until it's restarted.
 fn create_listener() -> std::result::Result<UnixListener, ListenerError> {
-    let path = socket_path().map_err(ListenerError::Other)?;
+    let path = socket_path();
 
     match UnixStream::connect(&path) {
         Ok(_) => return Err(ListenerError::AlreadyRunning),

--- a/src/main.rs
+++ b/src/main.rs
@@ -80,9 +80,8 @@ fn main() -> iced::Result {
 
     debug!("args: {args:?}");
 
-    let logdir = xdg::get_runtime_dir().unwrap_or_else(
-        || [env::temp_dir(), PathBuf::from("ashell")].iter().collect()
-    );
+    let logdir = xdg::get_runtime_dir()
+        .unwrap_or_else(|| [env::temp_dir(), PathBuf::from("ashell")].iter().collect());
     let logger = Logger::with(
         LogSpecBuilder::new()
             .default(log::LevelFilter::Info)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use flexi_logger::{
 use iced::{Anchor, Font, KeyboardInteractivity, Layer, LayerShellSettings};
 use log::{debug, error, warn};
 use std::backtrace::Backtrace;
+use std::env;
 use std::panic;
 use std::path::PathBuf;
 
@@ -22,6 +23,7 @@ mod outputs;
 mod services;
 mod theme;
 mod utils;
+mod xdg;
 
 const NERD_FONT: &[u8] = include_bytes!("../target/generated/SymbolsNerdFont-Regular-Subset.ttf");
 const NERD_FONT_MONO: &[u8] =
@@ -78,12 +80,15 @@ fn main() -> iced::Result {
 
     debug!("args: {args:?}");
 
+    let logdir = xdg::get_runtime_dir().unwrap_or_else(
+        || [env::temp_dir(), PathBuf::from("ashell")].iter().collect()
+    );
     let logger = Logger::with(
         LogSpecBuilder::new()
             .default(log::LevelFilter::Info)
             .build(),
     )
-    .log_to_file(FileSpec::default().directory("/tmp/ashell"))
+    .log_to_file(FileSpec::default().directory(logdir))
     .duplicate_to_stdout(flexi_logger::Duplicate::All)
     .rotate(
         Criterion::AgeOrSize(Age::Day, TMP_FILE_SIZE),

--- a/src/xdg.rs
+++ b/src/xdg.rs
@@ -1,0 +1,19 @@
+use std::env;
+use std::os::linux::fs::MetadataExt;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+
+// $XDG_RUNTIME_DIR defines the base directory relative to which user-specific non-essential runtime
+// files and other file objects (such as sockets, named pipes, ...) should be stored.
+// The directory MUST be owned by the user, and they MUST be the only one having read and write
+// access to it. Its Unix access mode MUST be 0700.
+pub fn get_runtime_dir() -> Option<PathBuf> {
+    let runtime_dir = PathBuf::from(env::var_os("XDG_RUNTIME_DIR")?);
+    let metadata = runtime_dir.metadata().ok()?;
+    let uid = unsafe { libc::geteuid() };
+    (runtime_dir.is_absolute()
+        && metadata.is_dir()
+        && metadata.st_uid() == uid
+        && metadata.permissions().mode() & 0o777 == 0o700)
+        .then_some(runtime_dir)
+}


### PR DESCRIPTION
Fixes a crash when I open a session as another user. When ashell starts as user alpha, it creates /tmp/ashell/, owned by alpha. Then, logging in as user beta, ashell attempts to create /tmp/ashell for user beta, but that directory exists and is owned by user alpha.

In order to allow multiple users on the same system to use ashell, store the logs under a location specific to that user: `$XDG_RUNTIME_DIR/ashell`.
https://specifications.freedesktop.org/basedir/latest/#variables:~:text=actions%20history%20%28logs%2C%20history%2C%20recently%20used%20files%2C%20%E2%80%A6%29

## Notes

- <s>Added the xdg dependency. Multiple places implement XDG_* logic in ashell, the dependency may help simplify some locations. It's easy to remove the dependency and implement the specification if the dependency is an issue.</s> => [no](https://github.com/MalpenZibo/ashell/pull/760#discussion_r3272184244)
- Not sure if a changelog / upgrade doc is needed?

<details>
<summary>
Output from steps I took debugging the issue, it may help understanding it better.
</summary>
<pre>
```
$ RUST_BACKTRACE=1 ashell
INFO [ashell::config] Decoding config file "/home/pdi/.config/ashell/config.toml"
ERROR [ashell] Panic: panicked at /home/freitafr/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/flexi_logger-0.31.8/src/parameters/file_spec.rs:392:14:
called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
    0: <unknown>
   1: <unknown>
   2: <unknown>
   3: <unknown>
   4: <unknown>
   5: <unknown>
   6: <unknown>
   7: <unknown>
   8: <unknown>
   9: <unknown>
  10: <unknown>
  11: <unknown>
  12: <unknown>
  13: <unknown>
  14: <unknown>
  15: <unknown>
  16: <unknown>
  17: <unknown>
  18: <unknown>
  19: <unknown>
  20: <unknown>
  21: <unknown>
  22: <unknown>
  23: <unknown>
  24: <unknown>
  25: __libc_start_main
  26: <unknown>
```

```shell
$ strace ashell
# ...
write(1, "INFO [ashell::config] Decoding c"..., 82INFO [ashell::config] Decoding config file "/home/pdi/.config/ashell/config.toml"
) = 82
statx(AT_FDCWD, "/tmp/ashell/ashell_rCURRENT.log", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffdba1601e0) = -1 EACCES (Permission denied)
statx(AT_FDCWD, "/tmp/ashell/ashell_rCURRENT.log", AT_STATX_SYNC_AS_STAT, STATX_ALL, 0x7ffdba1601e0) = -1 EACCES (Permission denied)
openat(AT_FDCWD, "/tmp/ashell", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = -1 EACCES (Permission denied)
write(1, "\33[38;5;196mERROR\33[0m [ashell] \33["..., 324ERROR [ashell] Panic: panicked at /home/freitafr/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/flexi_logger-0.31.8/src/parameters/file_spec.rs:392:14:
called `Result::unwrap()` on an `Err` value: Os { code: 13, kind: PermissionDenied, message: "Permission denied" }
 disabled backtrace
) = 324
```

```shell
$ ls -l /tmp/ | rg ashell
drwx------ 2 freitafr freitafr  60 May 19 14:31 ashell
$ whoami
pdi
```
</details>
