### PR TITLE
refactor: code cleanup and streamlining

### DIFF
--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -86,7 +86,7 @@ impl Custom {
         match msg {
             Message::LaunchCommand => {
                 if let Some(cmd) = &self.config.command {
-                    execute_command(cmd.clone());
+                    execute_command(cmd);
                 }
             }
             Message::Update(data) => {

--- a/src/modules/settings/audio.rs
+++ b/src/modules/settings/audio.rs
@@ -277,19 +277,19 @@ impl AudioSettings {
             }
             Message::OpenMore => {
                 if let Some(cmd) = &self.config.sinks_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                 }
                 Action::None
             }
             Message::OpenSourceMore => {
                 if let Some(cmd) = &self.config.sources_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                 }
                 Action::None
             }
             Message::SinksMore(id) => {
                 if let Some(cmd) = &self.config.sinks_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                     Action::CloseMenu(id)
                 } else {
                     Action::None
@@ -297,7 +297,7 @@ impl AudioSettings {
             }
             Message::SourcesMore(id) => {
                 if let Some(cmd) = &self.config.sources_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                     Action::CloseMenu(id)
                 } else {
                     Action::None

--- a/src/modules/settings/bluetooth.rs
+++ b/src/modules/settings/bluetooth.rs
@@ -148,13 +148,13 @@ impl BluetoothSettings {
             },
             Message::OpenMore => {
                 if let Some(cmd) = &self.config.more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                 }
                 Action::None
             }
             Message::More(id) => {
                 if let Some(cmd) = &self.config.more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
 
                     Action::CloseMenu(id)
                 } else {

--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -228,16 +228,20 @@ impl Settings {
         }
     }
 
+    fn toggle_sub_menu(&mut self, target: SubMenu) {
+        if self.sub_menu == Some(target) {
+            self.sub_menu.take();
+        } else {
+            self.sub_menu.replace(target);
+        }
+    }
+
     pub fn update(&mut self, message: Message) -> Action {
         match message {
             Message::Power(msg) => match self.power.update(msg) {
                 power::Action::None => Action::None,
                 power::Action::TogglePeripheralMenu => {
-                    if self.sub_menu == Some(SubMenu::PeripheralMenu) {
-                        self.sub_menu.take();
-                    } else {
-                        self.sub_menu.replace(SubMenu::PeripheralMenu);
-                    }
+                    self.toggle_sub_menu(SubMenu::PeripheralMenu);
                     Action::None
                 }
                 power::Action::Command(task) => Action::Command(task.map(Message::Power)),
@@ -245,19 +249,11 @@ impl Settings {
             Message::Audio(msg) => match self.audio.update(msg) {
                 audio::Action::None => Action::None,
                 audio::Action::ToggleSinksMenu => {
-                    if self.sub_menu == Some(SubMenu::Sinks) {
-                        self.sub_menu.take();
-                    } else {
-                        self.sub_menu.replace(SubMenu::Sinks);
-                    }
+                    self.toggle_sub_menu(SubMenu::Sinks);
                     Action::None
                 }
                 audio::Action::ToggleSourcesMenu => {
-                    if self.sub_menu == Some(SubMenu::Sources) {
-                        self.sub_menu.take();
-                    } else {
-                        self.sub_menu.replace(SubMenu::Sources);
-                    }
+                    self.toggle_sub_menu(SubMenu::Sources);
                     Action::None
                 }
                 audio::Action::CloseSubMenu => {
@@ -290,19 +286,11 @@ impl Settings {
                 }
                 network::Action::Command(task) => Action::Command(task.map(Message::Network)),
                 network::Action::ToggleWifiMenu => {
-                    if self.sub_menu == Some(SubMenu::Wifi) {
-                        self.sub_menu.take();
-                    } else {
-                        self.sub_menu.replace(SubMenu::Wifi);
-                    }
+                    self.toggle_sub_menu(SubMenu::Wifi);
                     Action::None
                 }
                 network::Action::ToggleVpnMenu => {
-                    if self.sub_menu == Some(SubMenu::Vpn) {
-                        self.sub_menu.take();
-                    } else {
-                        self.sub_menu.replace(SubMenu::Vpn);
-                    }
+                    self.toggle_sub_menu(SubMenu::Vpn);
                     Action::None
                 }
                 network::Action::CloseSubMenu(task) => {
@@ -317,11 +305,7 @@ impl Settings {
             Message::Bluetooth(msg) => match self.bluetooth.update(msg) {
                 bluetooth::Action::None => Action::None,
                 bluetooth::Action::ToggleBluetoothMenu => {
-                    if self.sub_menu == Some(SubMenu::Bluetooth) {
-                        self.sub_menu.take();
-                    } else {
-                        self.sub_menu.replace(SubMenu::Bluetooth);
-                    }
+                    self.toggle_sub_menu(SubMenu::Bluetooth);
                     Action::None
                 }
                 bluetooth::Action::CloseSubMenu(task) => {
@@ -339,23 +323,18 @@ impl Settings {
                 brightness::Action::Command(task) => Action::Command(task.map(Message::Brightness)),
             },
             Message::ToggleSubMenu(menu_type) => {
-                if self.sub_menu == Some(menu_type) {
-                    self.sub_menu.take();
+                let was_open = self.sub_menu == Some(menu_type);
+                self.toggle_sub_menu(menu_type);
 
-                    Action::None
-                } else {
-                    self.sub_menu.replace(menu_type);
-
-                    if menu_type == SubMenu::Wifi {
-                        match self.network.update(network::Message::WifiMenuOpened) {
-                            network::Action::Command(task) => {
-                                Action::Command(task.map(Message::Network))
-                            }
-                            _ => Action::None,
+                if !was_open && menu_type == SubMenu::Wifi {
+                    match self.network.update(network::Message::WifiMenuOpened) {
+                        network::Action::Command(task) => {
+                            Action::Command(task.map(Message::Network))
                         }
-                    } else {
-                        Action::None
+                        _ => Action::None,
                     }
+                } else {
+                    Action::None
                 }
             }
             Message::ToggleInhibitIdle => {
@@ -366,7 +345,7 @@ impl Settings {
             }
             Message::Lock => {
                 if let Some(lock_cmd) = &self.lock_cmd {
-                    crate::utils::launcher::execute_command(lock_cmd.to_string());
+                    crate::utils::launcher::execute_command(lock_cmd);
                 }
                 Action::None
             }
@@ -418,7 +397,7 @@ impl Settings {
             },
             Message::CustomButton(name) => {
                 if let Some(button) = self.custom_buttons.iter().find(|b| b.name == name) {
-                    crate::utils::launcher::execute_command(button.command.clone());
+                    crate::utils::launcher::execute_command(&button.command);
 
                     // Toggle button state immediately
                     let current_status = self.custom_buttons_status.get(&name).and_then(|v| *v);

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -211,7 +211,7 @@ impl NetworkSettings {
             },
             Message::WiFiMore(id) => {
                 if let Some(cmd) = &self.config.wifi_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                     Action::CloseMenu(id)
                 } else {
                     Action::None
@@ -219,7 +219,7 @@ impl NetworkSettings {
             }
             Message::VpnMore(id) => {
                 if let Some(cmd) = &self.config.vpn_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                     Action::CloseMenu(id)
                 } else {
                     Action::None
@@ -235,7 +235,7 @@ impl NetworkSettings {
             },
             Message::OpenMore => {
                 if let Some(cmd) = &self.config.wifi_more_cmd {
-                    crate::utils::launcher::execute_command(cmd.to_string());
+                    crate::utils::launcher::execute_command(cmd);
                 }
                 Action::None
             }

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -146,25 +146,25 @@ impl PowerSettings {
                 _ => Action::None,
             },
             Message::Suspend => {
-                utils::launcher::suspend(self.config.suspend_cmd.clone());
+                utils::launcher::suspend(&self.config.suspend_cmd);
                 Action::None
             }
             Message::Hibernate => {
                 if let Some(hibernate_cmd) = &self.config.hibernate_cmd {
-                    utils::launcher::hibernate(hibernate_cmd.to_string());
+                    utils::launcher::hibernate(hibernate_cmd);
                 }
                 Action::None
             }
             Message::Reboot => {
-                utils::launcher::reboot(self.config.reboot_cmd.clone());
+                utils::launcher::reboot(&self.config.reboot_cmd);
                 Action::None
             }
             Message::Shutdown => {
-                utils::launcher::shutdown(self.config.shutdown_cmd.clone());
+                utils::launcher::shutdown(&self.config.shutdown_cmd);
                 Action::None
             }
             Message::Logout => {
-                utils::launcher::logout(self.config.logout_cmd.clone());
+                utils::launcher::logout(&self.config.logout_cmd);
                 Action::None
             }
             Message::ConfigReloaded(config) => {

--- a/src/services/compositor/niri.rs
+++ b/src/services/compositor/niri.rs
@@ -31,10 +31,8 @@ pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
                 ));
             }
         },
-        CompositorCommand::FocusSpecialWorkspace(_) => {
-            return Err(anyhow!("Special workspaces not supported in Niri backend"));
-        }
-        CompositorCommand::ToggleSpecialWorkspace(_) => {
+        CompositorCommand::FocusSpecialWorkspace(_)
+        | CompositorCommand::ToggleSpecialWorkspace(_) => {
             return Err(anyhow!("Special workspaces not supported in Niri backend"));
         }
         CompositorCommand::FocusMonitor(_) => {

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -543,17 +543,31 @@ impl NetworkDbus<'_> {
         }
 
         info.sort_by(|a, b| {
-            let helper = |conn: &ActiveConnectionInfo| match conn {
-                ActiveConnectionInfo::Vpn { name, .. } => format!("0{name}"),
-                ActiveConnectionInfo::Wired { name, .. } => format!("1{name}"),
-                ActiveConnectionInfo::WiFi { name, .. } => format!("2{name}"),
-            };
-            helper(a).cmp(&helper(b))
+            fn key(conn: &ActiveConnectionInfo) -> (u8, &str) {
+                match conn {
+                    ActiveConnectionInfo::Vpn { name, .. } => (0, name),
+                    ActiveConnectionInfo::Wired { name, .. } => (1, name),
+                    ActiveConnectionInfo::WiFi { name, .. } => (2, name),
+                }
+            }
+            key(a).cmp(&key(b))
         });
 
         Ok(info)
     }
+}
 
+fn connection_id(settings: &HashMap<String, HashMap<String, OwnedValue>>) -> Option<String> {
+    settings
+        .get("connection")?
+        .get("id")
+        .and_then(|v| match v.deref() {
+            Value::Str(v) => Some(v.to_string()),
+            _ => None,
+        })
+}
+
+impl NetworkDbus<'_> {
     pub async fn known_connections_internal(
         &self,
         wireless_access_points: &[AccessPoint],
@@ -577,29 +591,13 @@ impl NetworkDbus<'_> {
             let wifi = s.get("802-11-wireless");
 
             if wifi.is_some() {
-                let ssid = s
-                    .get("connection")
-                    .and_then(|c| c.get("id"))
-                    .map(|s| match s.deref() {
-                        Value::Str(v) => v.to_string(),
-                        _ => "".to_string(),
-                    });
-
-                if let Some(cur_ssid) = ssid {
+                if let Some(cur_ssid) = connection_id(&s) {
                     known_ssid.push(cur_ssid);
                 }
-            } else if s.contains_key("vpn") || s.contains_key("wireguard") {
-                let id = s
-                    .get("connection")
-                    .and_then(|c| c.get("id"))
-                    .map(|v| match v.deref() {
-                        Value::Str(v) => v.to_string(),
-                        _ => "".to_string(),
-                    });
-
-                if let Some(id) = id {
-                    known_vpn.push(Vpn { name: id, path: c });
-                }
+            } else if (s.contains_key("vpn") || s.contains_key("wireguard"))
+                && let Some(id) = connection_id(&s)
+            {
+                known_vpn.push(Vpn { name: id, path: c });
             }
         }
         let known_connections: Vec<_> = wireless_access_points
@@ -781,16 +779,7 @@ impl NetworkSettingsDbus<'_> {
                 .await?;
 
             let s = connection.get_settings().await?;
-            let id = s
-                .get("connection")
-                .and_then(|c| c.get("id"))
-                .and_then(|v| match v.deref() {
-                    Value::Str(v) => Some(v.to_string()),
-                    _ => {
-                        debug!("connection settings 'id' field is not a string");
-                        None
-                    }
-                });
+            let id = connection_id(&s);
             if id.as_deref() == Some(name) {
                 return Ok(Some(connection.inner().path().to_owned().into()));
             }
@@ -831,28 +820,6 @@ impl From<u32> for DeviceType {
     }
 }
 
-#[allow(unused)]
-#[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
-pub enum ActiveConnectionState {
-    #[default]
-    Unknown,
-    Activating,
-    Activated,
-    Deactivating,
-    Deactivated,
-}
-
-impl From<u32> for ActiveConnectionState {
-    fn from(device_state: u32) -> Self {
-        match device_state {
-            1 => ActiveConnectionState::Activating,
-            2 => ActiveConnectionState::Activated,
-            3 => ActiveConnectionState::Deactivating,
-            4 => ActiveConnectionState::Deactivated,
-            _ => ActiveConnectionState::Unknown,
-        }
-    }
-}
 #[derive(Default, Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConnectivityState {
     None,
@@ -1036,32 +1003,6 @@ pub trait Device {
 
     #[zbus(property)]
     fn state(&self) -> Result<u32>;
-}
-
-#[proxy(
-    interface = "org.freedesktop.NetworkManager.Device.Wired",
-    default_service = "org.freedesktop.NetworkManager"
-)]
-trait WiredDevice {
-    /// Carrier property
-    #[zbus(property)]
-    fn carrier(&self) -> zbus::Result<bool>;
-
-    /// `HwAddress` property
-    #[zbus(property)]
-    fn hw_address(&self) -> zbus::Result<String>;
-
-    /// `PermHwAddress` property
-    #[zbus(property)]
-    fn perm_hw_address(&self) -> zbus::Result<String>;
-
-    /// `S390Subchannels` property
-    #[zbus(property)]
-    fn s390subchannels(&self) -> zbus::Result<Vec<String>>;
-
-    /// Speed property
-    #[zbus(property)]
-    fn speed(&self) -> zbus::Result<u32>;
 }
 
 #[proxy(

--- a/src/utils/launcher.rs
+++ b/src/utils/launcher.rs
@@ -17,26 +17,26 @@ fn run_command(cmd: String, context: &'static str) {
     });
 }
 
-pub fn execute_command(command: String) {
-    run_command(command, "execute");
+pub fn execute_command(command: &str) {
+    run_command(command.to_owned(), "execute");
 }
 
-pub fn suspend(cmd: String) {
-    run_command(cmd, "suspend");
+pub fn suspend(cmd: &str) {
+    run_command(cmd.to_owned(), "suspend");
 }
 
-pub fn hibernate(cmd: String) {
-    run_command(cmd, "hibernate");
+pub fn hibernate(cmd: &str) {
+    run_command(cmd.to_owned(), "hibernate");
 }
 
-pub fn shutdown(cmd: String) {
-    run_command(cmd, "shutdown");
+pub fn shutdown(cmd: &str) {
+    run_command(cmd.to_owned(), "shutdown");
 }
 
-pub fn reboot(cmd: String) {
-    run_command(cmd, "reboot");
+pub fn reboot(cmd: &str) {
+    run_command(cmd.to_owned(), "reboot");
 }
 
-pub fn logout(cmd: String) {
-    run_command(cmd, "logout");
+pub fn logout(cmd: &str) {
+    run_command(cmd.to_owned(), "logout");
 }


### PR DESCRIPTION
## Summary

Mechanical cleanup: removes dead code, eliminates duplication, and reduces unnecessary allocations. Net result: **-82 lines**.

## Changes

| Change | Impact |
|--------|--------|
| Add `toggle_sub_menu()` helper to `Settings` | Replaces 7 identical if/else toggle blocks |
| Remove `ActiveConnectionState` enum | Dead code (never used, `#[allow(unused)]`) |
| Remove `WiredDevice` proxy trait | Dead code (never instantiated) |
| Sort with `(u8, &str)` tuple key | Eliminates 2 String allocations per comparison |
| Combine niri.rs match arms with `|` | Two identical arms → one |
| `launcher.rs` API: `String` → `&str` | Eliminates 16 unnecessary `.to_string()`/`.clone()` calls |
| Extract `connection_id()` helper | Replaces 3 duplicate D-Bus settings extraction chains |

## Testing

- `cargo check` ✓
- `cargo clippy -- -D warnings` ✓ (zero warnings)