### PR TITLE
add configurable wind speed unit

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use crate::app::Message;
-use crate::i18n::UnitSystem;
+use crate::i18n::{UnitSystem, unit_system};
 use crate::services::upower::PeripheralDeviceKind;
 use crate::utils::celsius_to_fahrenheit;
 use hex_color::HexColor;
@@ -477,6 +477,46 @@ pub struct TempoModuleConfig {
     #[serde(default)]
     pub weather_location: Option<WeatherLocation>,
     pub weather_indicator: WeatherIndicator,
+    #[serde(default)]
+    pub wind_speed_unit: Option<WindSpeedUnit>,
+}
+
+impl TempoModuleConfig {
+    pub fn resolved_wind_speed_unit(&self) -> WindSpeedUnit {
+        match self.wind_speed_unit {
+            Some(unit) => unit,
+            None => match unit_system() {
+                UnitSystem::Imperial => WindSpeedUnit::Mph,
+                UnitSystem::Metric => WindSpeedUnit::Kmh,
+            },
+        }
+    }
+}
+
+#[derive(Deserialize, Default, Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum WindSpeedUnit {
+    #[default]
+    Kmh,
+    Mph,
+    Ms,
+}
+
+impl WindSpeedUnit {
+    pub fn symbol(self) -> &'static str {
+        match self {
+            Self::Kmh => "km/h",
+            Self::Mph => "mph",
+            Self::Ms => "m/s",
+        }
+    }
+
+    pub fn api_param(self) -> &'static str {
+        match self {
+            Self::Kmh => "kmh",
+            Self::Mph => "mph",
+            Self::Ms => "ms",
+        }
+    }
 }
 
 #[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
@@ -517,6 +557,7 @@ impl Default for TempoModuleConfig {
             timezones: vec![],
             weather_location: None,
             weather_indicator: WeatherIndicator::IconAndTemperature,
+            wind_speed_unit: None,
         }
     }
 }

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -32,13 +32,6 @@ impl UnitSystem {
             Self::Imperial => "°F",
         }
     }
-
-    pub fn wind_speed_symbol(self) -> &'static str {
-        match self {
-            Self::Metric => "km/h",
-            Self::Imperial => "mph",
-        }
-    }
 }
 
 pub struct Localizer {

--- a/src/modules/tempo.rs
+++ b/src/modules/tempo.rs
@@ -4,7 +4,7 @@ use crate::{
         icons::{StaticIcon, icon_button},
         styled_button,
     },
-    config::{TempoModuleConfig, WeatherIndicator, WeatherLocation},
+    config::{TempoModuleConfig, WeatherIndicator, WeatherLocation, WindSpeedUnit},
     i18n::{UnitSystem, chrono_locale, language_subtag, unit_system},
     t,
     theme::{AshellTheme, use_theme},
@@ -487,7 +487,7 @@ impl Tempo {
         let locale = chrono_locale();
         let units = unit_system();
         let temp = units.temperature_symbol();
-        let wind = units.wind_speed_symbol();
+        let wind = self.config.resolved_wind_speed_unit().symbol();
         let location_visible = self.location_visible;
         self.weather_data
             .as_ref()
@@ -803,10 +803,12 @@ impl Tempo {
         });
 
         let weather_sub = self.config.weather_location.clone().map(|location| {
-            let key = (location, unit_system(), language_subtag());
-            Subscription::run_with(key, |(location, units, lang)| {
+            let wind_unit = self.config.resolved_wind_speed_unit();
+            let key = (location, unit_system(), wind_unit, language_subtag());
+            Subscription::run_with(key, |(location, units, wind_unit, lang)| {
                 let location = location.clone();
                 let units = *units;
+                let wind_unit = *wind_unit;
                 let lang = lang.clone();
                 channel(100, async move |mut output| {
                     let mut failed_attempt: u64 = 0;
@@ -826,7 +828,7 @@ impl Tempo {
                         };
 
                         if let Some((lat, lon)) = loc {
-                            match fetch_weather_data(lat, lon, units).await {
+                            match fetch_weather_data(lat, lon, units, wind_unit).await {
                                 Ok(weather_data) => {
                                     failed_attempt = 0;
                                     debug!("Weather data fetched successfully: {:?}", weather_data);
@@ -1038,15 +1040,21 @@ pub struct Location {
     region_name: String,
 }
 
-async fn fetch_weather_data(lat: f32, lon: f32, units: UnitSystem) -> anyhow::Result<WeatherData> {
+async fn fetch_weather_data(
+    lat: f32,
+    lon: f32,
+    units: UnitSystem,
+    wind_unit: WindSpeedUnit,
+) -> anyhow::Result<WeatherData> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(20))
         .build()?;
 
-    let (temp_param, wind_param) = match units {
-        UnitSystem::Metric => ("celsius", "kmh"),
-        UnitSystem::Imperial => ("fahrenheit", "mph"),
+    let temp_param = match units {
+        UnitSystem::Metric => "celsius",
+        UnitSystem::Imperial => "fahrenheit",
     };
+    let wind_param = wind_unit.api_param();
 
     let response = client.get(format!(
         "https://api.open-meteo.com/v1/forecast?\

--- a/website/docs/configuration/modules/tempo.md
+++ b/website/docs/configuration/modules/tempo.md
@@ -27,8 +27,25 @@ forecast, and a seven-day outlook.
 | `timezones`         | `array`  | `[]`                 | Timezone identifiers that can be cycled through by scrolling. Supports both IANA names (e.g., `"UTC"`, `"America/New_York"`) and fixed offsets (e.g., `"+00:00"`, `"-05:00"`).                                                                   |
 | `weather_location`  | `enum`   | `None`               | Determines which coordinates are queried when requesting weather data. `Current` geo-locates via IP using `ip-api.com`. Use the `City` variant to pin the module to a specific place. Use `Coordinates` to specify exact latitude and longitude. |
 | `weather_indicator` | `enum`   | `IconAndTemperature` | Determines what information about the weather is shown in the bar, valid options are `None`, `Icon`, and `IconAndTemperature`.                                                                                                                   |
+| `wind_speed_unit`   | `string` | `null`               | Override wind speed unit for both display and API requests. Options: `"Kmh"`, `"Mph"`, `"Ms"`. When omitted, derives from locale (Metric → `Kmh`, Imperial → `Mph`). Temperature unit is not affected.                                           |
 
 ### City-based weather
+
+```toml
+[tempo]
+clock_format = "%a %d %b %R"
+weather_location = { City = "Rome" }
+weather_indicator = "Icon"
+```
+
+### Wind speed in m/s
+
+```toml
+[tempo]
+clock_format = "%a %d %b %R"
+weather_location = { City = "Stockholm" }
+wind_speed_unit = "Ms"
+```
 
 ```toml
 [tempo]

--- a/website/versioned_docs/version-0.8.0/configuration/modules/tempo.md
+++ b/website/versioned_docs/version-0.8.0/configuration/modules/tempo.md
@@ -27,6 +27,7 @@ forecast, and a seven-day outlook.
 | `timezones`         | `array`  | `[]`                 | Timezone identifiers that can be cycled through by scrolling. Supports both IANA names (e.g., `"UTC"`, `"America/New_York"`) and fixed offsets (e.g., `"+00:00"`, `"-05:00"`).                                                                   |
 | `weather_location`  | `enum`   | `None`               | Determines which coordinates are queried when requesting weather data. `Current` geo-locates via IP using `ip-api.com`. Use the `City` variant to pin the module to a specific place. Use `Coordinates` to specify exact latitude and longitude. |
 | `weather_indicator` | `enum`   | `IconAndTemperature` | Determines what information about the weather is shown in the bar, valid options are `None`, `Icon`, and `IconAndTemperature`.                                                                                                                   |
+| `wind_speed_unit`   | `string` | `null`               | Override wind speed unit for both display and API requests. Options: `"Kmh"`, `"Mph"`, `"Ms"`. When omitted, derives from locale (Metric → `Kmh`, Imperial → `Mph`). Temperature unit is not affected.                                           |
 
 ### City-based weather
 


### PR DESCRIPTION
@MalpenZibo 

I added the functionality to override the `wind_speed_unit` in the config.

I was not sure if you want to re-calculate the km/h to m/s internally or if you want to use the OpenMeteo's API params like I did here.

Basically, we still default to the locale-based temperature units if this is not set otherwise we override that one.
Also no clue if you want to have that in lowercase or like this.

```
[tempo]
wind_speed_unit = "Ms"
```

closes https://github.com/MalpenZibo/ashell/issues/784
