### PR TITLE
Add configuration option to show active workspace in a different color

### DIFF
--- a/docs/src/core/theme-system.md
+++ b/docs/src/core/theme-system.md
@@ -16,6 +16,7 @@ pub struct AshellTheme {
     pub menu: MenuAppearance,                                 // Menu-specific styling
     pub workspace_colors: Vec<AppearanceColor>,               // Per-workspace color cycling
     pub special_workspace_colors: Option<Vec<AppearanceColor>>, // Special workspace colors
+    pub active_workspace_colors: Option<Vec<AppearanceColor>>, // Active workspace colors
     pub scale_factor: f64,                                    // DPI scale factor
 }
 ```

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -69,6 +69,7 @@ backdrop_blur = true
 [appearance]
 workspace_colors = ["#cba6f7", "#f38ba8", "#a6e3a1", "#89b4fa"]
 special_workspace_colors = ["#fab387"]
+active_workspace_colors = ["#fa9f42"]
 ```
 
 ## Updates Module

--- a/src/config.rs
+++ b/src/config.rs
@@ -903,6 +903,7 @@ pub struct Appearance {
     pub danger_color: AppearanceColor,
     pub text_color: AppearanceColor,
     pub workspace_colors: Vec<AppearanceColor>,
+    pub active_workspace_colors: Option<Vec<AppearanceColor>>,
     pub special_workspace_colors: Option<Vec<AppearanceColor>>,
 }
 
@@ -981,6 +982,7 @@ impl Default for Appearance {
                 AppearanceColor::Simple(HexColor::rgb(158, 206, 106)),
             ],
             special_workspace_colors: None,
+            active_workspace_colors: None,
         }
     }
 }

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -461,17 +461,25 @@ impl Workspaces {
                             } else {
                                 w.monitor_id
                             };
+                            let active = w.displayed == Displayed::Active;
 
                             let color = color_index.map(|i| {
-                                if w.id > 0 {
-                                    theme.workspace_colors.get(i as usize).copied()
-                                } else {
+                                if active {
+                                    theme
+                                        .active_workspace_colors
+                                        .as_ref()
+                                        .unwrap_or(&theme.workspace_colors)
+                                        .get(i as usize)
+                                        .copied()
+                                } else if w.id <= 0 {
                                     theme
                                         .special_workspace_colors
                                         .as_ref()
                                         .unwrap_or(&theme.workspace_colors)
                                         .get(i as usize)
                                         .copied()
+                                } else {
+                                    theme.workspace_colors.get(i as usize).copied()
                                 }
                             });
 

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -463,25 +463,19 @@ impl Workspaces {
                             };
                             let active = w.displayed == Displayed::Active;
 
-                            let color = color_index.map(|i| {
-                                if active {
-                                    theme
-                                        .active_workspace_colors
-                                        .as_ref()
-                                        .unwrap_or(&theme.workspace_colors)
-                                        .get(i as usize)
-                                        .copied()
-                                } else if w.id <= 0 {
-                                    theme
-                                        .special_workspace_colors
-                                        .as_ref()
-                                        .unwrap_or(&theme.workspace_colors)
-                                        .get(i as usize)
-                                        .copied()
-                                } else {
-                                    theme.workspace_colors.get(i as usize).copied()
-                                }
-                            });
+                            let palette = match &theme.active_workspace_colors {
+                                // active_workspace_colors is set AND the workspace is active
+                                Some(colors) if active => colors,
+                                // Special workspace with fallback in case its not set
+                                _ if w.id <= 0 => theme
+                                    .special_workspace_colors
+                                    .as_ref()
+                                    .unwrap_or(&theme.workspace_colors),
+                                // Standard workspaces
+                                _ => &theme.workspace_colors,
+                            };
+
+                            let color = color_index.map(|i| palette.get(i as usize).copied());
 
                             {
                                 let name = w.name.clone();

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -111,6 +111,7 @@ pub struct AshellTheme {
     pub menu: MenuAppearance,
     pub workspace_colors: Vec<AppearanceColor>,
     pub special_workspace_colors: Option<Vec<AppearanceColor>>,
+    pub active_workspace_colors: Option<Vec<AppearanceColor>>,
     pub scale_factor: f64,
     // Read by animation call sites added in subsequent PRs.
     #[allow(dead_code)]
@@ -245,6 +246,7 @@ fn base_theme_from_appearance(
         menu: appearance.menu,
         workspace_colors: appearance.workspace_colors.clone(),
         special_workspace_colors: appearance.special_workspace_colors.clone(),
+        active_workspace_colors: appearance.active_workspace_colors.clone(),
         scale_factor: appearance.scale_factor,
         animations_enabled,
         iced_theme: build_iced_theme(appearance),

--- a/website/docs/configuration/appearance/palette.md
+++ b/website/docs/configuration/appearance/palette.md
@@ -72,19 +72,20 @@ a range of surface tones from subtle to prominent.
 
 ## Workspace Colors
 
-You can specify which color to use for workspace indicators based on
-the monitor to which a workspace is attached.
+You can customize the color of workspace indicators 
+based on the monitor they are attached to.
 
-For example, if workspace 1 is attached to `monitorA`, the first
-color will be used; if workspace 2 is attached to `monitorB`,
-the second color will be used, and so on.
+| Option | Description |
+| -------------- | --------------- |
+| `workspace_colors` | The default colors of regular, inactive workspaces (falls back to `primary_color` if undefined) |
+| `active_workspace_colors` | The colors used for currently active workspaces (falls back to `workspace_colors` if undefined) |
+| `special_workspace_colors` | The colors used for special workspaces (falls back to `workspace_colors` if undefined) |
 
-Use the `workspace_colors` field for regular workspaces, `active_workspace_colors` for the active workspace per monitor, and
-`special_workspace_colors` for special workspaces.
-
-If `special_workspace_colors`/`active_workspace_colors` are not defined, `workspace_colors` will be used.
-If neither `workspace_colors` is defined nor a color exists
-for a given monitor, the `primary_color` will be used.
+Each option accepts a list of colors. 
+The colors are assigned to monitors sequentially based on the order your monitors are defined/detected.
+This means the first color in each list only applies to workspaces on monitor 1, the second color to workspaces on monitor 2, and so on.
+Example: If workspace 1 and 3 are both on `monitorA`, the first
+color will be used for both of them; if workspace 2 is attached to `monitorB`, the second color will be used.
 
 ## Complete Examples
 

--- a/website/docs/configuration/appearance/palette.md
+++ b/website/docs/configuration/appearance/palette.md
@@ -79,10 +79,10 @@ For example, if workspace 1 is attached to `monitorA`, the first
 color will be used; if workspace 2 is attached to `monitorB`,
 the second color will be used, and so on.
 
-Use the `workspace_colors` field for regular workspaces, and
+Use the `workspace_colors` field for regular workspaces, `active_workspace_colors` for the active workspace per monitor, and
 `special_workspace_colors` for special workspaces.
 
-If `special_workspace_colors` is not defined, `workspace_colors` will be used.
+If `special_workspace_colors`/`active_workspace_colors` are not defined, `workspace_colors` will be used.
 If neither `workspace_colors` is defined nor a color exists
 for a given monitor, the `primary_color` will be used.
 

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -173,6 +173,7 @@ danger_color = "#f7768e"
 text_color = "#a9b1d6"
 workspace_colors = [ "#7aa2f7", "#9ece6a" ]
 # special_workspace_colors = [ "#7aa2f7", "#9ece6a" ]  # (default: None, falls back to workspace_colors)
+# active_workspace_colors = [ "#fa9f42", "#fa9f42" ]              # (default: None, falls back to workspace_colors)
 
 [appearance.menu]
 # opacity = 1.0   # (default) menu background opacity


### PR DESCRIPTION
Currently the only indication of the active workspace is a slightly bigger amount of padding around the name or number.
However, especially when you have workspace labels that are not all just one character in length it becomes very hard to see which workspace is currently active. (This might be the case if when #495 is mergend and used, but can also already happen for example when using named workspaces on niri)

Therefore, as previously pushed for in #495 , I would like to add a new config option that allow the configuration of differing color(s) for active workspaces, making it easy to spot the active workspace with one glance at the bar.