### PR TITLE
Chore/upower cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,9 @@ regex = "1.12.2"
 serde_with = { version = "3.12", default-features = false, features = [
   "macros",
 ] }
-tokio-stream = { version = "0.1", default-features = false, features = ["sync"] }
+tokio-stream = { version = "0.1", default-features = false, features = [
+  "sync",
+] }
 clap = { version = "4.5", default-features = false, features = [
   "std",
   "derive",

--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -213,7 +213,7 @@ impl UpDeviceKind {
     }
 
     /// Check if this device type is a peripheral input device.
-    pub fn is_peripheral(&self) -> bool {
+    pub fn is_peripheral(self) -> bool {
         matches!(
             self,
             Self::Mouse | Self::Keyboard | Self::GamingInput | Self::Headset | Self::Headphones
@@ -221,12 +221,12 @@ impl UpDeviceKind {
     }
 
     /// Check if this device type is a system power source.
-    pub fn is_power_source(&self) -> bool {
+    pub fn is_power_source(self) -> bool {
         matches!(self, Self::Battery)
     }
 
     /// Get a human-readable description.
-    pub fn description(&self) -> &'static str {
+    pub fn description(self) -> &'static str {
         match self {
             Self::Unknown => "Unknown",
             Self::LinePower => "Line Power",

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -172,7 +172,7 @@ impl fmt::Display for PeripheralDeviceKind {
 }
 
 impl PeripheralDeviceKind {
-    pub fn get_icon(&self) -> StaticIcon {
+    pub fn get_icon(self) -> StaticIcon {
         match self {
             PeripheralDeviceKind::Keyboard => StaticIcon::Keyboard,
             PeripheralDeviceKind::Mouse => StaticIcon::Mouse,
@@ -181,7 +181,7 @@ impl PeripheralDeviceKind {
         }
     }
 
-    fn get_battery_icon(&self, level: BatLevel) -> StaticIcon {
+    fn get_battery_icon(self, level: BatLevel) -> StaticIcon {
         let icons = match self {
             PeripheralDeviceKind::Keyboard => &KEYBOARD_BATTERY_ICONS,
             PeripheralDeviceKind::Mouse => &MOUSE_BATTERY_ICONS,
@@ -460,7 +460,7 @@ impl UPowerService {
 
     async fn events(
         conn: &zbus::Connection,
-        system_battery_devices: &Option<Vec<ObjectPath<'static>>>,
+        system_battery_devices: Option<&Vec<ObjectPath<'static>>>,
         peripheral_paths: &[ObjectPath<'static>],
     ) -> anyhow::Result<impl Stream<Item = UPowerEvent> + use<>> {
         let system_battery_event = if let Some(battery_devices) = system_battery_devices {
@@ -641,12 +641,14 @@ impl UPowerService {
                     }
                 },
                 Err(err) => {
-                    error!("Failed to connect to system bus for upower: {err}",);
+                    error!("Failed to connect to system bus for upower: {err}");
                     State::Error
                 }
             },
             State::Active(conn, system_battery_paths, peripheral_paths) => {
-                match UPowerService::events(&conn, &system_battery_paths, &peripheral_paths).await {
+                match UPowerService::events(&conn, system_battery_paths.as_ref(), &peripheral_paths)
+                    .await
+                {
                     Ok(mut events) => {
                         while let Some(event) = events.next().await {
                             let _ = output.send(ServiceEvent::Update(event)).await;


### PR DESCRIPTION
**dbus.rs:**
- Changed `&self` to `self` for `is_peripheral()`, `is_power_source()`, and `description()` methods (the enum is `Copy`, so passing by value is more efficient)

**mod.rs:**
- Changed `&self` to `self` for `get_icon()` and `get_battery_icon()` methods (enum is `Copy`)
- Changed `&Option<Vec<...>>` to `Option<&Vec<...>>` for `system_battery_devices` parameter (more idiomatic)
- Removed trailing comma in error message
- Removed unused imports (`ThrottleExt`, `stream_select`)
</assistant>