### PR TITLE
fix: suppress zbus proxy warnings for optional interfaces

### DIFF
--- a/src/services/bluetooth/dbus.rs
+++ b/src/services/bluetooth/dbus.rs
@@ -110,6 +110,7 @@ impl BluetoothDbus<'_> {
             let battery = if connected && has_battery {
                 let battery_proxy = BatteryProxy::builder(self.bluez.inner().connection())
                     .path(&device_path)?
+                    .cache_properties(zbus::proxy::CacheProperties::No)
                     .build()
                     .await?;
 
@@ -124,6 +125,7 @@ impl BluetoothDbus<'_> {
                 path: device_path,
                 connected,
                 paired,
+                has_battery,
             });
         }
 

--- a/src/services/bluetooth/mod.rs
+++ b/src/services/bluetooth/mod.rs
@@ -29,6 +29,7 @@ pub struct BluetoothDevice {
     pub path: OwnedObjectPath,
     pub connected: bool,
     pub paired: bool,
+    pub has_battery: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -120,17 +121,20 @@ impl BluetoothService {
                 for device in devices {
                     let conn = bluetooth.bluez.inner().connection();
 
-                    let battery = BatteryProxy::builder(conn)
-                        .path(device.path.clone())?
-                        .build()
-                        .await?;
-                    batteries.push(
-                        battery
-                            .receive_percentage_changed()
-                            .await
-                            .map(|_| {})
-                            .boxed(),
-                    );
+                    if device.has_battery {
+                        let battery = BatteryProxy::builder(conn)
+                            .path(device.path.clone())?
+                            .cache_properties(zbus::proxy::CacheProperties::No)
+                            .build()
+                            .await?;
+                        batteries.push(
+                            battery
+                                .receive_percentage_changed()
+                                .await
+                                .map(|_| {})
+                                .boxed(),
+                        );
+                    }
 
                     let device_proxy = DeviceProxy::builder(conn)
                         .path(device.path)?

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -359,7 +359,10 @@ impl UPowerService {
     async fn initialize_power_profile_data(
         conn: &zbus::Connection,
     ) -> anyhow::Result<PowerProfile> {
-        let powerprofiles = PowerProfilesProxy::new(conn).await?;
+        let powerprofiles = PowerProfilesProxy::builder(conn)
+            .cache_properties(zbus::proxy::CacheProperties::No)
+            .build()
+            .await?;
 
         let profile = powerprofiles
             .active_profile()
@@ -678,7 +681,10 @@ impl UPowerService {
             })
             .boxed();
 
-        let powerprofiles = PowerProfilesProxy::new(conn).await?;
+        let powerprofiles = PowerProfilesProxy::builder(conn)
+            .cache_properties(zbus::proxy::CacheProperties::No)
+            .build()
+            .await?;
         let power_profile_event =
             powerprofiles
                 .receive_active_profile_changed()
@@ -778,7 +784,11 @@ impl Service for UPowerService {
                 async move {
                     match command {
                         UPowerCommand::TogglePowerProfile => {
-                            let Some(powerprofiles) = PowerProfilesProxy::new(&conn).await.ok()
+                            let Some(powerprofiles) = PowerProfilesProxy::builder(&conn)
+                                .cache_properties(zbus::proxy::CacheProperties::No)
+                                .build()
+                                .await
+                                .ok()
                             else {
                                 return UPowerEvent::UpdatePowerProfile(power_profile);
                             };


### PR DESCRIPTION
- Add `has_battery` field to BluetoothDevice to avoid creating `BatteryProxy` for devices that don't support `org.bluez.Battery1`
- Use `CacheProperties::No` on `BatteryProxy` and `PowerProfilesProxy` to skip eager `GetAll` calls that produce warnings when services/interfaces are not available

related to https://github.com/MalpenZibo/ashell/pull/794#issuecomment-4640326723