### PR TITLE
add Name/IconAndName formats to show network name in indicator

### DIFF
--- a/src/components/format_indicator.rs
+++ b/src/components/format_indicator.rs
@@ -50,13 +50,15 @@ impl<'a, Msg: 'static + Clone> From<FormatIndicator<'a, Msg>> for Element<'a, Ms
 
         let content = match fi.format {
             SettingsFormat::Icon => fi.icon.to_text().into(),
-            SettingsFormat::Percentage | SettingsFormat::Time => fi.label_element,
-            SettingsFormat::IconAndPercentage | SettingsFormat::IconAndTime => {
-                row![fi.icon.to_text(), fi.label_element]
-                    .spacing(space.xxs)
-                    .align_y(Alignment::Center)
-                    .into()
+            SettingsFormat::Percentage | SettingsFormat::Time | SettingsFormat::Name => {
+                fi.label_element
             }
+            SettingsFormat::IconAndPercentage
+            | SettingsFormat::IconAndTime
+            | SettingsFormat::IconAndName => row![fi.icon.to_text(), fi.label_element]
+                .spacing(space.xxs)
+                .align_y(Alignment::Center)
+                .into(),
         };
 
         let state = fi.state;

--- a/src/config.rs
+++ b/src/config.rs
@@ -587,6 +587,8 @@ pub enum SettingsFormat {
     IconAndPercentage,
     Time,
     IconAndTime,
+    Name,
+    IconAndName,
 }
 
 #[derive(Deserialize, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -323,20 +323,28 @@ impl NetworkSettings {
                         _ => None,
                     };
                     let strength_text = strength.map_or("100%".to_string(), |s| format!("{}%", s));
+                    let label = match self.config.indicator_format {
+                        SettingsFormat::Name | SettingsFormat::IconAndName => a.name(),
+                        _ => strength_text,
+                    };
 
                     format_indicator(
                         self.config.indicator_format,
                         icon_type,
-                        text(strength_text).into(),
+                        text(label).into(),
                         state,
                     )
                     .on_right_press(Message::OpenMore)
                     .into()
                 } else {
+                    let label = match self.config.indicator_format {
+                        SettingsFormat::Name | SettingsFormat::IconAndName => "-".to_string(),
+                        _ => "0%".to_string(),
+                    };
                     format_indicator(
                         self.config.indicator_format,
                         StaticIcon::Wifi0,
-                        text("0%").into(),
+                        text(label).into(),
                         IndicatorState::Normal,
                     )
                     .on_right_press(Message::OpenMore)

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -287,6 +287,9 @@ impl PowerSettings {
                     .spacing(space.xxs)
                     .align_y(Alignment::Center)
                     .into(),
+                    SettingsFormat::Name | SettingsFormat::IconAndName => {
+                        convert::Into::<Element<'a, Message>>::into(icon(p.get_icon_state()))
+                    }
                 })
                 .style(move |theme: &Theme| container::Style {
                     text_color: Some(match state {

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -135,7 +135,7 @@ peripheral_battery_format = "Icon"  # (default), "IconAndPercentage", "Percentag
 # peripheral_expanded_by_default = false  # (default)
 audio_indicator_format = "Icon"        # (default), "IconAndPercentage", "Percentage", etc.
 microphone_indicator_format = "Icon"   # (default)
-network_indicator_format = "Icon"      # (default)
+network_indicator_format = "Icon"      # (default), "IconAndPercentage", "Percentage", "Name", "IconAndName" (Name/IconAndName show the SSID/interface/VPN name)
 bluetooth_indicator_format = "Icon"    # (default)
 brightness_indicator_format = "Icon"   # (default)
 volume_step = 5    # (default) step size for IPC volume up/down, range 1..=50

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -231,12 +231,16 @@ microphone_indicator_format = "IconAndPercentage"
 
 With the `network_indicator_format` option you can customize the network connection indicator format.
 For WiFi connections, this shows the signal strength as a percentage.
+You can also use `Name` or `IconAndName` to display the connected network name (the SSID for WiFi
+connections, the interface name for wired connections, or the VPN name for VPN connections).
 
 The default value is `Icon`.
 
 ```toml
 [settings]
 network_indicator_format = "IconAndPercentage"
+# or, to show the SSID next to the wifi icon:
+network_indicator_format = "IconAndName"
 ```
 
 ### Bluetooth Format


### PR DESCRIPTION
Adds 2 config options `Name` and `IconAndName` to the existing `SettingsFormat` enum.
This lets users display the connected network's name (the SSID for WiFi, the interface name for wired) in the top-bar network indicator instead of the signal-strength percentage.

```
[settings]
network_indicator_format = "IconAndName" 
# or
network_indicator_format = "Name" 
```

<img width="161" height="60" alt="image" src="https://github.com/user-attachments/assets/14529318-d26a-470d-b442-1b157662fd84" />

closes https://github.com/MalpenZibo/ashell/issues/515