### PR TITLE
add troubleshooting guide for hybrid graphics display issues

### DIFF
--- a/website/docs/configuration/troubleshooting.md
+++ b/website/docs/configuration/troubleshooting.md
@@ -43,6 +43,27 @@ You can use a single value or a comma-separated list (e.g. `WGPU_BACKEND=gl,vulk
 
 **If the issue persists:** Try forcing a different backend or using `ICED_BACKEND=tiny-skia`.
 
+### Hybrid / Multi-GPU: Black Bar or Missing Bar on External Monitor
+
+**Problem:** ashell renders a black bar, or the bar doesn't appear on all monitors. Common on laptops with hybrid graphics (e.g. NVIDIA dGPU + iGPU) or when an external monitor is connected to a different GPU.
+
+**Cause:** By default, `iced_layershell` sets `WGPU_POWER_PREF=low`, which tells wgpu to prefer the integrated GPU. On hybrid setups, the iGPU may not be connected to all outputs, for example, an external monitor wired to the NVIDIA dGPU won't receive frames rendered on the iGPU. The result is a black bar or a bar that only appears on one screen.
+
+**Solution:** Force the discrete GPU with:
+```bash
+WGPU_POWER_PREF=high ashell
+```
+
+To make it permanent, add to your compositor config. For Hyprland, in `hyprland.conf`:
+```
+env = WGPU_POWER_PREF,high
+```
+
+**Note:** `WGPU_POWER_PREF` is a regular process-level environment variable. Using Hyprland's `env =` propagates it to all wgpu-based applications (browsers, games, etc.), not just ashell. To limit it to ashell only, use `exec-once` instead:
+```
+exec-once = env WGPU_POWER_PREF=high ashell
+```
+
 ## Idle Inhibitor Issues
 
 **Problem:** Screen sleeps even when ashell is running.


### PR DESCRIPTION
Adds documentation for resolving black bars or missing bars on external
monitors in hybrid graphics setups. Explains `WGPU_POWER_PREF` environment
variable configuration for proper GPU selection.

related to https://github.com/MalpenZibo/ashell/issues/739