### PR TITLE
ci: upgrade dorny/paths-filter v3 → v4 (node24)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Changes

Upgrade `dorny/paths-filter` from `v3` to `v4` in `ci.yml` and `nix-ci.yml`.

### Why

`v3` runs on `node20`, which is deprecated and will be forcibly removed from GitHub runners on **September 16, 2026**. `v4` (released March 2026) upgrades the runtime to `node24`.

All other actions in the repo are already on node24-compatible versions. `peaceiris/actions-mdbook` is the only remaining node20 action but has no node24 release yet — it is handled separately via `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` in the gh-pages workflow (PR #775).