### PR TITLE
feat(utils): add send_or_log helper and replace silent output.send calls

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,10 +1,10 @@
 use crate::app::Message;
 use crate::i18n::{UnitSystem, unit_system};
 use crate::services::upower::PeripheralDeviceKind;
-use crate::utils::celsius_to_fahrenheit;
+use crate::utils::{celsius_to_fahrenheit, send_or_log};
 use hex_color::HexColor;
 use iced::futures::StreamExt;
-use iced::{Color, Subscription, futures::SinkExt, stream::channel, theme::palette};
+use iced::{Color, Subscription, stream::channel, theme::palette};
 use inotify::EventMask;
 use inotify::Inotify;
 use inotify::WatchMask;
@@ -1336,9 +1336,11 @@ pub fn subscription(path: &Path) -> Subscription<Message> {
                                     .await
                                     .unwrap_or_default();
 
-                                    let _ = output
-                                        .send(Message::ConfigChanged(Box::new(new_config)))
-                                        .await;
+                                    send_or_log(
+                                        &mut output,
+                                        Message::ConfigChanged(Box::new(new_config)),
+                                    )
+                                    .await;
                                 }
                                 Some(Event::Removed) => {
                                     // wait and double check if the file is really gone
@@ -1346,9 +1348,11 @@ pub fn subscription(path: &Path) -> Subscription<Message> {
 
                                     if !path.exists() {
                                         info!("Config file removed");
-                                        let _ = output
-                                            .send(Message::ConfigChanged(Box::default()))
-                                            .await;
+                                        send_or_log(
+                                            &mut output,
+                                            Message::ConfigChanged(Box::default()),
+                                        )
+                                        .await;
                                     }
                                 }
                                 None => {

--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -1,8 +1,8 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
-use crate::utils::remote_value::Remote;
+use crate::utils::{remote_value::Remote, send_or_log};
 use iced::{
     Subscription, Task,
-    futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending},
+    futures::{StreamExt, channel::mpsc::Sender, stream::pending},
     stream::channel,
 };
 use itertools::Either;
@@ -164,13 +164,15 @@ impl AudioService {
         match state {
             State::Init => match Self::init_service().await {
                 Ok(handle) => {
-                    let _ = output
-                        .send(ServiceEvent::Init(AudioService {
+                    send_or_log(
+                        output,
+                        ServiceEvent::Init(AudioService {
                             data: AudioData::default(),
                             commander: handle.sender.clone(),
                             wake: handle.wake.clone(),
-                        }))
-                        .await;
+                        }),
+                    )
+                    .await;
                     State::Active(handle)
                 }
                 Err(err) => {
@@ -184,23 +186,17 @@ impl AudioService {
                     State::Error
                 }
                 Some(PulseAudioServerEvent::Sinks(sinks)) => {
-                    let _ = output
-                        .send(ServiceEvent::Update(AudioEvent::Sinks(sinks)))
-                        .await;
+                    send_or_log(output, ServiceEvent::Update(AudioEvent::Sinks(sinks))).await;
 
                     State::Active(handle)
                 }
                 Some(PulseAudioServerEvent::Sources(sources)) => {
-                    let _ = output
-                        .send(ServiceEvent::Update(AudioEvent::Sources(sources)))
-                        .await;
+                    send_or_log(output, ServiceEvent::Update(AudioEvent::Sources(sources))).await;
 
                     State::Active(handle)
                 }
                 Some(PulseAudioServerEvent::ServerInfo(info)) => {
-                    let _ = output
-                        .send(ServiceEvent::Update(AudioEvent::ServerInfo(info)))
-                        .await;
+                    send_or_log(output, ServiceEvent::Update(AudioEvent::ServerInfo(info))).await;
 
                     State::Active(handle)
                 }

--- a/src/services/bluetooth/mod.rs
+++ b/src/services/bluetooth/mod.rs
@@ -1,8 +1,9 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
+use crate::utils::send_or_log;
 use dbus::{BatteryProxy, BluetoothDbus, DeviceProxy};
 use iced::{
     Subscription, Task,
-    futures::{SinkExt, Stream, StreamExt, channel::mpsc::Sender, stream::pending, stream_select},
+    futures::{Stream, StreamExt, channel::mpsc::Sender, stream::pending, stream_select},
     stream::channel,
 };
 use inotify::{Inotify, WatchMask};
@@ -181,12 +182,14 @@ impl BluetoothService {
                         Ok(data) => {
                             info!("Bluetooth service initialized");
 
-                            let _ = output
-                                .send(ServiceEvent::Init(BluetoothService {
+                            send_or_log(
+                                output,
+                                ServiceEvent::Init(BluetoothService {
                                     data,
                                     conn: conn.clone(),
-                                }))
-                                .await;
+                                }),
+                            )
+                            .await;
 
                             State::Active(conn)
                         }
@@ -210,7 +213,7 @@ impl BluetoothService {
                     Ok(mut events) => {
                         while events.next().await.is_some() {
                             if let Ok(data) = BluetoothService::initialize_data(&conn).await {
-                                let _ = output.send(ServiceEvent::Update(data)).await;
+                                send_or_log(output, ServiceEvent::Update(data)).await;
                             }
                         }
 

--- a/src/services/brightness.rs
+++ b/src/services/brightness.rs
@@ -1,8 +1,11 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
-use crate::{services::throttle::ThrottleExt, utils::remote_value::Remote};
+use crate::{
+    services::throttle::ThrottleExt,
+    utils::{remote_value::Remote, send_or_log},
+};
 use iced::{
     Subscription, Task,
-    futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending},
+    futures::{StreamExt, channel::mpsc::Sender, stream::pending},
     stream::channel,
 };
 use log::{debug, error, info, warn};
@@ -143,12 +146,14 @@ impl BrightnessService {
                         Ok(data) => {
                             let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
                             Self::start_commander(conn.clone(), device_path.clone(), rx);
-                            let _ = output
-                                .send(ServiceEvent::Init(BrightnessService {
+                            send_or_log(
+                                output,
+                                ServiceEvent::Init(BrightnessService {
                                     data,
                                     commander: tx,
-                                }))
-                                .await;
+                                }),
+                            )
+                            .await;
 
                             State::Active(device_path)
                         }
@@ -194,11 +199,13 @@ impl BrightnessService {
                                                         && new_value != current_value
                                                     {
                                                         current_value = new_value;
-                                                        let _ = output
-                                                            .send(ServiceEvent::Update(
-                                                                BrightnessEvent(new_value),
-                                                            ))
-                                                            .await;
+                                                        send_or_log(
+                                                            output,
+                                                            ServiceEvent::Update(BrightnessEvent(
+                                                                new_value,
+                                                            )),
+                                                        )
+                                                        .await;
                                                     }
 
                                                     break;

--- a/src/services/logind.rs
+++ b/src/services/logind.rs
@@ -1,9 +1,6 @@
 use super::{ReadOnlyService, ServiceEvent};
-use iced::{
-    Subscription,
-    futures::{SinkExt, StreamExt},
-    stream::channel,
-};
+use crate::utils::send_or_log;
+use iced::{Subscription, futures::StreamExt, stream::channel};
 use std::any::TypeId;
 use zbus::Connection;
 
@@ -26,7 +23,7 @@ impl ReadOnlyService for LogindService {
                     Ok(conn) => conn,
                     Err(e) => {
                         let err = format!("Failed to connect to system bus: {e}");
-                        let _ = output.send(ServiceEvent::Error(err)).await;
+                        send_or_log(&mut output, ServiceEvent::Error(err)).await;
                         return;
                     }
                 };
@@ -35,7 +32,7 @@ impl ReadOnlyService for LogindService {
                     Ok(p) => p,
                     Err(e) => {
                         let err = format!("Failed to create logind proxy: {e}");
-                        let _ = output.send(ServiceEvent::Error(err)).await;
+                        send_or_log(&mut output, ServiceEvent::Error(err)).await;
                         return;
                     }
                 };
@@ -44,18 +41,18 @@ impl ReadOnlyService for LogindService {
                     Ok(s) => s,
                     Err(e) => {
                         let err = format!("Failed to subscribe to PrepareForSleep: {e}");
-                        let _ = output.send(ServiceEvent::Error(err)).await;
+                        send_or_log(&mut output, ServiceEvent::Error(err)).await;
                         return;
                     }
                 };
 
-                let _ = output.send(ServiceEvent::Init(LogindService)).await;
+                send_or_log(&mut output, ServiceEvent::Init(LogindService)).await;
 
                 while let Some(signal) = stream.next().await {
                     if let Ok(args) = signal.args()
                         && !args.starting
                     {
-                        let _ = output.send(ServiceEvent::Update(ResumeEvent)).await;
+                        send_or_log(&mut output, ServiceEvent::Update(ResumeEvent)).await;
                     }
                 }
             })

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -407,12 +407,13 @@ impl MprisPlayerService {
                                     match res {
                                         Ok(bytes) => {
                                             state_data.fetched_covers.insert(url.clone());
-                                        send_or_log(
-                                            output,
-                                            ServiceEvent::Update(
-                                                Event::CoverFetched(url.clone(), bytes)
-                                            ),
-                                        ).await;
+                                            send_or_log(
+                                                output,
+                                                ServiceEvent::Update(
+                                                    Event::CoverFetched(url.clone(), bytes),
+                                                ),
+                                            )
+                                            .await;
                                         }
                                         Err(err) => {
                                             error!("Failed to fetch cover art from {url}: {err}");

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -1,10 +1,11 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
+use crate::utils::send_or_log;
 use dbus::MprisPlayerProxy;
 use iced::{
     Subscription,
     core::Bytes,
     futures::{
-        FutureExt, SinkExt, Stream, StreamExt,
+        FutureExt, Stream, StreamExt,
         channel::mpsc::Sender,
         future::{BoxFuture, join_all},
         select,
@@ -355,13 +356,15 @@ impl MprisPlayerService {
         match zbus::Connection::session().await {
             Ok(conn) => {
                 info!("MPRIS player service initialized");
-                let _ = output
-                    .send(ServiceEvent::Init(MprisPlayerService {
+                send_or_log(
+                    output,
+                    ServiceEvent::Init(MprisPlayerService {
                         data: Vec::new(),
                         conn: conn.clone(),
                         covers: HashMap::new(),
-                    }))
-                    .await;
+                    }),
+                )
+                .await;
                 State::Active(ActiveData::new(conn))
             }
             Err(err) => {
@@ -404,9 +407,12 @@ impl MprisPlayerService {
                                     match res {
                                         Ok(bytes) => {
                                             state_data.fetched_covers.insert(url.clone());
-                                            let _ = output.send(ServiceEvent::Update(
+                                        send_or_log(
+                                            output,
+                                            ServiceEvent::Update(
                                                 Event::CoverFetched(url.clone(), bytes)
-                                            )).await;
+                                            ),
+                                        ).await;
                                         }
                                         Err(err) => {
                                             error!("Failed to fetch cover art from {url}: {err}");
@@ -434,9 +440,7 @@ impl MprisPlayerService {
             Ok(data) => {
                 debug!("Refreshing MPRIS player data for {} players", data.len());
                 Self::check_cover_update(&data, state_data);
-                let _ = output
-                    .send(ServiceEvent::Update(Event::MetadataChanged(data)))
-                    .await;
+                send_or_log(output, ServiceEvent::Update(Event::MetadataChanged(data))).await;
             }
             Err(err) => {
                 error!("Failed to fetch MPRIS player data: {err}");

--- a/src/services/network/mod.rs
+++ b/src/services/network/mod.rs
@@ -1,11 +1,12 @@
 use super::{Service, ServiceEvent};
 use crate::services::ReadOnlyService;
+use crate::utils::send_or_log;
 use dbus::ConnectivityState;
 use dbus::NetworkDbus;
 use iced::futures::TryFutureExt;
 use iced::{
     Subscription, Task,
-    futures::{SinkExt, StreamExt, channel::mpsc::Sender},
+    futures::{StreamExt, channel::mpsc::Sender},
     stream::channel,
 };
 use iwd_dbus::IwdDbus;
@@ -452,14 +453,16 @@ impl NetworkService {
                     match maybe_backend {
                         Ok((data, choice)) => {
                             info!("Network service initialized");
-                            let _ = output
-                                .send(ServiceEvent::Init(NetworkService {
+                            send_or_log(
+                                output,
+                                ServiceEvent::Init(NetworkService {
                                     data,
                                     conn: conn.clone(),
                                     backend_choice: choice,
                                     pending_scan_devices: Vec::new(),
-                                }))
-                                .await;
+                                }),
+                            )
+                            .await;
                             State::Active(conn, choice)
                         }
                         Err(err) => {
@@ -499,7 +502,7 @@ impl NetworkService {
                                         matches!(event, NetworkEvent::WirelessDevice { .. });
                                     // Send the event to UI before exiting - UI needs the WirelessDevice data
                                     // (wifi_present and access_points) to populate the network menu
-                                    let _ = output.send(ServiceEvent::Update(event)).await;
+                                    send_or_log(output, ServiceEvent::Update(event)).await;
 
                                     if exit_loop {
                                         break;
@@ -532,7 +535,7 @@ impl NetworkService {
                                         // TODO: network manager leaves with device - we can also
                                         // do that, but would need a different way to disable
                                         // scanning
-                                        let _ = output.send(ServiceEvent::Update(event)).await;
+                                        send_or_log(output, ServiceEvent::Update(event)).await;
                                     }
                                 }
 

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -1,6 +1,7 @@
 use crate::services::{ReadOnlyService, ServiceEvent};
+use crate::utils::send_or_log;
 use iced::Subscription;
-use iced::futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending};
+use iced::futures::{StreamExt, channel::mpsc::Sender, stream::pending};
 use iced::stream::channel;
 use iced::widget::{image, svg};
 use log::{error, info};
@@ -116,11 +117,13 @@ impl NotificationsService {
             State::Init => match Self::init_service().await {
                 Ok((connection, event_tx)) => {
                     info!("Notifications service initialized");
-                    let _ = output
-                        .send(ServiceEvent::Init(NotificationsService {
+                    send_or_log(
+                        output,
+                        ServiceEvent::Init(NotificationsService {
                             connection: connection.clone(),
-                        }))
-                        .await;
+                        }),
+                    )
+                    .await;
                     State::Active(connection, event_tx)
                 }
                 Err(err) => {
@@ -135,7 +138,7 @@ impl NotificationsService {
                 while let Some(result) = stream.next().await {
                     match result {
                         Ok(event) => {
-                            let _ = output.send(ServiceEvent::Update(event)).await;
+                            send_or_log(output, ServiceEvent::Update(event)).await;
                         }
                         Err(e) => {
                             error!("Error receiving notification event: {e}");

--- a/src/services/privacy.rs
+++ b/src/services/privacy.rs
@@ -1,9 +1,8 @@
 use super::{ReadOnlyService, ServiceEvent};
+use crate::utils::send_or_log;
 use iced::{
     Subscription,
-    futures::{
-        FutureExt, SinkExt, Stream, StreamExt, channel::mpsc::Sender, select, stream::pending,
-    },
+    futures::{FutureExt, Stream, StreamExt, channel::mpsc::Sender, select, stream::pending},
     stream::channel,
 };
 use inotify::{EventMask, Inotify, WatchMask};
@@ -181,9 +180,7 @@ impl PrivacyService {
                     (Ok(pipewire), Ok(webcam)) => {
                         let data = PrivacyData::new();
 
-                        let _ = output
-                            .send(ServiceEvent::Init(PrivacyService { data }))
-                            .await;
+                        send_or_log(output, ServiceEvent::Init(PrivacyService { data })).await;
 
                         State::Active((pipewire, webcam))
                     }
@@ -212,7 +209,11 @@ impl PrivacyService {
                     value = pipewire.recv().fuse() => {
                         match value {
                             Some(event) => {
-                                let _ = output.send(ServiceEvent::Update(event)).await;
+                                send_or_log(
+                                    output,
+                                    ServiceEvent::Update(event),
+                                )
+                                .await;
                             }
                             None => {
                                 error!("Pipewire listener exited");
@@ -222,7 +223,11 @@ impl PrivacyService {
                     value = webcam.next().fuse() => {
                         match value {
                             Some(event) => {
-                                let _ = output.send(ServiceEvent::Update(event)).await;
+                                send_or_log(
+                                    output,
+                                    ServiceEvent::Update(event),
+                                )
+                                .await;
                             }
                             None => {
                                 error!("Webcam listener exited");

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -1,4 +1,5 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
+use crate::utils::send_or_log;
 use dbus::{
     DBusMenuProxy, Layout, StatusNotifierItemProxy, StatusNotifierWatcher,
     StatusNotifierWatcherProxy,
@@ -7,7 +8,7 @@ use freedesktop_icons::lookup;
 use iced::{
     Subscription, Task,
     futures::{
-        SinkExt, Stream, StreamExt,
+        Stream, StreamExt,
         channel::mpsc::Sender,
         stream::{pending, select_all},
         stream_select,
@@ -559,12 +560,14 @@ impl TrayService {
                         Ok(data) => {
                             info!("Tray service initialized");
 
-                            let _ = output
-                                .send(ServiceEvent::Init(TrayService {
+                            send_or_log(
+                                output,
+                                ServiceEvent::Init(TrayService {
                                     data,
                                     _conn: conn.clone(),
-                                }))
-                                .await;
+                                }),
+                            )
+                            .await;
 
                             State::Active(conn)
                         }
@@ -591,7 +594,7 @@ impl TrayService {
 
                             let reload_events = matches!(event, TrayEvent::Registered(_));
 
-                            let _ = output.send(ServiceEvent::Update(event)).await;
+                            send_or_log(output, ServiceEvent::Update(event)).await;
 
                             if reload_events {
                                 break;

--- a/src/services/upower/mod.rs
+++ b/src/services/upower/mod.rs
@@ -1,12 +1,14 @@
 use super::{ReadOnlyService, Service, ServiceEvent};
 use crate::{
-    components::icons::StaticIcon, services::throttle::ThrottleExt, utils::IndicatorState,
+    components::icons::StaticIcon,
+    services::throttle::ThrottleExt,
+    utils::{IndicatorState, send_or_log},
 };
 use dbus::{DeviceProxy, PowerProfilesProxy, SystemBattery, UPowerDbus, UPowerProxy, UpDeviceKind};
 use iced::{
     Subscription,
     futures::{
-        SinkExt, Stream, StreamExt,
+        Stream, StreamExt,
         channel::mpsc::Sender,
         stream::{once, pending, select_all},
         stream_select,
@@ -719,7 +721,7 @@ impl UPowerService {
                             power_profile,
                             conn: conn.clone(),
                         };
-                        let _ = output.send(ServiceEvent::Init(service)).await;
+                        send_or_log(output, ServiceEvent::Init(service)).await;
 
                         State::Active(conn, system_battery.map(|b| b.1), peripheral_paths)
                     }
@@ -740,7 +742,7 @@ impl UPowerService {
                 {
                     Ok(mut events) => {
                         while let Some(event) = events.next().await {
-                            let _ = output.send(ServiceEvent::Update(event)).await;
+                            send_or_log(output, ServiceEvent::Update(event)).await;
                         }
 
                         State::Active(conn, system_battery_paths, peripheral_paths)

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,9 +1,20 @@
 use std::time::Duration;
 
+use iced::futures::{SinkExt, channel::mpsc};
+use log::warn;
 use unicode_segmentation::UnicodeSegmentation;
 
 pub mod launcher;
 pub mod remote_value;
+
+/// Send a message through an iced `mpsc::Sender`, logging a warning
+/// if the receiver has been dropped instead of silently swallowing the
+/// error.
+pub async fn send_or_log<T: std::fmt::Debug>(output: &mut mpsc::Sender<T>, msg: T) {
+    if let Err(e) = output.send(msg).await {
+        warn!("Channel send failed (receiver dropped): {e:?}");
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub enum IndicatorState {


### PR DESCRIPTION
Adds a `send_or_log` utility function in `src/utils/mod.rs` that logs a warning when an iced channel send fails (receiver dropped), instead of silently discarding the error with `let _ = output.send(...)`.

Affected files:
- `src/utils/mod.rs` — new `send_or_log` helper
- `src/services/audio.rs`, `bluetooth/mod.rs`, `brightness.rs`, `logind.rs`, `mpris/mod.rs`, `network/mod.rs`, `notifications/mod.rs`, `privacy.rs`, `tray/mod.rs`, `upower/mod.rs` — replace all `let _ = output.send()` patterns
- `src/config.rs` — same replacement in config subscription

Also removes unused `SinkExt` imports from all affected service files.
No behavior changes — pure quality-of-life improvement for debugging.