### PR TITLE
Change cpu icon to nerdfont cpu icon (from nf-md-television)

### DIFF
--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -144,7 +144,7 @@ impl StaticIcon {
             StaticIcon::UpdatesAvailable => "\u{f0cdb}",
             StaticIcon::MenuClosed => "\u{f035f}",
             StaticIcon::MenuOpen => "\u{f035d}",
-            StaticIcon::Cpu => "\u{f0502}",
+            StaticIcon::Cpu => "\u{f4bc}",
             StaticIcon::Mem => "\u{efc5}",
             StaticIcon::Temp => "\u{f050f}",
             StaticIcon::Speaker0 => "\u{f0e08}",


### PR DESCRIPTION
A bit subjective this one. Changes the cpu icon to the nerdfont cpu icon. More consistent with the memory icon.
from this:
<img width="180" height="181" alt="image" src="https://github.com/user-attachments/assets/b660581a-bf27-45d4-a599-9f53bf81c29a" />

to this:
<img width="183" height="179" alt="image" src="https://github.com/user-attachments/assets/1e1b9bdb-0e81-4644-aeea-3b2b682c4534" />
