### PR TITLE
fix: simplify COPR workflow and fix make install

### DIFF
--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -2,11 +2,6 @@ name: Copr Build
 
 on:
   workflow_dispatch:
-    inputs:
-      chroots:
-        description: "Space-separated Copr chroots"
-        required: false
-        default: "fedora-42-x86_64"
   push:
     tags:
       - "v*"
@@ -22,7 +17,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install deps
         run: |
-          dnf -y install git cargo rust rpm-build copr-cli gcc make pkgconf-pkg-config
+          dnf -y install git cargo rust rpm-build copr-cli gcc make pkgconf-pkg-config \
+            pipewire-devel libinput-devel systemd-devel dbus-devel wayland-devel \
+            libxkbcommon-devel mesa-libEGL-devel pango-devel cairo-devel glib2-devel \
+            openssl-devel fontconfig-devel freetype-devel clang-devel
           dnf -y clean all
       - name: Configure copr-cli
         if: env.COPR_CONFIG != ''
@@ -42,13 +40,7 @@ jobs:
         run: echo "path=$(ls -1 target/release/rpmbuild/SRPMS/*.src.rpm | head -n1)" >> $GITHUB_OUTPUT
       - name: Trigger Copr build
         if: env.COPR_CONFIG != ''
-        env:
-          CHROOTS: ${{ github.event.inputs.chroots }}
-        run: |
-          CHROOTS="${CHROOTS:-fedora-42-x86_64}"
-          args=()
-          for c in $CHROOTS; do args+=( -r "$c" ); done
-          copr-cli build "${args[@]}" killcrb/ashell "${{ steps.srpm.outputs.path }}"
+        run: copr-cli build killcrb/ashell "${{ steps.srpm.outputs.path }}"
       - name: List builds
         if: env.COPR_CONFIG != ''
         run: copr-cli list-builds killcrb/ashell

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 .PHONY: help build start install fmt check
 
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+
 help:
 	@echo "Usage: make [target]"
 	@echo ""
@@ -7,7 +10,7 @@ help:
 	@echo "  help          Show this help message"
 	@echo "  build         Build the project"
 	@echo "  start         Run the build"
-	@echo "  install       Install the build to /usr/bin"
+	@echo "  install       Install the build (supports DESTDIR and PREFIX)"
 	@echo "  fmt           Format the code"
 	@echo "  check         Format, check and lint the code"
 
@@ -18,7 +21,7 @@ start: build
 	./target/release/ashell
 
 install: build
-	sudo cp -f target/release/ashell /usr/bin
+	install -Dm755 target/release/ashell $(DESTDIR)$(BINDIR)/ashell
 
 fmt:
 	cargo fmt


### PR DESCRIPTION
## Summary

- **COPR workflow**: Remove chroot selection logic. `copr-cli build` without `-r` flags automatically builds for all chroots enabled in the COPR project, so chroot management is done via project settings (or `copr-cli modify`) rather than hardcoded in CI.
- **Build deps**: Add missing build dependencies (pipewire-devel, wayland-devel, clang-devel, etc.) that are required for the SRPM build to succeed.
- **Makefile install**: Replace `sudo cp -f` with `install -Dm755` and support `DESTDIR`/`PREFIX` variables for proper packaging integration.

## Changes

| File | Change |
|------|--------|
| `.github/workflows/copr-build.yml` | Remove `workflow_dispatch` chroots input, add build deps, simplify build step |
| `Makefile` | Use `install -Dm755` with `DESTDIR`/`PREFIX` support |

## Notes

The `COPR_CONFIG` secret still needs to be configured in the repository for the workflow to submit builds. Without it, the workflow builds the SRPM but skips the COPR submission (existing behavior).