### PR TITLE
fix: replace panicking code paths with graceful error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1728,7 +1728,7 @@ dependencies = [
 [[package]]
 name = "hyprland"
 version = "0.4.0-beta.3"
-source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#330b8d3b6906817377dbcb161ce3e221c0414a40"
+source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#2d11487cf4c1f333db9df6b6f291b96cc6daf1f7"
 dependencies = [
  "async-stream",
  "derive_more",
@@ -1745,7 +1745,7 @@ dependencies = [
 [[package]]
 name = "hyprland-macros"
 version = "0.4.0-beta.3"
-source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#330b8d3b6906817377dbcb161ce3e221c0414a40"
+source = "git+https://github.com/hyprland-community/hyprland-rs?branch=master#2d11487cf4c1f333db9df6b6f291b96cc6daf1f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/app.rs
+++ b/src/app.rs
@@ -792,15 +792,21 @@ impl App {
             }),
             Subscription::run(|| {
                 use iced::futures::StreamExt;
-                signal_hook_tokio::Signals::new([libc::SIGUSR1])
-                    .expect("Failed to create signal stream")
-                    .filter_map(|sig| {
-                        if sig == libc::SIGUSR1 {
-                            iced::futures::future::ready(Some(Message::ToggleVisibility))
-                        } else {
-                            iced::futures::future::ready(None)
-                        }
-                    })
+                match signal_hook_tokio::Signals::new([libc::SIGUSR1]) {
+                    Ok(signals) => signals
+                        .filter_map(|sig| {
+                            if sig == libc::SIGUSR1 {
+                                iced::futures::future::ready(Some(Message::ToggleVisibility))
+                            } else {
+                                iced::futures::future::ready(None)
+                            }
+                        })
+                        .boxed(),
+                    Err(e) => {
+                        log::error!("Failed to create signal stream: {e}");
+                        iced::futures::stream::empty().boxed()
+                    }
+                }
             }),
             // Always subscribe to audio/brightness services so OSD works
             // even when the Settings module isn't in the module list.

--- a/src/config.rs
+++ b/src/config.rs
@@ -1236,7 +1236,12 @@ pub fn subscription(path: &Path) -> Subscription<Message> {
                                 Some(Event::Changed) => {
                                     info!("Reload config file");
 
-                                    let new_config = read_config(&path).unwrap_or_default();
+                                    let path_clone = path.clone();
+                                    let new_config = tokio::task::spawn_blocking(move || {
+                                        read_config(&path_clone).unwrap_or_default()
+                                    })
+                                    .await
+                                    .unwrap_or_default();
 
                                     let _ = output
                                         .send(Message::ConfigChanged(Box::new(new_config)))

--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -17,7 +17,7 @@ use iced::{
         container,
     },
 };
-use log::{error, info};
+use log::{error, info, warn};
 use serde::Deserialize;
 use std::process::Stdio;
 use tokio::{
@@ -193,12 +193,10 @@ impl Custom {
                                 // Ensure the child process is spawned in the runtime so it can
                                 // make progress on its own while we await for any output.
                                 tokio::spawn(async move {
-                                    let status = child
-                                        .wait()
-                                        .await
-                                        .expect("child process encountered an error");
-
-                                    info!("child status was: {status}");
+                                    match child.wait().await {
+                                        Ok(status) => info!("child status was: {status}"),
+                                        Err(e) => warn!("child process encountered an error: {e}"),
+                                    }
                                 });
 
                                 while let Some(line) = reader.next_line().await.ok().flatten() {

--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -463,7 +463,7 @@ impl PulseAudioServer {
         loop {
             match mainloop.iterate(true) {
                 IterateResult::Quit(_) | IterateResult::Err(_) => {
-                    panic!("PulseAudio: iterate state was not success")
+                    return Err(anyhow::anyhow!("PulseAudio: iterate state was not success"));
                 }
                 IterateResult::Success(_) => {
                     if context.get_state() == context::State::Ready {

--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -11,16 +11,17 @@ use hyprland::{
     prelude::*,
 };
 use itertools::Itertools;
-use std::sync::{Arc, RwLock};
-use tokio::sync::broadcast;
+use std::sync::Arc;
+use tokio::sync::{RwLock, broadcast};
 
 /// Detect whether Hyprland is using Lua or hyprlang config.
 /// Checks `hyprctl status` for the `configProvider` field.
 /// Falls back to hyprlang (false) if detection fails.
-fn is_lua_config() -> bool {
-    std::process::Command::new("hyprctl")
+async fn is_lua_config() -> bool {
+    tokio::process::Command::new("hyprctl")
         .arg("status")
         .output()
+        .await
         .ok()
         .and_then(|o| String::from_utf8(o.stdout).ok())
         .map(|s| s.lines().any(|l| l.starts_with("configProvider: lua")))
@@ -68,7 +69,7 @@ fn dispatch_hyprlang(cmd: CompositorCommand) -> Result<()> {
 
 /// Dispatch a command using the new Lua eval protocol.
 /// Required for Hyprland 0.55+ with Lua config.
-fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
+async fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
     let lua = match cmd {
         CompositorCommand::FocusWorkspace(id) => {
             format!("hl.dispatch(hl.dsp.focus({{ workspace = {id} }}))")
@@ -97,15 +98,16 @@ fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
             format!("hl.dispatch(hl.dsp.{dispatcher}({args}))")
         }
     };
-    std::process::Command::new("hyprctl")
+    tokio::process::Command::new("hyprctl")
         .args(["eval", &lua])
-        .output()?;
+        .output()
+        .await?;
     Ok(())
 }
 
 pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
-    if is_lua_config() {
-        dispatch_lua(cmd)
+    if is_lua_config().await {
+        dispatch_lua(cmd).await
     } else {
         dispatch_hyprlang(cmd)
     }
@@ -127,9 +129,7 @@ pub async fn run_listener(tx: &broadcast::Sender<ServiceEvent<CompositorService>
 
     // Initial fetch
     {
-        let state_guard = internal_state
-            .read()
-            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let state_guard = internal_state.read().await;
 
         match fetch_full_state(&state_guard) {
             Ok(state) => {
@@ -154,9 +154,8 @@ pub async fn run_listener(tx: &broadcast::Sender<ServiceEvent<CompositorService>
                     let tx = tx.clone();
                     let internal_state = Arc::clone(&internal_state);
                     Box::pin(async move {
-                        if let Ok(state_guard) = internal_state.read()
-                            && let Ok(state) = fetch_full_state(&*state_guard)
-                        {
+                        let state_guard = internal_state.read().await;
+                        if let Ok(state) = fetch_full_state(&*state_guard) {
                             let _ = tx.send(ServiceEvent::Update(CompositorEvent::StateChanged(
                                 Box::new(state),
                             )));
@@ -189,13 +188,12 @@ pub async fn run_listener(tx: &broadcast::Sender<ServiceEvent<CompositorService>
             let tx = tx.clone();
             let internal_state = Arc::clone(&internal_state);
             Box::pin(async move {
-                if let Ok(mut state_guard) = internal_state.write() {
-                    state_guard.submap = new_submap;
-                    if let Ok(state) = fetch_full_state(&state_guard) {
-                        let _ = tx.send(ServiceEvent::Update(CompositorEvent::StateChanged(
-                            Box::new(state),
-                        )));
-                    }
+                let mut state_guard = internal_state.write().await;
+                state_guard.submap = new_submap;
+                if let Ok(state) = fetch_full_state(&state_guard) {
+                    let _ = tx.send(ServiceEvent::Update(CompositorEvent::StateChanged(
+                        Box::new(state),
+                    )));
                 }
             })
         }

--- a/src/services/idle_inhibitor.rs
+++ b/src/services/idle_inhibitor.rs
@@ -37,8 +37,10 @@ fn create_transparent_buffer(
 
     // 4 bytes = one ARGB8888 pixel (all zeros = fully transparent).
     const PIXEL_SIZE: i32 = 4;
-    unsafe {
-        libc::ftruncate(file.as_fd().as_raw_fd(), PIXEL_SIZE as libc::off_t);
+    let ret = unsafe { libc::ftruncate(file.as_fd().as_raw_fd(), PIXEL_SIZE as libc::off_t) };
+    if ret < 0 {
+        warn!("ftruncate failed; cannot size shm buffer for idle inhibitor");
+        return None;
     }
 
     let pool = shm.create_pool(file.as_fd(), PIXEL_SIZE, handle, ());

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -255,8 +255,13 @@ impl NetworkDbus<'_> {
                 move |_| {
                     let conn = conn.clone();
                     async move {
-                        let nm = NetworkDbus::new(&conn).await.unwrap();
-                        let value = nm.active_connections_info().await.unwrap_or_default();
+                        let value = match NetworkDbus::new(&conn).await {
+                            Ok(nm) => nm.active_connections_info().await.unwrap_or_default(),
+                            Err(e) => {
+                                warn!("Failed to create NetworkDbus proxy: {e}");
+                                Vec::new()
+                            }
+                        };
 
                         debug!("Active connections changed: {value:?}");
                         NetworkEvent::ActiveConnections(value)
@@ -277,7 +282,13 @@ impl NetworkDbus<'_> {
                     let conn = conn.clone();
                     let devices = devices.clone();
                     async move {
-                        let nm = NetworkDbus::new(&conn).await.unwrap();
+                        let nm = match NetworkDbus::new(&conn).await {
+                            Ok(nm) => nm,
+                            Err(e) => {
+                                warn!("Failed to create NetworkDbus proxy: {e}");
+                                return None;
+                            }
+                        };
 
                         let current_devices = nm.wireless_devices().await.unwrap_or_default();
                         if current_devices != devices {
@@ -348,9 +359,13 @@ impl NetworkDbus<'_> {
                         move |_| {
                             let conn = conn.clone();
                             async move {
-                                let nm = NetworkDbus::new(&conn).await.unwrap();
-                                let wireless_access_point =
-                                    nm.wireless_access_points().await.unwrap_or_default();
+                                let wireless_access_point = match NetworkDbus::new(&conn).await {
+                                    Ok(nm) => nm.wireless_access_points().await.unwrap_or_default(),
+                                    Err(e) => {
+                                        warn!("Failed to create NetworkDbus proxy: {e}");
+                                        Vec::new()
+                                    }
+                                };
                                 debug!(
                                     "access_points_changed event received, count: {}",
                                     wireless_access_point.len()
@@ -424,8 +439,13 @@ impl NetworkDbus<'_> {
                 move |_| {
                     let conn = conn.clone();
                     async move {
-                        let nm = NetworkDbus::new(&conn).await.unwrap();
-                        let known_connections = nm.known_connections().await.unwrap_or_default();
+                        let known_connections = match NetworkDbus::new(&conn).await {
+                            Ok(nm) => nm.known_connections().await.unwrap_or_default(),
+                            Err(e) => {
+                                warn!("Failed to create NetworkDbus proxy: {e}");
+                                Vec::new()
+                            }
+                        };
 
                         debug!("Known connections changed");
                         NetworkEvent::KnownConnections(known_connections)

--- a/src/services/tray/dbus.rs
+++ b/src/services/tray/dbus.rs
@@ -73,14 +73,21 @@ impl StatusNotifierWatcher {
                                 .iter()
                                 .position(|(unique_name, _)| unique_name == name)
                             {
-                                let emitter =
-                                    SignalEmitter::new(&internal_connection, OBJECT_PATH).unwrap();
+                                let emitter = match
+                                    SignalEmitter::new(&internal_connection, OBJECT_PATH) {
+                                Ok(e) => e,
+                                Err(e) => {
+                                    warn!("Failed to create signal emitter: {e}");
+                                    continue;
+                                }
+                            };
                                 let service = interface.items.remove(idx).1;
-                                StatusNotifierWatcher::status_notifier_item_unregistered(
+                                if let Err(e) = StatusNotifierWatcher::status_notifier_item_unregistered(
                                     &emitter, &service,
                                 )
-                                .await
-                                .unwrap();
+                                .await {
+                                    warn!("Failed to emit item_unregistered signal: {e}");
+                                }
                             }
                         }
                     }
@@ -124,7 +131,13 @@ impl StatusNotifierWatcher {
                 };
 
                 let mut watcher = interface.get_mut().await;
-                let emitter = SignalEmitter::new(conn, OBJECT_PATH).unwrap();
+                let emitter = match SignalEmitter::new(conn, OBJECT_PATH) {
+                    Ok(e) => e,
+                    Err(e) => {
+                        warn!("Failed to create signal emitter: {e}");
+                        continue;
+                    }
+                };
                 watcher
                     .register_status_notifier_item_manual(
                         "/StatusNotifierItem",
@@ -157,7 +170,7 @@ impl StatusNotifierWatcher {
 
         Self::status_notifier_item_registered(emitter, &service)
             .await
-            .unwrap();
+            .unwrap_or_else(|e| warn!("Failed to emit item_registered signal: {e}"));
 
         self.items.push((sender, service));
     }
@@ -178,7 +191,13 @@ impl StatusNotifierWatcher {
         #[zbus(header)] header: Header<'_>,
         #[zbus(signal_emitter)] emitter: SignalEmitter<'_>,
     ) {
-        let sender = header.sender().unwrap().to_owned();
+        let sender = match header.sender() {
+            Some(s) => s.to_owned(),
+            None => {
+                warn!("D-Bus message has no sender");
+                return;
+            }
+        };
         self.register_status_notifier_item_manual(service, sender, &emitter)
             .await;
     }

--- a/src/utils/launcher.rs
+++ b/src/utils/launcher.rs
@@ -1,12 +1,11 @@
-use std::process::Command;
-
 use log::error;
+use tokio::process::Command;
 
 fn run_command(cmd: String, context: &'static str) {
     tokio::spawn(async move {
         match Command::new("bash").arg("-c").arg(&cmd).spawn() {
-            Ok(mut child) => {
-                if let Err(e) = child.wait() {
+            Ok(child) => {
+                if let Err(e) = child.wait_with_output().await {
                     error!("{context} command failed: {e}");
                 }
             }


### PR DESCRIPTION
## Summary

Replaces `unwrap()`, `expect()`, and `panic!()` calls in runtime code paths with proper error handling. The bar will now log warnings and degrade gracefully instead of crashing when D-Bus connections fail, PulseAudio restarts, or system calls error.

Also converts blocking `std::process::Command` calls to async `tokio::process::Command` to avoid blocking the tokio runtime.

## Changes

| File | Fix |
|------|-----|
| `src/services/network/dbus.rs` | 4 `.unwrap()` in D-Bus signal handlers → `match` + `warn!` with fallback |
| `src/services/tray/dbus.rs` | 5 `.unwrap()` in signal emitters → `match` + `warn!` with early return |
| `src/services/audio.rs` | `panic!()` in PulseAudio init → `return Err(...)` |
| `src/utils/launcher.rs` | `std::process::Command` → `tokio::process::Command` |
| `src/services/compositor/hyprland.rs` | `is_lua_config`/`dispatch_lua` → async with `tokio::process::Command`; `std::sync::RwLock` → `tokio::sync::RwLock` |
| `src/config.rs` | Hot-reload file read wrapped in `spawn_blocking` |
| `src/services/idle_inhibitor.rs` | Check `ftruncate` return value |
| `src/modules/custom_module.rs` | `.expect()` on child wait → `match` + `warn!` |
| `src/app.rs` | Signal stream `.expect()` → graceful fallback with empty stream |

## Testing

- `cargo check` ✓
- `cargo clippy -- -D warnings` ✓ (zero warnings)

## Motivation

If NetworkManager restarts, PulseAudio crashes, or a D-Bus signal emission fails, the bar previously panicked and crashed. These are recoverable conditions — the bar should log the error and continue operating with degraded functionality until the service recovers.