### PR TITLE
fix(logger): scope stdout log duplication to debug builds, guard OSD handler

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -582,7 +582,12 @@ impl App {
                     IpcCommand::BrightnessDown { .. } => self.settings.brightness_adjust(false),
                     IpcCommand::ToggleAirplaneMode { .. } => self.settings.toggle_airplane(),
                     IpcCommand::ToggleIdleInhibitor { .. } => self.settings.toggle_idle_inhibitor(),
-                    IpcCommand::ToggleVisibility => unreachable!(),
+                    IpcCommand::ToggleVisibility => {
+                        warn!(
+                            "IpcCommand::ToggleVisibility reached IpcOsdCommand handler; use Message::ToggleVisibility instead"
+                        );
+                        modules::settings::Action::None
+                    }
                 };
                 if let settings::Action::Command(task) = action {
                     tasks.push(task.map(Message::Settings));

--- a/src/main.rs
+++ b/src/main.rs
@@ -88,7 +88,6 @@ fn main() -> iced::Result {
             .build(),
     )
     .log_to_file(FileSpec::default().directory(logdir))
-    .duplicate_to_stdout(flexi_logger::Duplicate::All)
     .rotate(
         Criterion::AgeOrSize(Age::Day, TMP_FILE_SIZE),
         Naming::Timestamps,


### PR DESCRIPTION
The unconditional `duplicate_to_stdout(Duplicate::All)` on the primary logger made the conditional debug-only duplication on line 97 dead code. Removed the unconditional call so stdout duplication only happens in debug builds.

Also replaces `unreachable!()` for `IpcCommand::ToggleVisibility` in the `IpcOsdCommand` handler with a logged warning, since the invariant was externally enforced and fragile.