### PR TITLE
workspaces: compare monitor names by equality, not substring

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -482,7 +482,16 @@ impl App {
             Message::OutputEvent(event) => match event {
                 OutputEvent::Added(info) => {
                     info!("Output created: {info:?}");
-                    let name = &format!("{} {} {}", info.name, info.make, info.model);
+                    // Use just the canonical output name as the layer-shell
+                    // surface key. The workspace visibility filter compares
+                    // this against `w.monitor` (also a canonical name from
+                    // the compositor), so the two sides must agree on
+                    // shape. Concatenating make/model worked on Hyprland
+                    // (whose `w.monitor` happens to be the canonical name)
+                    // but broke on Niri (where the filter then never
+                    // matched any workspaces because the stored key was
+                    // "eDP-1 Make Model" vs an incoming "eDP-1").
+                    let name = info.name.as_str();
 
                     if let Some((_, h)) = info.logical_size {
                         self.outputs.set_output_logical_height(info.id, h as u32);

--- a/src/app.rs
+++ b/src/app.rs
@@ -482,16 +482,16 @@ impl App {
             Message::OutputEvent(event) => match event {
                 OutputEvent::Added(info) => {
                     info!("Output created: {info:?}");
-                    // Use just the canonical output name as the layer-shell
-                    // surface key. The workspace visibility filter compares
-                    // this against `w.monitor` (also a canonical name from
-                    // the compositor), so the two sides must agree on
-                    // shape. Concatenating make/model worked on Hyprland
-                    // (whose `w.monitor` happens to be the canonical name)
-                    // but broke on Niri (where the filter then never
-                    // matched any workspaces because the stored key was
-                    // "eDP-1 Make Model" vs an incoming "eDP-1").
+                    // Pass both the canonical name and the full EDID
+                    // description down to Outputs::add. The workspace
+                    // visibility filter compares against just the
+                    // canonical `info.name` (matches `w.monitor` from
+                    // the compositor); name_in_config / has_name keep
+                    // matching against the concatenated description
+                    // too so #312's fuzzy-EDID-alias config behaviour
+                    // is preserved.
                     let name = info.name.as_str();
+                    let description = format!("{} {} {}", info.name, info.make, info.model);
 
                     if let Some((_, h)) = info.logical_size {
                         self.outputs.set_output_logical_height(info.id, h as u32);
@@ -505,6 +505,7 @@ impl App {
                         bar_position,
                         self.general_config.layer,
                         name,
+                        &description,
                         info.id,
                         scale_factor,
                     )

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -440,17 +440,24 @@ impl Workspaces {
                 self.ui_workspaces
                     .iter()
                     .filter_map(|w| {
+                        // Compare canonical compositor names by equality, not
+                        // substring containment. Both `monitor_name` (the
+                        // bar's surface output) and `w.monitor` (the workspace's
+                        // home output) come from the compositor as canonical
+                        // names, so equality is the correct relation. Using
+                        // `.contains()` falsely matches any pair where one
+                        // name is a substring of the other — most commonly
+                        // `eDP-1` vs `DP-1`, causing the laptop bar to leak
+                        // the external monitor's workspaces in and stop
+                        // tracking its own focused workspace.
+                        let monitor_matches =
+                            monitor_name.is_none_or(|n| n == w.monitor.as_str());
                         let show = match self.config.visibility_mode {
                             WorkspaceVisibilityMode::All => true,
                             WorkspaceVisibilityMode::MonitorSpecific => {
-                                monitor_name
-                                    .unwrap_or_else(|| &w.monitor)
-                                    .contains(&w.monitor)
-                                    || !outputs.has_name(&w.monitor)
+                                monitor_matches || !outputs.has_name(&w.monitor)
                             }
-                            WorkspaceVisibilityMode::MonitorSpecificExclusive => monitor_name
-                                .unwrap_or_else(|| &w.monitor)
-                                .contains(&w.monitor),
+                            WorkspaceVisibilityMode::MonitorSpecificExclusive => monitor_matches,
                         };
 
                         if show {

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -450,8 +450,7 @@ impl Workspaces {
                         // `eDP-1` vs `DP-1`, causing the laptop bar to leak
                         // the external monitor's workspaces in and stop
                         // tracking its own focused workspace.
-                        let monitor_matches =
-                            monitor_name.is_none_or(|n| n == w.monitor.as_str());
+                        let monitor_matches = monitor_name.is_none_or(|n| n == w.monitor.as_str());
                         let show = match self.config.visibility_mode {
                             WorkspaceVisibilityMode::All => true,
                             WorkspaceVisibilityMode::MonitorSpecific => {

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -64,9 +64,22 @@ impl OverlaySurface {
     }
 }
 
+/// Pair of strings identifying an output. `name` is the canonical
+/// short name reported by the compositor (e.g. `eDP-1`) — used for
+/// equality checks against workspace events. `description` includes
+/// the EDID (e.g. `eDP-1 Make Model Serial`) — used for the fuzzy
+/// substring matching in `name_in_config` / `has_name` so users can
+/// alias outputs by any string that appears in the EDID (the
+/// behaviour added by #312).
+#[derive(Debug, Clone)]
+pub struct OutputKey {
+    pub name: String,
+    pub description: String,
+}
+
 #[derive(Debug, Clone)]
 pub struct Outputs {
-    entries: Vec<(String, Option<ShellInfo>, Option<OutputId>)>,
+    entries: Vec<(OutputKey, Option<ShellInfo>, Option<OutputId>)>,
     toast: Option<OverlaySurface>,
     osd: Option<OverlaySurface>,
     /// Last toast input-region request, replayed once the toast's output is
@@ -82,7 +95,7 @@ pub enum HasOutput<'a> {
 }
 
 impl Outputs {
-    pub fn iter(&self) -> std::slice::Iter<'_, (String, Option<ShellInfo>, Option<OutputId>)> {
+    pub fn iter(&self) -> std::slice::Iter<'_, (OutputKey, Option<ShellInfo>, Option<OutputId>)> {
         self.entries.iter()
     }
 
@@ -157,13 +170,23 @@ impl Outputs {
         (id, main_task)
     }
 
-    fn name_in_config(name: &str, outputs: &config::Outputs) -> bool {
+    /// Match a user-supplied output spec against an output's name +
+    /// description pair. Returns true when:
+    ///   - the spec equals the canonical name (`info.name`), OR
+    ///   - the spec appears anywhere in the description (`info.name +
+    ///     info.make + info.model`), preserving #312's fuzzy alias
+    ///     matching by EDID substring.
+    fn matches_spec(name: &str, description: &str, spec: &str) -> bool {
+        name == spec || description.contains(spec)
+    }
+
+    fn name_in_config(name: &str, description: &str, outputs: &config::Outputs) -> bool {
         match outputs {
             config::Outputs::All => true,
             config::Outputs::Active => false,
-            config::Outputs::Targets(request_outputs) => {
-                request_outputs.iter().any(|output| name.contains(output))
-            }
+            config::Outputs::Targets(request_outputs) => request_outputs
+                .iter()
+                .any(|spec| Self::matches_spec(name, description, spec)),
         }
     }
 
@@ -187,11 +210,13 @@ impl Outputs {
         })
     }
 
+    /// Returns the canonical short name (e.g. `eDP-1`) — used by the
+    /// workspace visibility filter which compares against `w.monitor`.
     pub fn get_monitor_name(&self, id: SurfaceId) -> Option<&str> {
-        self.entries.iter().find_map(|(name, info, _)| {
+        self.entries.iter().find_map(|(key, info, _)| {
             info.as_ref().and_then(|info| {
                 if info.id == id {
-                    Some(name.as_str())
+                    Some(key.name.as_str())
                 } else {
                     None
                 }
@@ -200,9 +225,11 @@ impl Outputs {
     }
 
     pub fn has_name(&self, name: &str) -> bool {
-        self.entries
-            .iter()
-            .any(|(n, info, _)| info.is_some() && n.as_str().contains(name))
+        // Match by canonical name (equality) OR description (substring,
+        // to preserve #312's EDID-alias behaviour).
+        self.entries.iter().any(|(key, info, _)| {
+            info.is_some() && Self::matches_spec(&key.name, &key.description, name)
+        })
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -213,10 +240,11 @@ impl Outputs {
         position: Position,
         layer: config::Layer,
         name: &str,
+        description: &str,
         output_id: OutputId,
         scale_factor: f64,
     ) -> Task<Message> {
-        let target = Self::name_in_config(name, request_outputs);
+        let target = Self::name_in_config(name, description, request_outputs);
 
         if target {
             debug!("Found target output, creating a new layer surface");
@@ -224,10 +252,14 @@ impl Outputs {
             let (id, task) =
                 Self::create_output_layers(style, Some(output_id), position, layer, scale_factor);
 
+            // Replace an existing entry with the same canonical name
+            // (e.g. monitor was reconnected). Description-match is
+            // intentionally NOT used here — replacement is identity-
+            // based, not alias-based.
             let destroy_task = match self
                 .entries
                 .iter()
-                .position(|(key, _, _)| key.as_str() == name)
+                .position(|(key, _, _)| key.name.as_str() == name)
             {
                 Some(index) => {
                     let old_output = self.entries.swap_remove(index);
@@ -241,7 +273,10 @@ impl Outputs {
             };
 
             self.entries.push((
-                name.to_owned(),
+                OutputKey {
+                    name: name.to_owned(),
+                    description: description.to_owned(),
+                },
                 Some(ShellInfo {
                     id,
                     menu: Menu::new(),
@@ -278,7 +313,14 @@ impl Outputs {
                 name, request_outputs
             );
 
-            self.entries.push((name.to_owned(), None, Some(output_id)));
+            self.entries.push((
+                OutputKey {
+                    name: name.to_owned(),
+                    description: description.to_owned(),
+                },
+                None,
+                Some(output_id),
+            ));
 
             Task::none()
         }
@@ -327,7 +369,10 @@ impl Outputs {
                         Self::create_output_layers(style, None, position, layer, scale_factor);
 
                     self.entries.push((
-                        "Fallback".to_string(),
+                        OutputKey {
+                            name: "Fallback".to_string(),
+                            description: String::new(),
+                        },
                         Some(ShellInfo {
                             id,
                             menu: Menu::new(),
@@ -360,8 +405,10 @@ impl Outputs {
         let to_remove = self
             .entries
             .iter()
-            .filter_map(|(name, shell_info, output_id)| {
-                if !Self::name_in_config(name, request_outputs) && shell_info.is_some() {
+            .filter_map(|(key, shell_info, output_id)| {
+                if !Self::name_in_config(&key.name, &key.description, request_outputs)
+                    && shell_info.is_some()
+                {
                     *output_id
                 } else {
                     None
@@ -373,9 +420,11 @@ impl Outputs {
         let to_add = self
             .entries
             .iter()
-            .filter_map(|(name, shell_info, output_id)| {
-                if Self::name_in_config(name, request_outputs) && shell_info.is_none() {
-                    Some((name.clone(), *output_id))
+            .filter_map(|(key, shell_info, output_id)| {
+                if Self::name_in_config(&key.name, &key.description, request_outputs)
+                    && shell_info.is_none()
+                {
+                    Some((key.clone(), *output_id))
                 } else {
                     None
                 }
@@ -385,14 +434,15 @@ impl Outputs {
 
         let mut tasks = Vec::new();
 
-        for (name, output_id) in to_add {
+        for (key, output_id) in to_add {
             if let Some(output_id) = output_id {
                 tasks.push(self.add(
                     style,
                     request_outputs,
                     position,
                     layer,
-                    name.as_str(),
+                    key.name.as_str(),
+                    key.description.as_str(),
                     output_id,
                     scale_factor,
                 ));

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -224,12 +224,16 @@ impl Outputs {
         })
     }
 
+    /// Strict canonical-name equality. Called by the workspace
+    /// visibility filter with `w.monitor` (a compositor-canonical
+    /// output name), where the substring fuzz used by `name_in_config`
+    /// would re-introduce the very false-match bug this PR fixed
+    /// (e.g. an event for `DP-1` matching an output whose description
+    /// contains `"DP-1"` as a substring).
     pub fn has_name(&self, name: &str) -> bool {
-        // Match by canonical name (equality) OR description (substring,
-        // to preserve #312's EDID-alias behaviour).
-        self.entries.iter().any(|(key, info, _)| {
-            info.is_some() && Self::matches_spec(&key.name, &key.description, name)
-        })
+        self.entries
+            .iter()
+            .any(|(key, info, _)| info.is_some() && key.name == name)
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -66,11 +66,12 @@ impl OverlaySurface {
 
 /// Pair of strings identifying an output. `name` is the canonical
 /// short name reported by the compositor (e.g. `eDP-1`) — used for
-/// equality checks against workspace events. `description` includes
-/// the EDID (e.g. `eDP-1 Make Model Serial`) — used for the fuzzy
-/// substring matching in `name_in_config` / `has_name` so users can
-/// alias outputs by any string that appears in the EDID (the
-/// behaviour added by #312).
+/// strict equality checks against workspace events (`has_name`) and
+/// as the layer-shell surface key. `description` includes the EDID
+/// (e.g. `eDP-1 Make Model Serial`) — used only for the fuzzy
+/// substring matching in `name_in_config`, so users can alias
+/// outputs by any string that appears in the EDID (the behaviour
+/// added by #312).
 #[derive(Debug, Clone)]
 pub struct OutputKey {
     pub name: String,

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -111,7 +111,10 @@ impl Outputs {
         // on demand when a menu is opened.
         Self {
             entries: vec![(
-                "Fallback".to_string(),
+                OutputKey {
+                    name: "Fallback".to_string(),
+                    description: String::new(),
+                },
                 Some(ShellInfo {
                     id: SurfaceId::MAIN,
                     menu: Menu::new(),
@@ -530,7 +533,7 @@ impl Outputs {
     fn find_by_surface_id(
         &self,
         id: SurfaceId,
-    ) -> Option<&(String, Option<ShellInfo>, Option<OutputId>)> {
+    ) -> Option<&(OutputKey, Option<ShellInfo>, Option<OutputId>)> {
         self.entries.iter().find(|(_, shell_info, _)| {
             shell_info
                 .as_ref()
@@ -541,7 +544,7 @@ impl Outputs {
     fn find_by_surface_id_mut(
         &mut self,
         id: SurfaceId,
-    ) -> Option<&mut (String, Option<ShellInfo>, Option<OutputId>)> {
+    ) -> Option<&mut (OutputKey, Option<ShellInfo>, Option<OutputId>)> {
         self.entries.iter_mut().find(|(_, shell_info, _)| {
             shell_info
                 .as_ref()


### PR DESCRIPTION
Fixes #804.

### What this changes

`WorkspaceVisibilityMode::MonitorSpecific` and `MonitorSpecificExclusive` compared `monitor_name.contains(&w.monitor)` instead of `monitor_name == w.monitor`. The substring form falsely matches any pair where one canonical name is a substring of the other (`eDP-1`/`DP-1` being the common case for laptops with a docked DisplayPort monitor).

This PR restores equality. Both sides of the comparison are canonical compositor output names by the time they reach this filter, so equality is the correct relation.

### Why not just keep `.contains()`?

#331 introduced `.contains()` to fix #325, which was a regression from #312's fuzzy output-name matching. But the fuzzy matching belongs in the config→output resolution path — once `w.monitor` and `monitor_name` are populated from compositor events, they're already canonical names. Filtering them with substring semantics ends up matching pairs the user never asked to alias.

If a future change re-introduces a config-side alias that doesn't get resolved before this filter sees it, a dedicated alias-resolution step (rather than blanket substring matching) is the right place to handle it.

### Repro for verification

Any host with two outputs whose names are substring-overlapping (`eDP-1` + `DP-1`, `HDMI-1` + `DMI-1`, etc.) and `visibility_mode = "MonitorSpecific"`. Before this patch, the bar on the *longer* name's monitor shows the other monitor's workspaces and stops tracking its own focused workspace. After this patch, each bar renders only its own monitor's workspaces.
