### PR TITLE
Force cpu temp to always be metric

### DIFF
--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -152,7 +152,7 @@ alert_threshold = 80
 ```
 
 **Dependencies:**
-- Temperature monitoring reads the kernel `hwmon` sysfs interface directly (no extra package required). The `sensor` option is either a type keyword (`"Cpu"`, `"Gpu"`, `"Acpi"`, `"Nvme"`) for auto-detection or an exact hwmon label (e.g. `"acpitz temp1"`) — run `sensors` (from `lm_sensors`) to find the right name. The displayed unit follows the locale / unit system, not a per-module option.
+- Temperature monitoring reads the kernel `hwmon` sysfs interface directly (no extra package required). The `sensor` option is either a type keyword (`"Cpu"`, `"Gpu"`, `"Acpi"`, `"Nvme"`) for auto-detection or an exact hwmon label (e.g. `"acpitz temp1"`) — run `sensors` (from `lm_sensors`) to find the right name. The displayed unit follows the locale / unit system unless `units` (`"Celsius"` / `"Fahrenheit"`) overrides it.
 - CPU, memory, disk, and network info use standard kernel interfaces and do not need extra packages.
 
 ## Clock Module (Deprecated)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,6 @@
 use crate::app::Message;
-use crate::i18n::{UnitSystem, unit_system};
+use crate::i18n::{TemperatureUnit, UnitSystem, unit_system};
 use crate::services::upower::PeripheralDeviceKind;
-use crate::utils::celsius_to_fahrenheit;
 use hex_color::HexColor;
 use iced::futures::StreamExt;
 use iced::{Color, Subscription, futures::SinkExt, stream::channel, theme::palette};
@@ -305,23 +304,27 @@ pub struct SystemInfoTemperature {
     warn_threshold: Option<i32>,
     alert_threshold: Option<i32>,
     pub sensor: TemperatureSensor,
+    units: Option<TemperatureUnit>,
 }
 
 impl SystemInfoTemperature {
+    pub fn resolved_units(&self) -> TemperatureUnit {
+        self.units
+            .unwrap_or_else(|| unit_system().temperature_unit())
+    }
+
     pub fn warn_threshold(&self) -> i32 {
-        self.warn_threshold
-            .unwrap_or_else(|| match crate::i18n::unit_system() {
-                UnitSystem::Metric => DEFAULT_TEMP_WARN_CELSIUS,
-                UnitSystem::Imperial => celsius_to_fahrenheit(DEFAULT_TEMP_WARN_CELSIUS),
-            })
+        self.warn_threshold.unwrap_or_else(|| {
+            self.resolved_units()
+                .convert_celsius(DEFAULT_TEMP_WARN_CELSIUS)
+        })
     }
 
     pub fn alert_threshold(&self) -> i32 {
-        self.alert_threshold
-            .unwrap_or_else(|| match crate::i18n::unit_system() {
-                UnitSystem::Metric => DEFAULT_TEMP_ALERT_CELSIUS,
-                UnitSystem::Imperial => celsius_to_fahrenheit(DEFAULT_TEMP_ALERT_CELSIUS),
-            })
+        self.alert_threshold.unwrap_or_else(|| {
+            self.resolved_units()
+                .convert_celsius(DEFAULT_TEMP_ALERT_CELSIUS)
+        })
     }
 
     fn validate(&mut self) {

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -7,7 +7,10 @@ use i18n_embed::{
     fluent::{FluentLanguageLoader, fluent_language_loader},
 };
 use log::warn;
+use serde::Deserialize;
 use unic_langid::LanguageIdentifier;
+
+use crate::utils::celsius_to_fahrenheit;
 
 const CATALOGS: &[(&str, &str)] = &[
     ("en-US", include_str!("../i18n/en-US/ashell.ftl")),
@@ -27,10 +30,36 @@ pub enum UnitSystem {
 }
 
 impl UnitSystem {
-    pub fn temperature_symbol(self) -> &'static str {
+    pub fn temperature_unit(self) -> TemperatureUnit {
         match self {
-            Self::Metric => "°C",
-            Self::Imperial => "°F",
+            Self::Metric => TemperatureUnit::Celsius,
+            Self::Imperial => TemperatureUnit::Fahrenheit,
+        }
+    }
+
+    pub fn temperature_symbol(self) -> &'static str {
+        self.temperature_unit().symbol()
+    }
+}
+
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum TemperatureUnit {
+    Celsius,
+    Fahrenheit,
+}
+
+impl TemperatureUnit {
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Celsius => "°C",
+            Self::Fahrenheit => "°F",
+        }
+    }
+
+    pub fn convert_celsius(self, celsius: i32) -> i32 {
+        match self {
+            Self::Celsius => celsius,
+            Self::Fahrenheit => celsius_to_fahrenheit(celsius),
         }
     }
 }

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -431,14 +431,9 @@ impl SystemInfo {
                                 format!("{} GiB", self.data.memory_swap_usage.fraction),
                         }
                     ))
-                    .push(self.data.temperature.celsius.map(|cel| {
+                    .push(self.data.temperature.celsius.map(|temp| {
                         Self::info_element(StaticIcon::Temp, t!("system-info-temperature"), {
-                            let units = unit_system();
-                            let value = match units {
-                                UnitSystem::Metric => cel,
-                                UnitSystem::Imperial => utils::celsius_to_fahrenheit(cel),
-                            };
-                            format!("{value}{}", units.temperature_symbol())
+                            format!("{temp}{}", UnitSystem::Metric.temperature_symbol())
                         })
                     }))
                     .push(
@@ -551,17 +546,12 @@ impl SystemInfo {
                 Some(t!("system-info-swap-indicator-prefix")),
             )),
 
-            SystemInfoIndicator::Temperature => self.data.temperature.celsius.map(|cel| {
-                let units = unit_system();
-                let temp_value = match units {
-                    UnitSystem::Metric => cel,
-                    UnitSystem::Imperial => utils::celsius_to_fahrenheit(cel),
-                };
+            SystemInfoIndicator::Temperature => self.data.temperature.celsius.map(|temp| {
                 Self::indicator_info_element(
                     StaticIcon::Temp,
-                    (temp_value, units.temperature_symbol()),
+                    (temp, UnitSystem::Metric.temperature_symbol()),
                     Some((
-                        temp_value,
+                        temp,
                         self.config.temperature.warn_threshold(),
                         self.config.temperature.alert_threshold(),
                     )),

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -567,14 +567,9 @@ impl SystemInfo {
                                 format!("{} GiB", self.data.memory_swap_usage.fraction),
                         }
                     ))
-                    .push(self.data.temperature.celsius.map(|cel| {
+                    .push(self.data.temperature.celsius.map(|temp| {
                         Self::info_element(StaticIcon::Temp, t!("system-info-temperature"), {
-                            let units = unit_system();
-                            let value = match units {
-                                UnitSystem::Metric => cel,
-                                UnitSystem::Imperial => utils::celsius_to_fahrenheit(cel),
-                            };
-                            format!("{value}{}", units.temperature_symbol())
+                            format!("{temp}{}", UnitSystem::Metric.temperature_symbol())
                         })
                     }))
                     .push(
@@ -687,17 +682,12 @@ impl SystemInfo {
                 Some(t!("system-info-swap-indicator-prefix")),
             )),
 
-            SystemInfoIndicator::Temperature => self.data.temperature.celsius.map(|cel| {
-                let units = unit_system();
-                let temp_value = match units {
-                    UnitSystem::Metric => cel,
-                    UnitSystem::Imperial => utils::celsius_to_fahrenheit(cel),
-                };
+            SystemInfoIndicator::Temperature => self.data.temperature.celsius.map(|temp| {
                 Self::indicator_info_element(
                     StaticIcon::Temp,
-                    (temp_value, units.temperature_symbol()),
+                    (temp, UnitSystem::Metric.temperature_symbol()),
                     Some((
-                        temp_value,
+                        temp,
                         self.config.temperature.warn_threshold(),
                         self.config.temperature.alert_threshold(),
                     )),

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -6,7 +6,6 @@ use crate::{
         CpuFormat, DiskFormat, MemoryFormat, SystemInfoIndicator, SystemInfoModuleConfig,
         SystemInfoTemperature, TemperatureSensor, TemperatureSensorType,
     },
-    i18n::{UnitSystem, unit_system},
     t,
     theme::{lerp_color, use_theme},
     utils,
@@ -567,9 +566,10 @@ impl SystemInfo {
                                 format!("{} GiB", self.data.memory_swap_usage.fraction),
                         }
                     ))
-                    .push(self.data.temperature.celsius.map(|temp| {
+                    .push(self.data.temperature.celsius.map(|cel| {
                         Self::info_element(StaticIcon::Temp, t!("system-info-temperature"), {
-                            format!("{temp}{}", UnitSystem::Metric.temperature_symbol())
+                            let units = self.config.temperature.resolved_units();
+                            format!("{}{}", units.convert_celsius(cel), units.symbol())
                         })
                     }))
                     .push(
@@ -682,12 +682,14 @@ impl SystemInfo {
                 Some(t!("system-info-swap-indicator-prefix")),
             )),
 
-            SystemInfoIndicator::Temperature => self.data.temperature.celsius.map(|temp| {
+            SystemInfoIndicator::Temperature => self.data.temperature.celsius.map(|cel| {
+                let units = self.config.temperature.resolved_units();
+                let value = units.convert_celsius(cel);
                 Self::indicator_info_element(
                     StaticIcon::Temp,
-                    (temp, UnitSystem::Metric.temperature_symbol()),
+                    (value, units.symbol()),
                     Some((
-                        temp,
+                        value,
                         self.config.temperature.warn_threshold(),
                         self.config.temperature.alert_threshold(),
                     )),

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -100,6 +100,7 @@ alert_threshold = 85
 # warn_threshold = 60     # (default: None, auto 60°C / 140°F based on unit system)
 # alert_threshold = 80    # (default: None, auto 80°C / 176°F based on unit system)
 # sensor = "Cpu"        # (default) type keyword: "Cpu", "Gpu", "Acpi", "Nvme" or exact label like "acpitz temp1"
+# units = "Celsius"       # (default: None = follow the unit system) or "Fahrenheit"
 
 [system_info.disk]
 # warn_threshold = 80     # (default)

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -101,6 +101,10 @@ They are optional and fall back to your environment: `language` resolves from
 `$LC_ALL`, then `$LC_TIME`, then `$LANG`. The unit system additionally honors
 `$LC_MEASUREMENT` when set. If nothing matches, ashell defaults to `en-US`.
 
+Individual modules can opt out of the unit system: see
+[`system_info.temperature.units`](./modules/system_info.md#temperature) and
+[`tempo.wind_speed_unit`](./modules/tempo.md).
+
 ```toml
 language = "en-US"   # UI language
 region   = "it-IT"   # date format + unit system

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -144,7 +144,12 @@ sensor = "Cpu"              # auto-detect by type
 # sensor = "k10temp Tctl"   # or pin an exact sensor label
 ```
 
-The temperature **unit** (Celsius or Fahrenheit) follows your locale / unit system (the global `region` option), so there is no separate temperature format option.
+The temperature **unit** follows your locale / unit system (the global `region` option) by default. Set `units` to `"Celsius"` or `"Fahrenheit"` to override it for this indicator only — useful if you want Fahrenheit for the weather but Celsius for hardware temperatures.
+
+```toml
+[system_info.temperature]
+units = "Celsius"           # override the locale unit system
+```
 
 To see available sensors on your system, you can check the output of `sensors` command or
 look at the component labels returned by the sysinfo library.
@@ -184,7 +189,7 @@ Higher values reduce CPU usage at the cost of less frequent updates.
 Each indicator type supports a `format` option that controls how its value is displayed in the status bar and menu. The format is configured in the corresponding `[system_info.<type>]` section.
 
 :::info
-Warning and alert color thresholds remain active regardless of the display format. For temperature, thresholds are interpreted in the unit determined by your locale / unit system — so if your locale uses Fahrenheit, set your thresholds in Fahrenheit (e.g., `warn_threshold = 140`).
+Warning and alert color thresholds remain active regardless of the display format. For temperature, thresholds are interpreted in the displayed unit (`units`, or the one determined by your locale / unit system) — so if the indicator shows Fahrenheit, set your thresholds in Fahrenheit (e.g., `warn_threshold = 140`).
 :::
 
 #### Example


### PR DESCRIPTION
For the most part, temps for computer components are always in Celsius. Even Task Manager on Windows uses Celsius when set to an English US region. I don't think I've personally ever seen anyone in the US use Fahrenheit to talk about computers.

This PR just locks the `SystemInfo` module to always give CPU temps in Celsius. Although, this could be a config option if anyone says they still want Fahrenheit.