### PR TITLE
support multiline JSON output in custom module

### DIFF
--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -214,7 +214,15 @@ impl Custom {
                                                 );
                                             }
                                         }
-                                        Err(e) if e.is_eof() => {}
+                                        Err(e) if e.is_eof() => {
+                                            if buf.len() > 1 << 20 {
+                                                warn!(
+                                                    "custom module '{name}': dropping {} bytes of unterminated JSON",
+                                                    buf.len()
+                                                );
+                                                buf.clear();
+                                            }
+                                        }
                                         Err(e) => {
                                             error!(
                                                 "Failed to parse JSON for custom module '{name}': {e} (payload: {buf})"

--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -189,6 +189,7 @@ impl Custom {
                         Ok(mut child) => {
                             if let Some(stdout) = child.stdout.take() {
                                 let mut reader = BufReader::new(stdout).lines();
+                                let mut buf = String::new();
 
                                 // Ensure the child process is spawned in the runtime so it can
                                 // make progress on its own while we await for any output.
@@ -200,8 +201,11 @@ impl Custom {
                                 });
 
                                 while let Some(line) = reader.next_line().await.ok().flatten() {
-                                    match serde_json::from_str(&line) {
+                                    buf.push_str(&line);
+                                    buf.push('\n');
+                                    match serde_json::from_str::<CustomListenData>(&buf) {
                                         Ok(event) => {
+                                            buf.clear();
                                             if let Err(e) = output
                                                 .try_send((name.clone(), Message::Update(event)))
                                             {
@@ -210,10 +214,12 @@ impl Custom {
                                                 );
                                             }
                                         }
+                                        Err(e) if e.is_eof() => {}
                                         Err(e) => {
                                             error!(
-                                                "Failed to parse JSON for custom module '{name}': {e} (payload: {line})"
+                                                "Failed to parse JSON for custom module '{name}': {e} (payload: {buf})"
                                             );
+                                            buf.clear();
                                         }
                                     }
                                 }

--- a/website/docs/configuration/modules/custom_module.md
+++ b/website/docs/configuration/modules/custom_module.md
@@ -97,6 +97,14 @@ Or you can output pretty-printed multiline JSON directly, which is buffered unti
 }
 ```
 
+:::warning Multiline JSON Buffer Limit
+
+When using pretty-printed (multiline) JSON, output is accumulated in an internal buffer until a complete, parseable JSON object is received. As a safeguard against malformed output, for example a script that opens a `{` and never closes it, the buffer is capped at **1 MiB**. If that limit is exceeded, the buffered bytes are dropped, a warning is logged, and the buffer is cleared.
+
+This limit only applies while buffering multiline JSON. Single-line (compact) JSON output is unaffected since each line is parsed independently.
+
+:::
+
 See the configuration examples below for multiline usage.
 
 :::
@@ -146,10 +154,16 @@ Text modules display only the text output from `listen_cmd` without any click ac
 [[CustomModule]]
 name = "MyClock"
 type = "Text"
-listen_cmd = '''sh -c 'while true; do
-  printf '{"text": "%s", "alt": ""}\n' "$(date +"%H:%M")"
+listen_cmd = '''
+while true; do
+  cat <<EOF
+{
+  "text": "$(date +'%H:%M')",
+  "alt": ""
+}
+EOF
   sleep 1
-done'
+done
 '''
 ```
 

--- a/website/docs/configuration/modules/custom_module.md
+++ b/website/docs/configuration/modules/custom_module.md
@@ -64,26 +64,22 @@ The `listen_cmd` should output JSON in
 the [Waybar format](https://github.com/Alexays/Waybar/wiki/Module:-Custom#script-output),
 using `text` and `alt` fields.
 
-:::warning JSON must be compact (single-line)
+:::tip JSON Output
 
-The `listen_cmd` output is read line-by-line and each line is parsed as JSON.
-**Pretty-printed JSON will not work** because each line would be parsed separately.
+Output compact single-line JSON:
 
-Always output compact JSON, or pipe through `jq -c --unbuffered .` to compact it:
+```json
+{"text": "3", "alt": "notification"}
+```
+
+If you have pretty-printed JSON and want to use it in a single line, pipe it through `jq` to compact it:
 
 ```bash
 your-command | jq -c --unbuffered .
 ```
 
-For example, this pretty-printed JSON:
-```json
-{
-  "text": "3",
-  "alt": "notification"
-}
-```
+For example:
 
-Can be converted to compact format with:
 ```bash
 echo '{
   "text": "3",
@@ -92,9 +88,20 @@ echo '{
 # Output: {"text":"3","alt":"notification"}
 ```
 
+Or you can output pretty-printed multiline JSON directly, which is buffered until valid JSON is formed:
+
+```json
+{
+  "text": "3",
+  "alt": "notification"
+}
+```
+
+See the configuration examples below for multiline usage.
+
 :::
 
-### Example Output (compact JSON)
+### Example Output
 
 ```json
 {"text": "3", "alt": "notification"}
@@ -139,7 +146,11 @@ Text modules display only the text output from `listen_cmd` without any click ac
 [[CustomModule]]
 name = "MyClock"
 type = "Text"
-listen_cmd = "sh -c 'while true; do echo \"{\\\"text\\\": \\\"$(date +\"%H:%M\")\\\", \\\"alt\\\": \\\"\\\"}\"; sleep 1; done'"
+listen_cmd = '''sh -c 'while true; do
+  printf '{"text": "%s", "alt": ""}\n' "$(date +"%H:%M")"
+  sleep 1
+done'
+'''
 ```
 
 ### Button Module with Icon (Interactive)
@@ -169,14 +180,19 @@ command = "walker"
 
 ### Button Module with Text Output
 
-Button modules can also display text output from `listen_cmd` with a click action:
+Button modules can display text from a multiline JSON output from `listen_cmd` with a click action:
 
 ```toml
 [[CustomModule]]
 name = "Clipboard"
 type = "Button"
+icon = "📋"
 command = "cliphist-rofi-img | wl-copy"
-listen_cmd = "echo '{\"text\": \"📋\", \"alt\": \"\"}'"
+listen_cmd = '''printf '%s\n' '{
+  "text": "Clipboard content",
+  "alt": ""
+}'
+'''
 ```
 
 ### Notifications (with wired)


### PR DESCRIPTION
based on @MalpenZibo proposal

Previously, the custom module only supported compact single-line JSON
output from `listen_cmd`, requiring each line to be valid JSON. This change
adds buffering support so that multiline/pretty-printed JSON can be used
directly without piping through `jq`.

The implementation accumulates lines in a buffer and attempts to parse
the complete JSON, handling EOF errors gracefully until valid JSON is
formed. This improves usability for scripts that output formatted JSON.

Updated documentation to reflect the new multiline JSON support with
examples showing both compact and pretty-printed output formats.

closes #618