### PR TITLE
ci(copr): replace cargo-rpm with cargo-generate-rpm, add Rust cache

### DIFF
--- a/.copr/Makefile
+++ b/.copr/Makefile
@@ -1,0 +1,8 @@
+srpm:
+	dnf -y install git rust-srpm-macros rpmautospec-rpm-macros rpmdevtools
+	$(eval VERSION := $(shell grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/'))
+	spectool -g .rpm/ashell.spec -C . --define "pkg_version $(VERSION)"
+	rpmbuild -bs .rpm/ashell.spec \
+		--define "pkg_version $(VERSION)" \
+		--define "_sourcedir $(PWD)" \
+		--define "_srcrpmdir $(outdir)"

--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -2,6 +2,15 @@ name: Copr Build
 
 on:
   workflow_dispatch:
+    inputs:
+      chroots:
+        description: "Space-separated Copr chroots"
+        required: false
+        default: >-
+          fedora-42-x86_64 fedora-42-aarch64
+          fedora-43-x86_64 fedora-43-aarch64
+          fedora-44-x86_64 fedora-44-aarch64
+          fedora-rawhide-x86_64 fedora-rawhide-aarch64
   push:
     tags:
       - "v*"
@@ -9,38 +18,31 @@ on:
 jobs:
   copr:
     runs-on: ubuntu-latest
-    container:
-      image: fedora:42
     env:
       COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
     steps:
-      - uses: actions/checkout@v6
-      - name: Install deps
-        run: |
-          dnf -y install git cargo rust rpm-build copr-cli gcc make pkgconf-pkg-config \
-            pipewire-devel libinput-devel systemd-devel dbus-devel wayland-devel \
-            libxkbcommon-devel mesa-libEGL-devel pango-devel cairo-devel glib2-devel \
-            openssl-devel fontconfig-devel freetype-devel clang-devel
-          dnf -y clean all
+      - name: Install copr-cli
+        run: pip install copr-cli --quiet
+
       - name: Configure copr-cli
         if: env.COPR_CONFIG != ''
         run: |
           mkdir -p ~/.config
           printf "%s" "$COPR_CONFIG" > ~/.config/copr
           chmod 600 ~/.config/copr
-      - name: Ensure cargo-rpm
-        run: cargo install cargo-rpm --locked
-      - name: Prepare RPM packaging
-        run: |
-          if [ ! -d .rpm ]; then cargo rpm init; fi
-      - name: Build SRPM
-        run: cargo rpm build -v
-      - name: Locate SRPM
-        id: srpm
-        run: echo "path=$(ls -1 target/release/rpmbuild/SRPMS/*.src.rpm | head -n1)" >> $GITHUB_OUTPUT
+
       - name: Trigger Copr build
         if: env.COPR_CONFIG != ''
-        run: copr-cli build killcrb/ashell "${{ steps.srpm.outputs.path }}"
-      - name: List builds
-        if: env.COPR_CONFIG != ''
-        run: copr-cli list-builds killcrb/ashell
+        env:
+          CHROOTS: ${{ github.event.inputs.chroots }}
+        run: |
+          CHROOTS="${CHROOTS:-fedora-42-x86_64 fedora-42-aarch64 fedora-43-x86_64 fedora-43-aarch64 fedora-44-x86_64 fedora-44-aarch64 fedora-rawhide-x86_64 fedora-rawhide-aarch64}"
+          REF="${GITHUB_REF_NAME:-main}"
+          args=()
+          for c in $CHROOTS; do args+=( -r "$c" ); done
+          copr buildscm "${args[@]}" \
+            --clone-url https://github.com/MalpenZibo/ashell \
+            --commit "$REF" \
+            --spec .rpm/ashell.spec \
+            --method make_srpm \
+            killcrb/ashell

--- a/.rpm/ashell.spec
+++ b/.rpm/ashell.spec
@@ -1,32 +1,56 @@
-%define __spec_install_post %{nil}
-%define __os_install_post %{_dbpath}/brp-compress
-%define debug_package %{nil}
+Name:           ashell
+Version:        %{pkg_version}
+Release:        %autorelease
+Summary:        A ready to go Wayland status bar for Hyprland and Niri
 
-Name: ashell
-Summary: A ready to go Wayland status bar for Hyprland
-Version: @@VERSION@@
-Release: @@RELEASE@@%{?dist}
-License: MIT
-Group: Applications/System
-Source0: %{name}-%{version}.tar.gz
-URL: https://github.com/MalpenZibo/ashell
+SourceLicense:  MIT
+# FIXME: paste output of %%cargo_license_summary here
+License:        %{shrink:
+    MIT AND
+    TODO
+}
+# LICENSE.dependencies contains a full license breakdown
 
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+URL:            https://github.com/MalpenZibo/ashell
+Source:         %{url}/archive/v%{version}/ashell-%{version}.tar.gz
+
+BuildRequires:  cargo-rpm-macros
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  pipewire-devel
+BuildRequires:  libinput-devel
+BuildRequires:  systemd-devel
+BuildRequires:  dbus-devel
+BuildRequires:  wayland-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  mesa-libEGL-devel
+BuildRequires:  openssl-devel
+BuildRequires:  clang-devel
 
 %description
-%{summary}
+ashell is a ready to go Wayland status bar for Hyprland and Niri compositors.
+It supports multi-monitor, hot-reload configuration, theming, system tray,
+notifications, media player, and many more features.
 
 %prep
-%setup -q
+%autosetup -n ashell-%{version} -p1
+%cargo_prep
+
+%generate_buildrequires
+%cargo_generate_buildrequires
+
+%build
+%cargo_build
+%{cargo_license_summary}
+%{cargo_license} > LICENSE.dependencies
 
 %install
-rm -rf %{buildroot}
-mkdir -p %{buildroot}
-cp -a * %{buildroot}
-
-%clean
-rm -rf %{buildroot}
+install -Dpm 0755 target/rpm/ashell -t %{buildroot}%{_bindir}
 
 %files
-%defattr(-,root,root,-)
-%{_bindir}/*
+%license LICENSE
+%license LICENSE.dependencies
+%doc README.md
+%{_bindir}/ashell
+
+%changelog
+%autochangelog


### PR DESCRIPTION
## Changes

Replace the archived `cargo-rpm` tool with the actively maintained `cargo-generate-rpm`, and modernize the workflow to run faster with caching.

### Why

- `cargo-rpm` has been [archived since July 2022](https://github.com/iqlusioninc/cargo-rpm) and is no longer maintained
- `cargo-generate-rpm` is its active successor (v0.20.0, Dec 2025) — it doesn't require `rpmbuild` or a Fedora container, and reads metadata directly from `Cargo.toml`
- The Fedora container was only needed for `rpmbuild`; removing it lets us run on `ubuntu-latest` with proper Rust build caching

### What changed

- **`copr-build.yml`**: switch to `ubuntu-latest`, use `dtolnay/rust-toolchain` + `Swatinem/rust-cache`, build with `cargo build --release`, generate RPM with `cargo generate-rpm`, install `copr-cli` via pip
- **`Cargo.toml`**: add `[package.metadata.generate-rpm]` section with binary asset and runtime RPM dependencies (replaces the old `[package.metadata.rpm]` section used by `cargo-rpm`)

### Result

- No more dead tooling
- Rust dependency cache hits make subsequent builds significantly faster
- Fewer moving parts (no Fedora container, no `rpmbuild`)