### PR TITLE
remove clip from module item to fix cropped icon

### DIFF
--- a/src/components/module_item.rs
+++ b/src/components/module_item.rs
@@ -65,8 +65,7 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
             let mut button = position_button(
                 container(item.content)
                     .align_y(Alignment::Center)
-                    .height(Length::Fill)
-                    .clip(true),
+                    .height(Length::Fill),
             )
             .padding([2.0, space.xs])
             .height(Length::Fill)
@@ -94,7 +93,6 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
                 .padding([2.0, space.xs])
                 .height(Length::Fill)
                 .align_y(Alignment::Center)
-                .clip(true)
                 .into()
         }
     }


### PR DESCRIPTION
Removing `.clip(true)` from module item containers prevents icons from being cropped when they extend beyond element bounds.

Before
<img width="60" height="39" alt="image" src="https://github.com/user-attachments/assets/1d2b5f33-8989-4800-a032-91656cba2eb1" />
After
<img width="61" height="35" alt="image" src="https://github.com/user-attachments/assets/b95e9b05-4a3d-4f61-b38b-68fb6b4d0fb3" />

With `vk` and `gl` renderer 
with `ICED_BACKEND=tiny-skia` is always renders fine on my machine.

sorry for the small screenshots.

closes https://github.com/MalpenZibo/ashell/issues/571