### PR TITLE
add help feature to clap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ tokio-stream = { version = "0.1", default-features = false, features = ["sync"] 
 clap = { version = "4.5", default-features = false, features = [
   "std",
   "derive",
+  "help",
 ] }
 shellexpand = { version = "3", features = ["path"] }
 inotify = { version = "0.11.1", default-features = false, features = [


### PR DESCRIPTION
Let's add the help feature for clap

<img width="361" height="157" alt="image" src="https://github.com/user-attachments/assets/f937d26e-84e7-4856-9c2c-e66113aade4b" />


<img width="605" height="312" alt="image" src="https://github.com/user-attachments/assets/e87eb5a2-9852-472a-b90a-8075b16aefe3" />

<img width="706" height="483" alt="image" src="https://github.com/user-attachments/assets/c1b91709-27ad-4e61-8ddb-f3eb7f690cbb" />


