### PR TITLE
warn and auto-select weight when font_name has no Normal(400) face

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,6 +144,7 @@ dependencies = [
  "chrono-tz",
  "clap",
  "flexi_logger",
+ "fontdb",
  "freedesktop-icons",
  "hex_color",
  "hyprland",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ url = "2.5.7"
 signal-hook = "0.4.3"
 signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
 libc = "0.2.182"
+fontdb = { version = "0.23", features = ["fontconfig"] }
 chrono-tz = "0.10.4"
 wayland-client = "0.31"
 wayland-protocols = { version = "0.32", features = ["client", "staging"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,7 @@ url = "2.5.7"
 signal-hook = "0.4.3"
 signal-hook-tokio = { version = "0.4", features = ["futures-v0_3"] }
 libc = "0.2.182"
+# keep in sync with the fontdb version pulled transitively by iced_layershell
 fontdb = { version = "0.23", features = ["fontconfig"] }
 chrono-tz = "0.10.4"
 wayland-client = "0.31"

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,10 @@ use clap::Parser;
 use flexi_logger::{
     Age, Cleanup, Criterion, FileSpec, LogSpecBuilder, LogSpecification, Logger, Naming,
 };
-use iced::{Anchor, Font, KeyboardInteractivity, Layer, LayerShellSettings};
+use iced::{
+    Anchor, Font, KeyboardInteractivity, Layer, LayerShellSettings,
+    font::{Style as FontStyle, Weight as FontWeight},
+};
 use log::{debug, error, warn};
 use std::backtrace::Backtrace;
 use std::env;
@@ -68,6 +71,98 @@ fn get_log_spec(log_level: &str) -> LogSpecification {
     }
 }
 
+fn fontdb_weight_to_iced(weight: fontdb::Weight) -> FontWeight {
+    // Map fontdb::Weight to iced::font::Weight.
+    // fontdb uses numeric values (100..=1000); iced uses named variants.
+    let numeric_weight = weight.0;
+    if numeric_weight <= 150 {
+        FontWeight::Thin
+    } else if numeric_weight <= 250 {
+        FontWeight::ExtraLight
+    } else if numeric_weight <= 350 {
+        FontWeight::Light
+    } else if numeric_weight <= 450 {
+        FontWeight::Normal
+    } else if numeric_weight <= 550 {
+        FontWeight::Medium
+    } else if numeric_weight <= 650 {
+        FontWeight::Semibold
+    } else if numeric_weight <= 750 {
+        FontWeight::Bold
+    } else if numeric_weight <= 850 {
+        FontWeight::ExtraBold
+    } else {
+        FontWeight::Black
+    }
+}
+
+fn resolve_font(name: &str) -> Font {
+    let mut db = fontdb::Database::new();
+    db.load_system_fonts();
+
+    // Find the best matching face for the requested Normal/Normal/Normal.
+    // cosmic-text's font matcher re-scores all faces and prefers a face whose
+    // weight/stretch/style are closest to the requested ones. So if the user
+    // asks for `Weight::Normal` (400) but the font only has a face with
+    // weight=500 (Medium), the matcher will prefer a different font with
+    // weight=400 — a silent fallback. To work around this, we detect the
+    // closest available face in the requested family and pass its actual
+    // weight to iced so the matcher's scoring keeps us on the right font.
+    let best_face = db
+        .faces()
+        .filter(|f| f.families.iter().any(|(fam, _)| fam == name))
+        .min_by_key(|f| {
+            // Score: prefer Normal style/stretch, then closest weight to 400.
+            let style_penalty = if f.style == fontdb::Style::Normal {
+                0
+            } else {
+                100
+            };
+            let stretch_penalty = if f.stretch == fontdb::Stretch::Normal {
+                0
+            } else {
+                100
+            };
+            let weight_penalty = f.weight.0.abs_diff(400) / 10;
+            style_penalty + stretch_penalty + weight_penalty
+        });
+
+    if best_face.is_none() {
+        warn!("Font '{}' was not found in the system font database.", name);
+        warn!("  Use `fc-list` to list all available fonts and their exact family names.");
+        return Font::with_name(Box::leak(name.to_string().into_boxed_str()));
+    }
+
+    let face = best_face.unwrap();
+    let weight = face.weight;
+    let iced_weight = fontdb_weight_to_iced(weight);
+
+    if weight != fontdb::Weight::NORMAL {
+        warn!(
+            "Font '{name}' has no face with weight=Normal(400) style=Normal. \
+             Using the closest available face (weight={}, style={:?}). \
+             Note: text rendered in a different weight (e.g. Bold) may look \
+             the same as regular text, since this font has no separate faces \
+             for those weights. Run `fc-list | grep -i {short_name}` to see \
+             all available faces of this font.",
+            weight.0,
+            face.style,
+            short_name = name.split_whitespace().next().unwrap_or(name),
+        );
+    }
+
+    Font {
+        family: iced::font::Family::Name(Box::leak(name.to_string().into_boxed_str())),
+        weight: iced_weight,
+        stretch: iced::font::Stretch::Normal,
+        style: if face.style == fontdb::Style::Italic {
+            FontStyle::Italic
+        } else {
+            FontStyle::Normal
+        },
+    }
+}
+
 fn main() -> iced::Result {
     let args = Args::parse();
 
@@ -123,7 +218,7 @@ fn main() -> iced::Result {
     logger.set_new_spec(get_log_spec(&config.log_level));
 
     let font = if let Some(font_name) = &config.appearance.font_name {
-        Font::with_name(Box::leak(font_name.clone().into_boxed_str()))
+        resolve_font(font_name)
     } else {
         Font::DEFAULT
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use flexi_logger::{
 };
 use iced::{
     Anchor, Font, KeyboardInteractivity, Layer, LayerShellSettings,
-    font::{Style as FontStyle, Weight as FontWeight},
+    font::{Stretch as FontStretch, Style as FontStyle, Weight as FontWeight},
 };
 use log::{debug, error, warn};
 use std::backtrace::Backtrace;
@@ -96,6 +96,27 @@ fn fontdb_weight_to_iced(weight: fontdb::Weight) -> FontWeight {
     }
 }
 
+fn fontdb_stretch_to_iced(stretch: fontdb::Stretch) -> FontStretch {
+    match stretch {
+        fontdb::Stretch::UltraCondensed => FontStretch::UltraCondensed,
+        fontdb::Stretch::ExtraCondensed => FontStretch::ExtraCondensed,
+        fontdb::Stretch::Condensed => FontStretch::Condensed,
+        fontdb::Stretch::SemiCondensed => FontStretch::SemiCondensed,
+        fontdb::Stretch::Normal => FontStretch::Normal,
+        fontdb::Stretch::SemiExpanded => FontStretch::SemiExpanded,
+        fontdb::Stretch::Expanded => FontStretch::Expanded,
+        fontdb::Stretch::ExtraExpanded => FontStretch::ExtraExpanded,
+        fontdb::Stretch::UltraExpanded => FontStretch::UltraExpanded,
+    }
+}
+
+// NOTE: workaround for iced-rs/iced#2847 — iced 0.14 doesn't expose face
+// selection, so cosmic-text's matcher can silently jump to another family
+// when the requested weight/stretch/style has no exact face. We pre-resolve
+// the real face here and pass its actual attributes so the matcher stays put.
+// Remove once iced exposes face selection. Loads the system font DB a second
+// time (cosmic-text already loads it internally); acceptable as a one-shot
+// startup cost paid only when `font_name` is set.
 fn resolve_font(name: &str) -> Font {
     let mut db = fontdb::Database::new();
     db.load_system_fonts();
@@ -127,13 +148,12 @@ fn resolve_font(name: &str) -> Font {
             style_penalty + stretch_penalty + weight_penalty
         });
 
-    if best_face.is_none() {
+    let Some(face) = best_face else {
         warn!("Font '{}' was not found in the system font database.", name);
         warn!("  Use `fc-list` to list all available fonts and their exact family names.");
         return Font::with_name(Box::leak(name.to_string().into_boxed_str()));
-    }
+    };
 
-    let face = best_face.unwrap();
     let weight = face.weight;
     let iced_weight = fontdb_weight_to_iced(weight);
 
@@ -154,11 +174,10 @@ fn resolve_font(name: &str) -> Font {
     Font {
         family: iced::font::Family::Name(Box::leak(name.to_string().into_boxed_str())),
         weight: iced_weight,
-        stretch: iced::font::Stretch::Normal,
-        style: if face.style == fontdb::Style::Italic {
-            FontStyle::Italic
-        } else {
-            FontStyle::Normal
+        stretch: fontdb_stretch_to_iced(face.stretch),
+        style: match face.style {
+            fontdb::Style::Italic | fontdb::Style::Oblique => FontStyle::Italic,
+            fontdb::Style::Normal => FontStyle::Normal,
         },
     }
 }

--- a/website/docs/configuration/appearance/general.md
+++ b/website/docs/configuration/appearance/general.md
@@ -22,6 +22,30 @@ Changing the font requires killing and restarting ashell process. The font confi
 
 :::
 
+:::tip Finding the exact font name
+
+The `font_name` must match the font's family name exactly (e.g. `"Terminus (TTF)"`,
+not `"Terminus"`). To list available fonts and their exact names, run:
+
+```bash
+fc-list | cut -d: -f2 | sort -u
+```
+
+:::
+
+:::info Font weight
+
+ashell picks the face whose declared weight is closest to Normal (400). If the
+font has no face with weight 400 (for example, Terminus TTF's Regular face reports
+weight 500/Medium), ashell uses the closest available face. Text that requests a
+different weight (e.g. Bold) will then look the same as regular text.
+
+This is also why ashell **cannot use bitmap fonts** (`.bdf`/`.pcf`), which are
+the format of the `terminus-font` package on Arch Linux — only TrueType (`.ttf`)
+and OpenType (`.otf`/`.otc`) fonts are supported.
+
+:::
+
 ## Scaling Factor
 
 You can change the scaling factor of the status bar using the `scale_factor` field.

--- a/website/docs/configuration/troubleshooting.md
+++ b/website/docs/configuration/troubleshooting.md
@@ -103,3 +103,20 @@ Include this info when reporting issues:
 - GPU/driver info
 - Full debug logs
 - Your ashell config
+
+## Font Changes Don't Take Effect
+
+**Problem:** Setting `font_name` in the config has no visible effect.
+
+**Cause:** Most often, the font name doesn't exactly match the font's family name,
+or the font has a non-standard weight that causes a silent fallback.
+
+**Fix:**
+
+1. Verify the exact family name:
+   ```bash
+   fc-list | grep -i <search-term>
+   ```
+2. ashell prints warnings at startup when the font name is not found or when
+   the weight doesn't match — check the logs.
+3. Restart ashell after editing the config (font changes are not hot-reloaded).


### PR DESCRIPTION
`ashell` silently falls back to a different font when the configured `font_name` exists in the system font database but has no face with `weight=Normal(400)` (e.g. Terminus TTF, whose Regular face reports `weight=500/Medium` in its OS/2 table). This happens because cosmic-text's font matcher re-scores all faces and prefers the one whose weight is closest to the requested `Normal(400)`, even if that means picking a font from a different family.

https://docs.rs/fontdb/0.23.0/src/fontdb/lib.rs.html#986
https://docs.rs/iced_core/0.14.0/src/iced_core/font.rs.html#74

**Changes:**
Add `fontdb` as a direct dependency (same version already used transitively by `iced_layershell`)(@MalpenZibo no idea i am really weighing if it is OK to keep it here or to put it into `iced_layershell`, but I think maybe you want to keep `iced_layershell` as slim as possible).

Add `resolve_font()` which:
- Finds all faces matching the configured font name.
- Picks the closest match to Normal style/stretch and weight 400.
- Builds an `iced::Font` with that face's actual weight and style, so cosmic-text's matcher stays on the right font.
- Warns clearly when no `Normal(400)` face is available.
- Warn when the font name isn't found at all (with a suggestion to use fc-list).
<img width="1209" height="111" alt="Image" src="https://github.com/user-attachments/assets/48ba54db-0e63-4d9d-8675-302f4a8f4971" />
<img width="725" height="93" alt="image" src="https://github.com/user-attachments/assets/0f53d9d0-5621-4c64-bf42-26377adbf20b" />

Fixes #768
<img width="739" height="33" alt="Image" src="https://github.com/user-attachments/assets/8a0114ca-18fe-4a2d-bf82-4eb738063c24" />