### PR TITLE
fix(settings): display battery indicator for touchpad peripherals

### DIFF
--- a/src/services/upower/dbus.rs
+++ b/src/services/upower/dbus.rs
@@ -252,7 +252,12 @@ impl UpDeviceKind {
     pub fn is_peripheral(self) -> bool {
         matches!(
             self,
-            Self::Mouse | Self::Keyboard | Self::GamingInput | Self::Headset | Self::Headphones
+            Self::Mouse
+                | Self::Keyboard
+                | Self::GamingInput
+                | Self::Headset
+                | Self::Headphones
+                | Self::Touchpad
         )
     }
 

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -427,7 +427,7 @@ impl UPowerService {
                 continue;
             };
             let device_kind = match UpDeviceKind::from_u32(device_type).unwrap_or_default() {
-                UpDeviceKind::Mouse => PeripheralDeviceKind::Mouse,
+                UpDeviceKind::Mouse | UpDeviceKind::Touchpad => PeripheralDeviceKind::Mouse,
                 UpDeviceKind::Keyboard => PeripheralDeviceKind::Keyboard,
                 UpDeviceKind::Headphones => PeripheralDeviceKind::Headphones,
                 UpDeviceKind::Headset => PeripheralDeviceKind::Headphones,


### PR DESCRIPTION
Fixes #816

This change enables battery indicators in the Settings module for battery-powered touchpad devices, such as the Apple Magic Trackpad.

**Before:** UPower devices with type `touchpad` (14) were silently ignored, and so would never display a battery indicator.
**After:** Touchpads are treated as mouse peripherals, and so they display with a mouse battery indicator.

I considered not aliasing them as mice and using the Nerd Font `nf-md-trackpad` icon (󰟸) but decided that it does not intuitively resemble a touchpad device enough, and that the mouse icon is fine for "some kind of pointing device."

`make check` in a `nix develop` shell passes. I also built and verified that the battery status of my physical device, the Magic Trackpad, displays correctly.