### PR TITLE
feat(notifications): add commands

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -4,7 +4,7 @@ use crate::{
     config::{self, AppearanceStyle, Config, Modules, Position},
     get_log_spec,
     i18n::{Localizer, init_localizer},
-    ipc::IpcCommand,
+    ipc::{IpcCommand, IpcRequest},
     modules::{
         self,
         custom_module::{self, Custom},
@@ -93,7 +93,7 @@ pub enum Message {
     MediaPlayer(modules::media_player::Message),
     Notifications(modules::notifications::Message),
     Osd(osd::Message),
-    IpcOsdCommand(IpcCommand),
+    IpcRequest(IpcRequest),
     OutputEvent(OutputEvent),
     CloseAllMenus,
     ResumeFromSleep,
@@ -313,8 +313,82 @@ impl App {
                     None
                 }
             }
-            IpcCommand::ToggleVisibility => None,
+            IpcCommand::ToggleVisibility
+            | IpcCommand::NotificationsClear { .. }
+            | IpcCommand::NotificationsInvoke { .. }
+            | IpcCommand::NotificationsList => None,
         }
+    }
+
+    fn handle_notifications_action(
+        &mut self,
+        action: modules::notifications::Action,
+    ) -> Task<Message> {
+        match action {
+            modules::notifications::Action::None => Task::none(),
+            modules::notifications::Action::Task(task) => task.map(Message::Notifications),
+            modules::notifications::Action::Show(task) => {
+                let position = self.notifications.toast_position();
+                let width = crate::components::MenuSize::Medium.size() as u32;
+                Task::batch(vec![
+                    task.map(Message::Notifications),
+                    self.outputs.show_toast_layer(width, position),
+                ])
+            }
+            modules::notifications::Action::Hide(task) => Task::batch(vec![
+                task.map(Message::Notifications),
+                self.outputs.hide_toast_layer(),
+            ]),
+            modules::notifications::Action::UpdateToastInputRegion(content_size) => {
+                let position = self.notifications.toast_position();
+                self.outputs
+                    .update_toast_input_region(content_size, position)
+            }
+        }
+    }
+
+    fn handle_ipc_osd_command(&mut self, cmd: &IpcCommand) -> Task<Message> {
+        let mut tasks = vec![];
+
+        // Execute the action via Settings.
+        let action = match cmd {
+            IpcCommand::VolumeUp { .. } => self.settings.volume_adjust(true),
+            IpcCommand::VolumeDown { .. } => self.settings.volume_adjust(false),
+            IpcCommand::VolumeToggleMute { .. } => self.settings.toggle_mute(),
+            IpcCommand::MicrophoneUp { .. } => self.settings.microphone_adjust(true),
+            IpcCommand::MicrophoneDown { .. } => self.settings.microphone_adjust(false),
+            IpcCommand::MicrophoneToggleMute { .. } => self.settings.microphone_toggle_mute(),
+            IpcCommand::BrightnessUp { .. } => self.settings.brightness_adjust(true),
+            IpcCommand::BrightnessDown { .. } => self.settings.brightness_adjust(false),
+            IpcCommand::ToggleAirplaneMode { .. } => self.settings.toggle_airplane(),
+            IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
+            IpcCommand::ToggleVisibility
+            | IpcCommand::NotificationsClear { .. }
+            | IpcCommand::NotificationsInvoke { .. }
+            | IpcCommand::NotificationsList => unreachable!(),
+        };
+        if let settings::Action::Command(task) = action {
+            tasks.push(task.map(Message::Settings));
+        }
+
+        // Show OSD overlay if enabled.
+        if self.osd.config().enabled && !cmd.no_osd() {
+            let osd_info = self.osd_info_for(cmd);
+
+            if let Some((kind, value, scale, muted)) = osd_info
+                && let osd::Action::Show(timer) = self.osd.update(osd::Message::Show {
+                    kind,
+                    value,
+                    scale,
+                    muted,
+                })
+            {
+                tasks.push(timer.map(Message::Osd));
+                tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
+            }
+        }
+
+        Task::batch(tasks)
     }
 
     pub fn update(&mut self, message: Message) -> Task<Message> {
@@ -544,69 +618,47 @@ impl App {
                     scale_factor,
                 )
             }
-            Message::Notifications(message) => match self.notifications.update(message) {
-                modules::notifications::Action::None => Task::none(),
-                modules::notifications::Action::Task(task) => task.map(Message::Notifications),
-                modules::notifications::Action::Show(task) => {
-                    let position = self.notifications.toast_position();
-                    let width = crate::components::MenuSize::Medium.size() as u32;
-                    Task::batch(vec![
-                        task.map(Message::Notifications),
-                        self.outputs.show_toast_layer(width, position),
-                    ])
+            Message::Notifications(message) => {
+                let action = self.notifications.update(message);
+                self.handle_notifications_action(action)
+            }
+            Message::IpcRequest(request) => match request.command() {
+                IpcCommand::ToggleVisibility => {
+                    request.respond_ok();
+                    self.update(Message::ToggleVisibility)
                 }
-                modules::notifications::Action::Hide(task) => Task::batch(vec![
-                    task.map(Message::Notifications),
-                    self.outputs.hide_toast_layer(),
-                ]),
-                modules::notifications::Action::UpdateToastInputRegion(content_size) => {
-                    let position = self.notifications.toast_position();
-                    self.outputs
-                        .update_toast_input_region(content_size, position)
+                IpcCommand::NotificationsClear { id } => {
+                    request.respond_ok();
+                    let message = match id {
+                        Some(id) => modules::notifications::Message::CloseNotificationById(*id),
+                        None => modules::notifications::Message::ClearNotifications,
+                    };
+                    let action = self.notifications.update(message);
+                    self.handle_notifications_action(action)
+                }
+                IpcCommand::NotificationsInvoke { id, action } => {
+                    request.respond_ok();
+                    let action_key = action.clone().unwrap_or_else(|| "default".to_string());
+                    let notification_action =
+                        self.notifications
+                            .update(modules::notifications::Message::InvokeAction {
+                                id: *id,
+                                action_key,
+                            });
+                    self.handle_notifications_action(notification_action)
+                }
+                IpcCommand::NotificationsList => {
+                    match self.notifications.list_json() {
+                        Ok(json) => request.respond(&json),
+                        Err(e) => request.respond_error(&format!("serialize notifications: {e}")),
+                    }
+                    Task::none()
+                }
+                cmd => {
+                    request.respond_ok();
+                    self.handle_ipc_osd_command(cmd)
                 }
             },
-            Message::IpcOsdCommand(cmd) => {
-                let mut tasks = vec![];
-
-                // Execute the action via Settings.
-                let action = match &cmd {
-                    IpcCommand::VolumeUp { .. } => self.settings.volume_adjust(true),
-                    IpcCommand::VolumeDown { .. } => self.settings.volume_adjust(false),
-                    IpcCommand::VolumeToggleMute { .. } => self.settings.toggle_mute(),
-                    IpcCommand::MicrophoneUp { .. } => self.settings.microphone_adjust(true),
-                    IpcCommand::MicrophoneDown { .. } => self.settings.microphone_adjust(false),
-                    IpcCommand::MicrophoneToggleMute { .. } => {
-                        self.settings.microphone_toggle_mute()
-                    }
-                    IpcCommand::BrightnessUp { .. } => self.settings.brightness_adjust(true),
-                    IpcCommand::BrightnessDown { .. } => self.settings.brightness_adjust(false),
-                    IpcCommand::ToggleAirplaneMode { .. } => self.settings.toggle_airplane(),
-                    IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
-                    IpcCommand::ToggleVisibility => unreachable!(),
-                };
-                if let settings::Action::Command(task) = action {
-                    tasks.push(task.map(Message::Settings));
-                }
-
-                // Show OSD overlay if enabled.
-                if self.osd.config().enabled && !cmd.no_osd() {
-                    let osd_info = self.osd_info_for(&cmd);
-
-                    if let Some((kind, value, scale, muted)) = osd_info
-                        && let osd::Action::Show(timer) = self.osd.update(osd::Message::Show {
-                            kind,
-                            value,
-                            scale,
-                            muted,
-                        })
-                    {
-                        tasks.push(timer.map(Message::Osd));
-                        tasks.push(self.outputs.show_osd_layer(OSD_WIDTH, OSD_HEIGHT));
-                    }
-                }
-
-                Task::batch(tasks)
-            }
             Message::Osd(msg) => match self.osd.update(msg) {
                 osd::Action::Hide => self.outputs.hide_osd_layer(),
                 _ => Task::none(),
@@ -848,10 +900,7 @@ impl App {
             // Always subscribe to audio/brightness services so OSD works
             // even when the Settings module isn't in the module list.
             self.settings.subscription().map(Message::Settings),
-            crate::ipc::subscription().map(|cmd| match cmd {
-                IpcCommand::ToggleVisibility => Message::ToggleVisibility,
-                other => Message::IpcOsdCommand(other),
-            }),
+            crate::ipc::subscription().map(Message::IpcRequest),
         ])
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -8,6 +8,7 @@ use std::io::{BufRead, BufReader, Read, Write};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::{Arc, Mutex};
 
 use anyhow::{Context, Result, anyhow};
 use clap::Subcommand;
@@ -17,6 +18,7 @@ use crate::xdg;
 
 /// Maximum bytes to read from a client connection.
 const MAX_REQUEST_LEN: u64 = 4096;
+const MAX_RESPONSE_LEN: u64 = 1024 * 1024;
 
 /// IPC command that can be sent to the daemon.
 #[derive(Subcommand, Debug, Clone)]
@@ -63,12 +65,83 @@ pub enum IpcCommand {
         #[arg(long)]
         no_osd: bool,
     },
+    /// Clear all notifications
+    NotificationsClear {
+        #[arg(short = 'n', long = "id")]
+        id: Option<u32>,
+    },
+    /// Invoke the default action on a notification
+    NotificationsInvoke {
+        #[arg(short = 'n', long = "id")]
+        id: Option<u32>,
+        action: Option<String>,
+    },
+    /// List active notifications as JSON
+    NotificationsList,
+}
+
+#[derive(Debug, Clone)]
+pub struct IpcRequest {
+    command: IpcCommand,
+    response: IpcResponse,
+}
+
+impl IpcRequest {
+    fn new(command: IpcCommand, stream: UnixStream) -> Self {
+        Self {
+            command,
+            response: IpcResponse::new(stream),
+        }
+    }
+
+    pub fn command(&self) -> &IpcCommand {
+        &self.command
+    }
+
+    pub fn respond_ok(&self) {
+        self.respond("ok");
+    }
+
+    pub fn respond_error(&self, error: &str) {
+        self.respond(&format!("error {error}"));
+    }
+
+    pub fn respond(&self, response: &str) {
+        self.response.respond(response);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct IpcResponse {
+    stream: Arc<Mutex<Option<UnixStream>>>,
+}
+
+impl IpcResponse {
+    fn new(stream: UnixStream) -> Self {
+        Self {
+            stream: Arc::new(Mutex::new(Some(stream))),
+        }
+    }
+
+    fn respond(&self, response: &str) {
+        match self.stream.lock() {
+            Ok(mut stream) => {
+                if let Some(mut stream) = stream.take() {
+                    write_response(&mut stream, response);
+                }
+            }
+            Err(e) => log::debug!("IPC response lock failed: {e}"),
+        }
+    }
 }
 
 impl IpcCommand {
     pub fn no_osd(&self) -> bool {
         match self {
-            IpcCommand::ToggleVisibility => false,
+            IpcCommand::ToggleVisibility
+            | IpcCommand::NotificationsClear { .. }
+            | IpcCommand::NotificationsInvoke { .. }
+            | IpcCommand::NotificationsList => false,
             IpcCommand::VolumeUp { no_osd }
             | IpcCommand::VolumeDown { no_osd }
             | IpcCommand::VolumeToggleMute { no_osd }
@@ -99,6 +172,26 @@ impl fmt::Display for IpcCommand {
             IpcCommand::BrightnessDown { .. } => "brightness-down",
             IpcCommand::ToggleAirplaneMode { .. } => "toggle-airplane-mode",
             IpcCommand::ToggleIdleInhibitor { .. } => "toggle-idle-inhibitor",
+            IpcCommand::NotificationsClear { id } => {
+                if let Some(id) = id {
+                    return write!(f, "notifications-clear?id={id}");
+                }
+                "notifications-clear"
+            }
+            IpcCommand::NotificationsInvoke { id, action } => {
+                if id.is_some() || action.is_some() {
+                    let mut args = url::form_urlencoded::Serializer::new(String::new());
+                    if let Some(id) = id {
+                        args.append_pair("id", &id.to_string());
+                    }
+                    if let Some(action) = action {
+                        args.append_pair("action", action);
+                    }
+                    return write!(f, "notifications-invoke?{}", args.finish());
+                }
+                "notifications-invoke"
+            }
+            IpcCommand::NotificationsList => "notifications-list",
         };
         write!(f, "{base}")?;
         if self.no_osd() {
@@ -116,6 +209,8 @@ impl FromStr for IpcCommand {
             Some(base) => (base, true),
             None => (s, false),
         };
+        let (cmd, args) = cmd.split_once('?').unwrap_or((cmd, ""));
+
         match cmd {
             "toggle-visibility" => Ok(IpcCommand::ToggleVisibility),
             "volume-up" => Ok(IpcCommand::VolumeUp { no_osd }),
@@ -128,6 +223,33 @@ impl FromStr for IpcCommand {
             "brightness-down" => Ok(IpcCommand::BrightnessDown { no_osd }),
             "toggle-airplane-mode" => Ok(IpcCommand::ToggleAirplaneMode { no_osd }),
             "toggle-idle-inhibitor" => Ok(IpcCommand::ToggleIdleInhibitor { no_osd }),
+            "notifications-clear" => {
+                let id = if args.is_empty() {
+                    None
+                } else if let Some(value) = args.strip_prefix("id=") {
+                    Some(value.parse().context("parse notification id")?)
+                } else {
+                    return Err(anyhow!("unknown IPC command arguments: {args:?}"));
+                };
+                Ok(IpcCommand::NotificationsClear { id })
+            }
+            "notifications-invoke" => {
+                let mut id = None;
+                let mut action = None;
+                if !args.is_empty() {
+                    for (key, value) in url::form_urlencoded::parse(args.as_bytes()) {
+                        match key.as_ref() {
+                            "id" => id = Some(value.parse().context("parse notification id")?),
+                            "action" => action = Some(value.into_owned()),
+                            _ => {
+                                return Err(anyhow!("unknown IPC command arguments: {args:?}"));
+                            }
+                        }
+                    }
+                }
+                Ok(IpcCommand::NotificationsInvoke { id, action })
+            }
+            "notifications-list" => Ok(IpcCommand::NotificationsList),
             _ => Err(anyhow!("unknown IPC command: {s:?}")),
         }
     }
@@ -162,9 +284,14 @@ pub fn run_client(cmd: &IpcCommand) -> Result<()> {
     stream.shutdown(std::net::Shutdown::Write)?;
 
     let mut response = String::new();
-    BufReader::new((&stream).take(MAX_REQUEST_LEN))
-        .read_line(&mut response)
-        .context("read response")?;
+    let mut reader = BufReader::new((&stream).take(MAX_RESPONSE_LEN));
+    let bytes_read = reader.read_line(&mut response).context("read response")?;
+    if bytes_read == 0 {
+        return Err(anyhow!("IPC server closed without response"));
+    }
+    if !response.ends_with('\n') {
+        return Err(anyhow!("truncated IPC response"));
+    }
     let response = response.trim_end();
 
     if let Some(err) = response.strip_prefix("error ") {
@@ -238,6 +365,13 @@ fn read_request(stream: &UnixStream) -> Result<IpcCommand> {
 
 /// Write a response line to the client.
 fn write_response(stream: &mut UnixStream, response: &str) {
+    // Tokio's into_std preserves nonblocking mode; std write_all would
+    // otherwise fail with WouldBlock after a partial large response.
+    if let Err(e) = stream.set_nonblocking(false) {
+        log::debug!("IPC set blocking response stream failed: {e}");
+        return;
+    }
+
     let msg = format!("{response}\n");
     if let Err(e) = stream.write_all(msg.as_bytes()) {
         log::debug!("IPC write response failed: {e}");
@@ -245,12 +379,9 @@ fn write_response(stream: &mut UnixStream, response: &str) {
 }
 
 /// Handle a single accepted client connection.
-fn handle_connection(mut stream: UnixStream) -> Option<IpcCommand> {
+fn handle_connection(mut stream: UnixStream) -> Option<IpcRequest> {
     match read_request(&stream) {
-        Ok(cmd) => {
-            write_response(&mut stream, "ok");
-            Some(cmd)
-        }
+        Ok(cmd) => Some(IpcRequest::new(cmd, stream)),
         Err(e) => {
             write_response(&mut stream, &format!("error {e:#}"));
             None
@@ -282,7 +413,7 @@ fn init_listener() -> Option<tokio::net::UnixListener> {
 }
 
 /// Subscription that listens for IPC commands on the Unix socket.
-pub fn subscription() -> Subscription<IpcCommand> {
+pub fn subscription() -> Subscription<IpcRequest> {
     use iced::futures::StreamExt;
 
     Subscription::run(|| {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -5,7 +5,7 @@ use crate::{
     services::{
         ReadOnlyService, ServiceEvent,
         notifications::{
-            Notification, NotificationIcon, NotificationsService, Urgency,
+            Notification, NotificationAction, NotificationIcon, NotificationsService, Urgency,
             dbus::{NotificationDaemon, NotificationEvent},
         },
     },
@@ -28,19 +28,13 @@ use zbus::Connection;
 const ICON_SIZE: f32 = 36.0;
 
 #[derive(serde::Serialize)]
-struct NotificationAction<'a> {
-    key: &'a str,
-    label: &'a str,
-}
-
-#[derive(serde::Serialize)]
 struct NotificationListEntry<'a> {
     id: u32,
     app_name: &'a str,
     summary: &'a str,
     body: &'a str,
     urgency: &'static str,
-    actions: Vec<NotificationAction<'a>>,
+    actions: &'a [NotificationAction],
 }
 
 fn notification_icon<'a, M: 'a>(icon_kind: Option<&NotificationIcon>) -> Element<'a, M> {
@@ -184,7 +178,7 @@ impl Notifications {
         self.find_notification(id)
             .filter(|n| !n.actions.is_empty())
             .and_then(|n| n.actions.first())
-            .cloned()
+            .map(|action| action.key.clone())
     }
 
     fn find_action_notification(&self, action_key: &str) -> Option<u32> {
@@ -215,7 +209,7 @@ impl Notifications {
                 summary: &notification.summary,
                 body: &notification.body,
                 urgency: urgency_name(notification.urgency),
-                actions: notification_actions(notification),
+                actions: &notification.actions,
             })
             .collect::<Vec<_>>();
 
@@ -443,22 +437,8 @@ impl Notifications {
 fn notification_has_action(notification: &Notification, action_key: &str) -> bool {
     notification
         .actions
-        .chunks(2)
-        .any(|action| action.first().is_some_and(|key| key.as_str() == action_key))
-}
-
-fn notification_actions(notification: &Notification) -> Vec<NotificationAction<'_>> {
-    notification
-        .actions
-        .chunks(2)
-        .filter_map(|action| {
-            let key = action.first()?;
-            Some(NotificationAction {
-                key,
-                label: action.get(1).map_or("", String::as_str),
-            })
-        })
-        .collect()
+        .iter()
+        .any(|action| action.key == action_key)
 }
 
 fn urgency_name(urgency: Urgency) -> &'static str {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -27,6 +27,22 @@ use zbus::Connection;
 
 const ICON_SIZE: f32 = 36.0;
 
+#[derive(serde::Serialize)]
+struct NotificationAction<'a> {
+    key: &'a str,
+    label: &'a str,
+}
+
+#[derive(serde::Serialize)]
+struct NotificationListEntry<'a> {
+    id: u32,
+    app_name: &'a str,
+    summary: &'a str,
+    body: &'a str,
+    urgency: &'static str,
+    actions: Vec<NotificationAction<'a>>,
+}
+
 fn notification_icon<'a, M: 'a>(icon_kind: Option<&NotificationIcon>) -> Element<'a, M> {
     match icon_kind {
         Some(NotificationIcon::Svg(handle)) => svg(handle.clone())
@@ -101,6 +117,7 @@ fn toast_timeout(required_timeout: i32, timeout_ms: u64) -> Option<Duration> {
 pub enum Message {
     ConfigReloaded(NotificationsModuleConfig),
     NotificationClicked(u32),
+    InvokeAction { id: Option<u32>, action_key: String },
     NotificationClosed,
     CloseNotificationById(u32),
     ClearNotifications,
@@ -168,6 +185,41 @@ impl Notifications {
             .filter(|n| !n.actions.is_empty())
             .and_then(|n| n.actions.first())
             .cloned()
+    }
+
+    fn find_action_notification(&self, action_key: &str) -> Option<u32> {
+        self.notifications
+            .iter()
+            .find(|notification| notification_has_action(notification, action_key))
+            .map(|notification| notification.id)
+    }
+
+    fn find_action_target(&self, id: Option<u32>, action_key: &str) -> Option<u32> {
+        if let Some(id) = id {
+            return self
+                .find_notification(id)
+                .filter(|notification| notification_has_action(notification, action_key))
+                .map(|notification| notification.id);
+        }
+
+        self.find_action_notification(action_key)
+    }
+
+    pub fn list_json(&self) -> serde_json::Result<String> {
+        let entries = self
+            .notifications
+            .iter()
+            .map(|notification| NotificationListEntry {
+                id: notification.id,
+                app_name: &notification.app_name,
+                summary: &notification.summary,
+                body: &notification.body,
+                urgency: urgency_name(notification.urgency),
+                actions: notification_actions(notification),
+            })
+            .collect::<Vec<_>>();
+
+        serde_json::to_string(&entries)
     }
 
     fn clear_toasts(&mut self) -> bool {
@@ -311,6 +363,16 @@ impl Notifications {
                 let action_key = self.find_first_action_key(id);
                 Action::Task(invoke_and_close_task(connection, id, action_key))
             }
+            Message::InvokeAction { id, action_key } => {
+                if let Some(id) = self.find_action_target(id, &action_key) {
+                    let connection = self.connection.clone();
+                    let had_toasts = self.remove_toast(id);
+                    let task = invoke_and_close_task(connection, id, Some(action_key));
+                    self.hide_toasts_if_empty_with_task(had_toasts, task)
+                } else {
+                    Action::None
+                }
+            }
             Message::NotificationClosed => Action::None,
             Message::ClearNotifications => {
                 let connection = self.connection.clone();
@@ -376,7 +438,38 @@ impl Notifications {
         let datetime: DateTime<Local> = timestamp.into();
         datetime.format(&self.config.format).to_string()
     }
+}
 
+fn notification_has_action(notification: &Notification, action_key: &str) -> bool {
+    notification
+        .actions
+        .chunks(2)
+        .any(|action| action.first().is_some_and(|key| key.as_str() == action_key))
+}
+
+fn notification_actions(notification: &Notification) -> Vec<NotificationAction<'_>> {
+    notification
+        .actions
+        .chunks(2)
+        .filter_map(|action| {
+            let key = action.first()?;
+            Some(NotificationAction {
+                key,
+                label: action.get(1).map_or("", String::as_str),
+            })
+        })
+        .collect()
+}
+
+fn urgency_name(urgency: Urgency) -> &'static str {
+    match urgency {
+        Urgency::Low => "low",
+        Urgency::Normal => "normal",
+        Urgency::Critical => "critical",
+    }
+}
+
+impl Notifications {
     fn notification_button_style(
         style: NotificationStyle,
         urgency: Urgency,

--- a/src/services/notifications/dbus.rs
+++ b/src/services/notifications/dbus.rs
@@ -46,13 +46,34 @@ impl Urgency {
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct NotificationAction {
+    pub key: String,
+    pub label: String,
+}
+
+impl NotificationAction {
+    fn from_raw_actions(raw_actions: Vec<String>) -> Vec<Self> {
+        raw_actions
+            .chunks(2)
+            .filter_map(|action| {
+                let key = action.first()?;
+                Some(Self {
+                    key: key.clone(),
+                    label: action.get(1).cloned().unwrap_or_default(),
+                })
+            })
+            .collect()
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Notification {
     pub id: u32,
     pub app_name: String,
     pub app_icon: String,
     pub summary: String,
     pub body: String,
-    pub actions: Vec<String>,
+    pub actions: Vec<NotificationAction>,
     pub hints: HashMap<String, OwnedValue>,
     pub expire_timeout: i32,
     pub timestamp: SystemTime,
@@ -109,6 +130,7 @@ impl NotificationDaemon {
 
         let icon = NotificationIcon::resolve(&app_name, &app_icon, &hints);
         let urgency = Urgency::from_hints(&hints);
+        let actions = NotificationAction::from_raw_actions(actions);
         let notification = Notification {
             id,
             app_name,

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -15,7 +15,7 @@ use zbus::zvariant::OwnedValue;
 pub mod dbus;
 
 use dbus::NotificationEvent;
-pub use dbus::{Notification, Urgency};
+pub use dbus::{Notification, NotificationAction, Urgency};
 
 #[derive(Debug, Clone)]
 pub enum NotificationIcon {

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -53,6 +53,9 @@ Available commands:
 | `brightness-down`        | Decrease screen brightness by 5%     |
 | `toggle-airplane-mode`   | Toggle airplane mode                 |
 | `toggle-idle-inhibitor`  | Toggle idle inhibitor                |
+| `notifications-clear [-n, --id <id>]` | Clear all active notifications, or one notification by id |
+| `notifications-invoke [-n, --id <id>] [action]` | Invoke a notification action, defaulting to `default` |
+| `notifications-list`     | List active notifications as JSON    |
 
 
 Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD (On-Screen Display)


### PR DESCRIPTION
Just switched over to using ashells notification module, and was missing a way
to invoke actions on current/active notifications.

Decided to add some basic other commands while am at it. I tried to take some
inspiration how makoctl have designed their commands. The more
opinionated/special one is probably list since it defaults to json and required
some changes to the IpcCommand handling (Request/Response). I'm not very
familiar with unix sockets so might have missed something obvious.

Thought about doing a scoped msg like `ashell msg notifications list` but tried
to follow the current naming schema. But I think this could be a better way to
handle things when the command list grow over time.

Not overly happy with how much I tocuhed, could probably revisit and keep it smaller.