### PR TITLE
refactor(network): rename AccessPoint to AccessPointData

### DIFF
--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -9,7 +9,7 @@ use crate::{
     services::{
         ReadOnlyService, Service, ServiceEvent,
         network::{
-            AccessPoint, ActiveConnectionInfo, KnownConnection, NetworkCommand, NetworkEvent,
+            AccessPointData, ActiveConnectionInfo, KnownConnection, NetworkCommand, NetworkEvent,
             NetworkService, Vpn, dbus::ConnectivityState,
         },
     },
@@ -87,7 +87,7 @@ pub enum Message {
     ScanNearByWiFi,
     WiFiMore(SurfaceId),
     VpnMore(SurfaceId),
-    SelectAccessPoint(AccessPoint),
+    SelectAccessPoint(AccessPointData),
     RequestWiFiPassword(SurfaceId, String),
     ConfirmOpenNetwork(String),
     ToggleVpn(Vpn),
@@ -541,7 +541,7 @@ impl NetworkSettings {
                             let is_known = service.known_connections.iter().any(|c| {
                                 matches!(
                                     c,
-                                    KnownConnection::AccessPoint(AccessPoint { ssid, .. }) if ssid == &ac.ssid
+                                    KnownConnection::AccessPoint(AccessPointData { ssid, .. }) if ssid == &ac.ssid
                                 )
                             });
 

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -3,7 +3,7 @@ use crate::services::{
     network::{NetworkBackend, NetworkData, NetworkEvent},
 };
 
-use super::{AccessPoint, ActiveConnectionInfo, KnownConnection, Vpn};
+use super::{AccessPointData, ActiveConnectionInfo, KnownConnection, Vpn};
 use iced::futures::{Stream, StreamExt, stream::select_all};
 use itertools::Itertools;
 use log::{debug, warn};
@@ -87,7 +87,7 @@ impl super::NetworkBackend for NetworkDbus<'_> {
 
     async fn select_access_point(
         &self,
-        access_point: &AccessPoint,
+        access_point: &AccessPointData,
         password: Option<String>,
     ) -> anyhow::Result<()> {
         let settings = NetworkSettingsDbus::new(self.0.inner().connection()).await?;
@@ -590,7 +590,7 @@ fn connection_id(settings: &HashMap<String, HashMap<String, OwnedValue>>) -> Opt
 impl NetworkDbus<'_> {
     pub async fn known_connections_internal(
         &self,
-        wireless_access_points: &[AccessPoint],
+        wireless_access_points: &[AccessPointData],
     ) -> anyhow::Result<Vec<KnownConnection>> {
         let settings = NetworkSettingsDbus::new(self.0.inner().connection()).await?;
 
@@ -655,7 +655,7 @@ impl NetworkDbus<'_> {
         Ok(wireless_devices)
     }
 
-    pub async fn wireless_access_points(&self) -> anyhow::Result<Vec<AccessPoint>> {
+    pub async fn wireless_access_points(&self) -> anyhow::Result<Vec<AccessPointData>> {
         let wireless_devices = self.wireless_devices().await?;
         let wireless_access_point_futures: Vec<_> = wireless_devices
             .into_iter()
@@ -683,7 +683,7 @@ impl NetworkDbus<'_> {
                     .map_or_else(|| DeviceState::Unknown, DeviceState::from);
 
                 // Sort by strength and remove duplicates
-                let mut aps = HashMap::<String, AccessPoint>::new();
+                let mut aps = HashMap::<String, AccessPointData>::new();
                 for ap in access_points {
                     let ap = AccessPointProxy::builder(self.0.inner().connection())
                         .path(ap)?
@@ -696,7 +696,7 @@ impl NetworkDbus<'_> {
                     let max_bitrate = ap.max_bitrate().await.unwrap_or_default();
                     let frequency = ap.frequency().await.unwrap_or_default();
                     if let Some(access_point) = aps.get(&ssid)
-                        && AccessPoint::is_better(
+                        && AccessPointData::is_better(
                             access_point.max_bitrate,
                             access_point.frequency,
                             access_point.strength,
@@ -710,7 +710,7 @@ impl NetworkDbus<'_> {
 
                     aps.insert(
                         ssid.clone(),
-                        AccessPoint {
+                        AccessPointData {
                             ssid,
                             strength,
                             max_bitrate,
@@ -735,7 +735,7 @@ impl NetworkDbus<'_> {
 
         let mut wireless_access_points = Vec::with_capacity(wireless_access_point_futures.len());
         for f in wireless_access_point_futures {
-            let mut access_points: anyhow::Result<Vec<AccessPoint>> = f.await;
+            let mut access_points: anyhow::Result<Vec<AccessPointData>> = f.await;
             if let Ok(access_points) = &mut access_points {
                 wireless_access_points.append(access_points);
             }
@@ -743,9 +743,9 @@ impl NetworkDbus<'_> {
 
         let wireless_access_points = wireless_access_points
             .into_iter()
-            .fold(HashMap::<String, AccessPoint>::new(), |mut acc, ap| {
+            .fold(HashMap::<String, AccessPointData>::new(), |mut acc, ap| {
                 if let Some(existing) = acc.get(&ap.ssid)
-                    && AccessPoint::is_better(
+                    && AccessPointData::is_better(
                         existing.max_bitrate,
                         existing.frequency,
                         existing.strength,

--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -24,7 +24,7 @@ use crate::services::bluetooth::BluetoothService;
 use zbus::interface;
 
 use super::dbus::DeviceState;
-use super::{AccessPoint, ActiveConnectionInfo, KnownConnection, NetworkBackend, NetworkEvent};
+use super::{AccessPointData, ActiveConnectionInfo, KnownConnection, NetworkBackend, NetworkEvent};
 use iced::futures::future::join_all;
 use iced::futures::stream::select_all;
 use iced::futures::{Stream, StreamExt};
@@ -145,7 +145,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
     /// List known (provisioned) SSIDs.
     async fn known_connections(&self) -> anyhow::Result<Vec<KnownConnection>> {
         let nets = self.reachable_networks().await?;
-        let mut networks = HashMap::<String, AccessPoint>::new();
+        let mut networks = HashMap::<String, AccessPointData>::new();
         for (n, signal_strength) in nets {
             if n.known_network().await.is_err() {
                 continue;
@@ -153,7 +153,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
             let ssid = n.name().await?;
             let path = n.inner().path().clone().into();
             let device_path = n.device().await?.clone();
-            let access_point = AccessPoint {
+            let access_point = AccessPointData {
                 ssid: ssid.clone(),
                 path,
                 device_path,
@@ -167,7 +167,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
 
             // maybe IWD will provide frequency and bitrate in the future
             if let Some(existing) = networks.get(&ssid)
-                && AccessPoint::is_better(
+                && AccessPointData::is_better(
                     existing.max_bitrate,
                     existing.frequency,
                     existing.strength,
@@ -208,7 +208,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
 
     async fn select_access_point(
         &self,
-        ap: &AccessPoint,
+        ap: &AccessPointData,
         password: Option<String>,
     ) -> anyhow::Result<()> {
         // Get the agent manager
@@ -794,7 +794,7 @@ impl IwdDbus<'_> {
     }
 
     /// Scan and list available access points.
-    pub async fn wireless_access_points(&self) -> anyhow::Result<Vec<AccessPoint>> {
+    pub async fn wireless_access_points(&self) -> anyhow::Result<Vec<AccessPointData>> {
         let mut aps = Vec::new();
         {
             let nets = self.reachable_networks().await?;
@@ -803,7 +803,7 @@ impl IwdDbus<'_> {
                 let public = net.type_().await? == "open";
                 let path = net.inner().path().clone().into();
                 let device_path = net.device().await?.clone();
-                aps.push(AccessPoint {
+                aps.push(AccessPointData {
                     ssid,
                     state: DeviceState::Unknown, // TODO:
                     // _s is between 0 and -10000
@@ -821,9 +821,9 @@ impl IwdDbus<'_> {
 
         let aps = aps
             .into_iter()
-            .fold(HashMap::<String, AccessPoint>::new(), |mut acc, ap| {
+            .fold(HashMap::<String, AccessPointData>::new(), |mut acc, ap| {
                 if let Some(existing) = acc.get(&ap.ssid)
-                    && AccessPoint::is_better(
+                    && AccessPointData::is_better(
                         existing.max_bitrate,
                         existing.frequency,
                         existing.strength,

--- a/src/services/network/mod.rs
+++ b/src/services/network/mod.rs
@@ -41,7 +41,7 @@ pub trait NetworkBackend: Send + Sync {
     /// Returns the updated list of known connections.
     async fn select_access_point(
         &self,
-        ap: &AccessPoint,
+        ap: &AccessPointData,
         password: Option<String>,
     ) -> anyhow::Result<()>;
 
@@ -63,11 +63,11 @@ pub enum NetworkEvent {
     Connectivity(ConnectivityState),
     WirelessDevice {
         wifi_present: bool,
-        wireless_access_points: Vec<AccessPoint>,
+        wireless_access_points: Vec<AccessPointData>,
     },
     ActiveConnections(Vec<ActiveConnectionInfo>),
     KnownConnections(Vec<KnownConnection>),
-    WirelessAccessPoint(Vec<AccessPoint>),
+    WirelessAccessPoint(Vec<AccessPointData>),
     Strength((Option<OwnedObjectPath>, String, u8)),
     RequestPasswordForSSID(String),
     ScanRequested(Vec<OwnedObjectPath>),
@@ -80,12 +80,12 @@ pub enum NetworkCommand {
     ScanNearByWiFi,
     ToggleWiFi,
     ToggleAirplaneMode,
-    SelectAccessPoint((AccessPoint, Option<String>)),
+    SelectAccessPoint((AccessPointData, Option<String>)),
     ToggleVpn(Vpn),
 }
 
 #[derive(Debug, PartialEq, Eq, Clone)]
-pub struct AccessPoint {
+pub struct AccessPointData {
     pub ssid: String,
     pub strength: u8,
     pub max_bitrate: u32,
@@ -97,7 +97,7 @@ pub struct AccessPoint {
     pub device_path: OwnedObjectPath,
 }
 
-impl AccessPoint {
+impl AccessPointData {
     /// Returns true if the first access point (by max_bitrate, frequency, strength) is better than the second.
     /// Comparison order: max_bitrate > frequency > strength (higher values are better)
     #[inline]
@@ -123,7 +123,7 @@ pub struct Vpn {
 
 #[derive(Debug, Clone)]
 pub enum KnownConnection {
-    AccessPoint(AccessPoint),
+    AccessPoint(AccessPointData),
     Vpn(Vpn),
 }
 
@@ -155,7 +155,7 @@ impl ActiveConnectionInfo {
 #[derive(Debug, Default, Clone)]
 pub struct NetworkData {
     pub wifi_present: bool,
-    pub wireless_access_points: Vec<AccessPoint>,
+    pub wireless_access_points: Vec<AccessPointData>,
     pub active_connections: Vec<ActiveConnectionInfo>,
     pub known_connections: Vec<KnownConnection>,
     pub wifi_enabled: bool,
@@ -363,7 +363,7 @@ impl NetworkBackend for BackendChoiceWithConnection {
 
     async fn select_access_point(
         &self,
-        ap: &AccessPoint,
+        ap: &AccessPointData,
         password: Option<String>,
     ) -> anyhow::Result<()> {
         match self.choice {


### PR DESCRIPTION
Renames the `AccessPoint` struct (the application-level data type, not the D-Bus proxy trait) to `AccessPointData` to disambiguate it from the various D-Bus `AccessPoint` proxy traits used by the NetworkManager and IWD backends.

- `KnownConnection::AccessPoint(AccessPointData)` variant name kept as-is
- `NetworkEvent::WirelessAccessPoint(Vec<AccessPointData>)` variant name kept as-is
- `NetworkCommand::SelectAccessPoint(AccessPointData, ...)` variant name kept as-is