### PR TITLE
fix(power): handle pending battery states

### DIFF
--- a/i18n/en-US/ashell.ftl
+++ b/i18n/en-US/ashell.ftl
@@ -87,6 +87,8 @@ settings-power-profile-power-saver = Power Saver
 
 settings-power-status-charging = Charging
 settings-power-status-discharging = Discharging
+settings-power-status-not-charging = Not charging
+settings-power-status-unknown = Unknown
 settings-power-status-full = Full
 
 ## Settings — idle inhibitor

--- a/i18n/fr-FR/ashell.ftl
+++ b/i18n/fr-FR/ashell.ftl
@@ -84,6 +84,8 @@ settings-power-charge-limit = Limite de charge
 settings-power-profile-balanced = Équilibré
 settings-power-profile-performance = Performance
 settings-power-profile-power-saver = Économie d'énergie
+settings-power-status-not-charging = Pas en charge
+settings-power-status-unknown = Inconnu
 
 ## Paramètres — inhibiteur de veille
 settings-idle-inhibitor = Inhibiteur de veille

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -39,6 +39,8 @@ fn format_time_for_battery(battery: &BatteryData) -> String {
                 format_duration(&duration)
             }
         }
+        BatteryStatus::NotCharging => format!("{}%", battery.capacity),
+        BatteryStatus::Unknown => String::new(),
         BatteryStatus::Full => "100%".to_string(),
     }
 }
@@ -534,12 +536,17 @@ impl PowerSettings {
                 let status_label = match battery.status {
                     BatteryStatus::Charging(_) => t!("settings-power-status-charging"),
                     BatteryStatus::Discharging(_) => t!("settings-power-status-discharging"),
+                    BatteryStatus::NotCharging => t!("settings-power-status-not-charging"),
+                    BatteryStatus::Unknown => t!("settings-power-status-unknown"),
                     BatteryStatus::Full => t!("settings-power-status-full"),
                 };
-                let details = if battery.capacity < 95 {
-                    format_time_for_battery(&battery)
-                } else {
-                    String::new()
+                let details = match battery.status {
+                    BatteryStatus::Charging(_) | BatteryStatus::Discharging(_)
+                        if battery.capacity < 95 =>
+                    {
+                        format_time_for_battery(&battery)
+                    }
+                    _ => String::new(),
                 };
                 (capacity, status_label, details)
             })

--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -50,6 +50,8 @@ impl SystemBattery {
     pub async fn state(&self) -> DeviceState {
         let mut charging = false;
         let mut discharging = false;
+        let mut pending_charge = false;
+        let mut pending_discharge = false;
         let mut fully_charged_count = 0;
         let mut total_devices = 0;
 
@@ -68,6 +70,8 @@ impl SystemBattery {
                 match state {
                     DeviceState::Charging => charging = true,
                     DeviceState::Discharging => discharging = true,
+                    DeviceState::PendingCharge => pending_charge = true,
+                    DeviceState::PendingDischarge => pending_discharge = true,
                     DeviceState::FullyCharged => fully_charged_count += 1,
                     _ => {}
                 }
@@ -86,6 +90,10 @@ impl SystemBattery {
             DeviceState::Charging
         } else if discharging {
             DeviceState::Discharging
+        } else if pending_charge {
+            DeviceState::PendingCharge
+        } else if pending_discharge {
+            DeviceState::PendingDischarge
         } else {
             DeviceState::Unknown
         }

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -106,50 +106,12 @@ impl BatteryData {
                 status: BatteryStatus::Discharging(_),
                 capacity,
                 ..
-            } if *capacity < 20 => StaticIcon::Battery0,
-            BatteryData {
-                status: BatteryStatus::Discharging(_),
-                capacity,
-                ..
-            } if *capacity < 40 => StaticIcon::Battery1,
-            BatteryData {
-                status: BatteryStatus::Discharging(_),
-                capacity,
-                ..
-            } if *capacity < 60 => StaticIcon::Battery2,
-            BatteryData {
-                status: BatteryStatus::Discharging(_),
-                capacity,
-                ..
-            } if *capacity < 80 => StaticIcon::Battery3,
-            BatteryData {
-                status: BatteryStatus::Discharging(_),
-                ..
-            } => StaticIcon::Battery4,
+            } => battery_level_icon(*capacity),
             BatteryData {
                 status: BatteryStatus::NotCharging,
                 capacity,
                 ..
-            } if *capacity < 20 => StaticIcon::Battery0,
-            BatteryData {
-                status: BatteryStatus::NotCharging,
-                capacity,
-                ..
-            } if *capacity < 40 => StaticIcon::Battery1,
-            BatteryData {
-                status: BatteryStatus::NotCharging,
-                capacity,
-                ..
-            } if *capacity < 60 => StaticIcon::Battery2,
-            BatteryData {
-                status: BatteryStatus::NotCharging,
-                capacity,
-                ..
-            } if *capacity < 80 => StaticIcon::Battery3,
-            BatteryData {
-                status: BatteryStatus::NotCharging,
-                ..
-            } => StaticIcon::Battery4,
+            } => battery_level_icon(*capacity),
             BatteryData {
                 status: BatteryStatus::Unknown,
                 ..
@@ -244,6 +206,20 @@ impl PeripheralDeviceKind {
             PeripheralDeviceKind::Gamepad => &GAMEPAD_BATTERY_ICONS,
         };
         icons[level as usize]
+    }
+}
+
+fn battery_level_icon(capacity: i64) -> StaticIcon {
+    if capacity < 20 {
+        StaticIcon::Battery0
+    } else if capacity < 40 {
+        StaticIcon::Battery1
+    } else if capacity < 60 {
+        StaticIcon::Battery2
+    } else if capacity < 80 {
+        StaticIcon::Battery3
+    } else {
+        StaticIcon::Battery4
     }
 }
 

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -112,6 +112,8 @@ impl BatteryData {
                 capacity,
                 ..
             } => battery_level_icon(*capacity),
+            // No dedicated unknown battery icon. Use Battery0 as a safe fallback
+            // instead of incorrectly showing a full battery.
             BatteryData {
                 status: BatteryStatus::Unknown,
                 ..
@@ -157,6 +159,8 @@ impl Peripheral {
                 status: BatteryStatus::Discharging(_),
                 ..
             } => get_type_icon(BatLevel::Full),
+            // Peripheral icons are coarse category/status icons.
+            // NotCharging is not active discharge, so keep the full-like state.
             BatteryData {
                 status: BatteryStatus::NotCharging | BatteryStatus::Full,
                 ..
@@ -936,7 +940,7 @@ mod tests {
     }
 
     #[test]
-    fn unknown_system_battery_uses_neutral_icon() {
+    fn unknown_system_battery_uses_empty_fallback_icon() {
         let battery = BatteryData {
             capacity: 50,
             status: BatteryStatus::Unknown,

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -81,7 +81,14 @@ impl BatteryData {
                 capacity,
                 ..
             } if *capacity < 20 => IndicatorState::Danger,
-            _ => IndicatorState::Normal,
+            BatteryData {
+                status: BatteryStatus::Discharging(_),
+                ..
+            } => IndicatorState::Normal,
+            BatteryData {
+                status: BatteryStatus::NotCharging | BatteryStatus::Unknown | BatteryStatus::Full,
+                ..
+            } => IndicatorState::Normal,
         }
     }
 
@@ -91,6 +98,10 @@ impl BatteryData {
                 status: BatteryStatus::Charging(_),
                 ..
             } => StaticIcon::BatteryCharging,
+            BatteryData {
+                status: BatteryStatus::Full,
+                ..
+            } => StaticIcon::Battery4,
             BatteryData {
                 status: BatteryStatus::Discharging(_),
                 capacity,
@@ -111,7 +122,38 @@ impl BatteryData {
                 capacity,
                 ..
             } if *capacity < 80 => StaticIcon::Battery3,
-            _ => StaticIcon::Battery4,
+            BatteryData {
+                status: BatteryStatus::Discharging(_),
+                ..
+            } => StaticIcon::Battery4,
+            BatteryData {
+                status: BatteryStatus::NotCharging,
+                capacity,
+                ..
+            } if *capacity < 20 => StaticIcon::Battery0,
+            BatteryData {
+                status: BatteryStatus::NotCharging,
+                capacity,
+                ..
+            } if *capacity < 40 => StaticIcon::Battery1,
+            BatteryData {
+                status: BatteryStatus::NotCharging,
+                capacity,
+                ..
+            } if *capacity < 60 => StaticIcon::Battery2,
+            BatteryData {
+                status: BatteryStatus::NotCharging,
+                capacity,
+                ..
+            } if *capacity < 80 => StaticIcon::Battery3,
+            BatteryData {
+                status: BatteryStatus::NotCharging,
+                ..
+            } => StaticIcon::Battery4,
+            BatteryData {
+                status: BatteryStatus::Unknown,
+                ..
+            } => StaticIcon::Battery0,
         }
     }
 }
@@ -152,11 +194,15 @@ impl Peripheral {
             BatteryData {
                 status: BatteryStatus::Discharging(_),
                 ..
-            }
-            | BatteryData {
-                status: BatteryStatus::Full,
+            } => get_type_icon(BatLevel::Full),
+            BatteryData {
+                status: BatteryStatus::NotCharging | BatteryStatus::Full,
                 ..
             } => get_type_icon(BatLevel::Full),
+            BatteryData {
+                status: BatteryStatus::Unknown,
+                ..
+            } => get_type_icon(BatLevel::Alert),
         }
     }
 }
@@ -210,10 +256,12 @@ pub enum UPowerEvent {
     UpdatePowerProfile(PowerProfile),
 }
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum BatteryStatus {
     Charging(Duration),
     Discharging(Duration),
+    NotCharging,
+    Unknown,
     Full,
 }
 
@@ -380,14 +428,15 @@ impl UPowerService {
                 let state_raw = battery.state().await;
                 let is_discharging = matches!(state_raw, dbus::DeviceState::Discharging);
                 let state = match state_raw {
-                    dbus::DeviceState::Charging => BatteryStatus::Charging(Duration::from_secs(
-                        battery.time_to_full().await as u64,
-                    )),
-                    dbus::DeviceState::Discharging => BatteryStatus::Discharging(
-                        Duration::from_secs(battery.time_to_empty().await as u64),
+                    dbus::DeviceState::Charging => battery_status_from_timed_system_state(
+                        state_raw,
+                        battery.time_to_full().await,
                     ),
-                    dbus::DeviceState::FullyCharged => BatteryStatus::Full,
-                    _ => BatteryStatus::Discharging(Duration::from_secs(0)),
+                    dbus::DeviceState::Discharging => battery_status_from_timed_system_state(
+                        state_raw,
+                        battery.time_to_empty().await,
+                    ),
+                    _ => battery_status_from_system_state(state_raw),
                 };
                 let percentage = match battery.percentage().await {
                     Ok(pct) => pct as i64,
@@ -465,7 +514,8 @@ impl UPowerService {
                     BatteryStatus::Discharging(Duration::from_secs(time_to_empty as u64))
                 }
                 4 => BatteryStatus::Full,
-                _ => BatteryStatus::Discharging(Duration::from_secs(0)),
+                5 | 6 => BatteryStatus::NotCharging,
+                _ => BatteryStatus::Unknown,
             };
             let Ok(percentage) = device.percentage().await else {
                 warn!(
@@ -761,6 +811,32 @@ impl UPowerService {
     }
 }
 
+fn battery_status_from_system_state(state: dbus::DeviceState) -> BatteryStatus {
+    match state {
+        dbus::DeviceState::Charging => BatteryStatus::Charging(Duration::ZERO),
+        dbus::DeviceState::Discharging => BatteryStatus::Discharging(Duration::ZERO),
+        dbus::DeviceState::FullyCharged => BatteryStatus::Full,
+        // PendingCharge/PendingDischarge are transitional, not active discharge.
+        // Do not show time estimates for them.
+        dbus::DeviceState::PendingCharge | dbus::DeviceState::PendingDischarge => {
+            BatteryStatus::NotCharging
+        }
+        dbus::DeviceState::Unknown | dbus::DeviceState::Empty => BatteryStatus::Unknown,
+    }
+}
+
+fn battery_status_from_timed_system_state(state: dbus::DeviceState, time: i64) -> BatteryStatus {
+    match state {
+        dbus::DeviceState::Charging => {
+            BatteryStatus::Charging(Duration::from_secs(time.try_into().unwrap_or_default()))
+        }
+        dbus::DeviceState::Discharging => {
+            BatteryStatus::Discharging(Duration::from_secs(time.try_into().unwrap_or_default()))
+        }
+        _ => battery_status_from_system_state(state),
+    }
+}
+
 pub enum UPowerCommand {
     TogglePowerProfile,
     ToggleChargeLimit,
@@ -844,5 +920,91 @@ impl Service for UPowerService {
             },
             ServiceEvent::Update,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        BatteryData, BatteryStatus, StaticIcon, battery_status_from_system_state,
+        battery_status_from_timed_system_state, dbus,
+    };
+    use std::time::Duration;
+
+    #[test]
+    fn pending_charge_is_not_mapped_to_discharging() {
+        assert_eq!(
+            battery_status_from_system_state(dbus::DeviceState::PendingCharge),
+            BatteryStatus::NotCharging
+        );
+    }
+
+    #[test]
+    fn pending_discharge_is_not_mapped_to_discharging() {
+        assert_eq!(
+            battery_status_from_system_state(dbus::DeviceState::PendingDischarge),
+            BatteryStatus::NotCharging
+        );
+    }
+
+    #[test]
+    fn unknown_and_empty_map_to_unknown() {
+        assert_eq!(
+            battery_status_from_system_state(dbus::DeviceState::Unknown),
+            BatteryStatus::Unknown
+        );
+        assert_eq!(
+            battery_status_from_system_state(dbus::DeviceState::Empty),
+            BatteryStatus::Unknown
+        );
+    }
+
+    #[test]
+    fn unknown_system_battery_uses_neutral_icon() {
+        let battery = BatteryData {
+            capacity: 50,
+            status: BatteryStatus::Unknown,
+            is_discharging: false,
+        };
+
+        assert!(matches!(battery.get_icon(), StaticIcon::Battery0));
+    }
+
+    #[test]
+    fn full_system_battery_uses_full_icon_even_low_capacity() {
+        let battery = BatteryData {
+            capacity: 10,
+            status: BatteryStatus::Full,
+            is_discharging: false,
+        };
+
+        assert!(matches!(battery.get_icon(), StaticIcon::Battery4));
+    }
+
+    #[test]
+    fn not_charging_system_battery_keeps_capacity_icon() {
+        let battery = BatteryData {
+            capacity: 10,
+            status: BatteryStatus::NotCharging,
+            is_discharging: false,
+        };
+
+        assert!(matches!(battery.get_icon(), StaticIcon::Battery0));
+    }
+
+    #[test]
+    fn normal_system_battery_states_keep_time_semantics() {
+        assert_eq!(
+            battery_status_from_timed_system_state(dbus::DeviceState::Charging, 120),
+            BatteryStatus::Charging(Duration::from_secs(120))
+        );
+        assert_eq!(
+            battery_status_from_timed_system_state(dbus::DeviceState::Discharging, 240),
+            BatteryStatus::Discharging(Duration::from_secs(240))
+        );
+        assert_eq!(
+            battery_status_from_system_state(dbus::DeviceState::FullyCharged),
+            BatteryStatus::Full
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a follow-up from #779 where batteries held by charge limit could still show as `Discharging` with `Calculating...` in the power tooltip.

UPower may report this held state as `PendingCharge` / `PendingDischarge`. These states are now handled explicitly as `NotCharging` instead of falling back to fake `Discharging(0)`.

## Improvements

- Shows `Not charging` instead of misleading `Discharging` for charge-limit held batteries.
- Removes fake `Calculating...` ETA for states that are not actively charging or discharging.
- Adds explicit handling for `PendingCharge`, `PendingDischarge`, `Unknown`, and `Empty`.
- Keeps low-battery danger styling limited to real discharging batteries.
- Keeps #779 top-bar charge-limit icon behavior unchanged.
- Adds regression tests for pending, unknown, timed, and icon fallback behavior.

## Behavior changes

| Scenario | Before | After |
|---|---|---|
| Charge-limit held battery | `Discharging` + `Calculating...` | `Not charging`, no ETA |
| `PendingCharge` / `PendingDischarge` | `Discharging(0)` | `NotCharging` |
| `Unknown` / `Empty` | `Discharging(0)` | `Unknown` |
| Low-battery danger | Could apply to fallback discharging states | Only applies to real `Discharging` |
| Charging / Discharging / Full | Existing behavior | Unchanged |
| #779 top-bar charge-limit icon | Existing behavior | Unchanged |

## Validation

- [x] `cargo fmt`
- [x] `cargo test`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `make check`

## Screenshots

### Before
<img width="553" height="95" alt="screenshot_2569-06-08_15-40-26" src="https://github.com/user-attachments/assets/86d4ad83-db03-48df-8804-6f5e38eedb6b" />

### After
<img width="258" height="105" alt="screenshot_2569-06-08_16-27-16" src="https://github.com/user-attachments/assets/8dfc90f6-e1de-49b2-8a8e-78f66d72b753" />