### PR TITLE
feat(media_player): support configurable indicator fields

### DIFF
--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -190,7 +190,9 @@ on_click = "vpn-toggle"
 
 ```toml
 [media_player]
-format = "{artist} - {title}"
+max_title_length = 100
+indicator_format = "IconAndText" # "Text", "IconAndText", or "Icon"
+indicator_fields = ["Artist", "Title"]
 ```
 
 **Dependencies:** Any MPRIS-compatible media player (e.g., Spotify, Firefox, VLC, Strawberry). No extra system package is needed.

--- a/src/config.rs
+++ b/src/config.rs
@@ -721,8 +721,18 @@ pub struct SettingsCustomButton {
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]
 pub enum MediaPlayerFormat {
     Icon,
+    #[serde(alias = "Title")]
+    Text,
+    #[serde(alias = "IconAndTitle")]
     #[default]
-    IconAndTitle,
+    IconAndText,
+}
+
+#[derive(Deserialize, Copy, Clone, PartialEq, Eq, Debug)]
+pub enum MediaPlayerTextField {
+    Artist,
+    Title,
+    Album,
 }
 
 #[derive(Deserialize, Clone, Debug)]
@@ -731,6 +741,7 @@ pub struct MediaPlayerModuleConfig {
     pub max_title_length: u32,
     pub indicator_format: MediaPlayerFormat,
     pub show_visualizer: bool,
+    pub indicator_fields: Vec<MediaPlayerTextField>,
 }
 
 impl Default for MediaPlayerModuleConfig {
@@ -739,6 +750,7 @@ impl Default for MediaPlayerModuleConfig {
             max_title_length: 100,
             indicator_format: MediaPlayerFormat::default(),
             show_visualizer: false,
+            indicator_fields: vec![MediaPlayerTextField::Artist, MediaPlayerTextField::Title],
         }
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -2,11 +2,12 @@ use crate::{
     components::divider,
     components::icons::{StaticIcon, icon, icon_button},
     components::{ButtonSize, MenuSize},
-    config::{MediaPlayerFormat, MediaPlayerModuleConfig},
+    config::{MediaPlayerFormat, MediaPlayerModuleConfig, MediaPlayerTextField},
     services::{
         ReadOnlyService, Service, ServiceEvent,
         mpris::{
-            MprisPlayerCommand, MprisPlayerData, MprisPlayerService, PlaybackStatus, PlayerCommand,
+            MprisPlayerCommand, MprisPlayerData, MprisPlayerMetadata, MprisPlayerService,
+            PlaybackStatus, PlayerCommand,
         },
     },
     t,
@@ -390,10 +391,44 @@ impl MediaPlayer {
         }
     }
 
+    fn field_value(metadata: &MprisPlayerMetadata, field: MediaPlayerTextField) -> Option<String> {
+        match field {
+            MediaPlayerTextField::Artist => {
+                metadata.artists.as_ref().map(|artists| artists.join(", "))
+            }
+            MediaPlayerTextField::Title => metadata.title.clone(),
+            MediaPlayerTextField::Album => metadata.album.clone(),
+        }
+    }
+
+    fn format_metadata_fields(
+        metadata: Option<&MprisPlayerMetadata>,
+        fields: &[MediaPlayerTextField],
+    ) -> String {
+        let default_fields = [MediaPlayerTextField::Artist, MediaPlayerTextField::Title];
+        let fields = if fields.is_empty() {
+            &default_fields
+        } else {
+            fields
+        };
+
+        metadata.map_or_else(String::new, |metadata| {
+            fields
+                .iter()
+                .filter_map(|field| Self::field_value(metadata, *field))
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+                .join(" - ")
+        })
+    }
+
     fn get_title(&self, d: &MprisPlayerData) -> String {
-        match &d.metadata {
-            Some(m) => truncate_text(&m.to_string(), self.config.max_title_length),
-            None => t!("media-player-no-title"),
+        let title =
+            Self::format_metadata_fields(d.metadata.as_ref(), &self.config.indicator_fields);
+        if title.is_empty() {
+            t!("media-player-no-title")
+        } else {
+            truncate_text(&title, self.config.max_title_length)
         }
     }
 
@@ -401,15 +436,14 @@ impl MediaPlayer {
         let (space, font_size, palette) =
             use_theme(|theme| (theme.space, theme.font_size, theme.iced_theme.palette()));
         self.active_player().map(|player| {
-            let title =
-                (self.config.indicator_format == MediaPlayerFormat::IconAndTitle).then(|| {
-                    container(
-                        text(self.get_title(player))
-                            .wrapping(text::Wrapping::None)
-                            .size(font_size.sm),
-                    )
-                    .clip(true)
-                });
+            let title = || {
+                container(
+                    text(self.get_title(player))
+                        .wrapping(text::Wrapping::None)
+                        .size(font_size.sm),
+                )
+                .clip(true)
+            };
 
             let visualizer = (self.config.show_visualizer
                 && player.state == PlaybackStatus::Playing
@@ -430,8 +464,13 @@ impl MediaPlayer {
                 .padding(space.xxs)
             });
 
-            row![icon(StaticIcon::MusicNote)]
-                .push(title)
+            let content = match self.config.indicator_format {
+                MediaPlayerFormat::Icon => row![icon(StaticIcon::MusicNote)],
+                MediaPlayerFormat::Text => row![title()],
+                MediaPlayerFormat::IconAndText => row![icon(StaticIcon::MusicNote), title()],
+            };
+
+            content
                 .push(visualizer)
                 .align_y(Vertical::Center)
                 .spacing(space.xs)

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -87,7 +87,8 @@ alert_threshold = 85
 
 [media_player]
 # max_title_length = 100        # (default)
-# indicator_format = "IconAndTitle"  # (default) or "Icon"
+# indicator_format = "IconAndText"  # (default), "Text", or "Icon"
+# indicator_fields = ["Artist", "Title"] # (default), also supports "Album"
 
 [tray]
 # blocklist = ["regex"]    # (default: []) hide tray items matching regex patterns

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -11,15 +11,32 @@ using the `max_title_length` field (default: `100`).
 
 ### Indicator Format
 
-The tray indicator can show either the media icon alone or the icon together with
-the current title. Configure this with the `indicator_format` field:
+The tray indicator can show configured metadata text, the media icon together
+with that text, or only the media icon. Configure this with the
+`indicator_format` field:
 
 | Value          | Description                                                |
 | -------------- | ---------------------------------------------------------- |
+| `Text`         | Displays only the configured text in the status bar.       |
+| `IconAndText`  | Displays the icon followed by the text (default).          |
 | `Icon`         | Displays only the media icon in the status bar.            |
-| `IconAndTitle` | Displays the icon followed by the current title (default). |
 
 Use `Icon` if you want a compact indicator or have limited space.
+
+### Indicator Fields
+
+When `indicator_format` is `Text` or `IconAndText`, configure the metadata
+fields shown in the status bar with `indicator_fields`
+(default: `["Artist", "Title"]`).
+
+Available fields:
+
+- `Artist`
+- `Title`
+- `Album`
+
+Fields are joined with ` - `. For example, use `["Title"]` to show only the
+current song title. An empty list uses the default fields.
 
 ### Visualizer
 
@@ -59,6 +76,7 @@ The menu shows all active media players with playback controls:
 ```toml
 [media_player]
 max_title_length = 50
-indicator_format = "Icon"
+indicator_format = "Text"
+indicator_fields = ["Title"]
 show_visualizer = true
 ```


### PR DESCRIPTION

## Summary

This PR adds configurable display fields to the media player indicator, mainly to reduce the space used by long artist names or song titles.

## Changes

- Updated `indicator_format` to support:
  - `Text`: displays text only
  - `IconAndText`: displays both the icon and text
  - `Icon`: displays the icon only
- Added `indicator_fields` to configure which MPRIS metadata fields are displayed:
  - `Artist`
  - `Title`
  - `Album`
- Metadata fields are displayed in their configured order and joined with ` - `.
- Updated the media player documentation and configuration reference.
- Note: `IconAndTitle` remains supported as an alias for `IconAndText` for backward compatibility.

## Default Behavior

The default configuration preserves the existing indicator appearance:

```toml
[media_player]
indicator_format = "IconAndText"
indicator_fields = ["Artist", "Title"]
```


## Example

Display only the song title in the status bar:

```toml
[media_player]
indicator_format = "Text"
indicator_fields = ["Title"]
```

## Screenshot

With `indicator_fields = ["Title"]`, the indicator no longer displays the artist name.
<img width="708" height="96" alt="Media player indicator displaying only the song title"
src="https://github.com/user-attachments/assets/d0b3c2ed-16a9-4e1c-8d58-88a5659a103b" />