### PR TITLE
make add() idempotent and guard run loop against panics

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -136,30 +136,52 @@ fn main() -> iced::Result {
         config::Layer::Overlay => Layer::Overlay,
     };
 
-    iced::application(
-        App::new((logger, config.clone(), config_path)),
-        App::update,
-        App::view,
-    )
-    .layer_shell(LayerShellSettings {
-        anchor: match config.position {
-            Position::Top => Anchor::TOP,
-            Position::Bottom => Anchor::BOTTOM,
-        } | Anchor::LEFT
-            | Anchor::RIGHT,
-        layer: iced_layer,
-        exclusive_zone: height as i32,
-        size: Some((0, height as u32)),
-        keyboard_interactivity: KeyboardInteractivity::None,
-        namespace: "ashell-main-layer".into(),
-        ..Default::default()
-    })
-    .subscription(App::subscription)
-    .theme(App::theme)
-    .scale_factor(App::scale_factor)
-    .font(NERD_FONT)
-    .font(NERD_FONT_MONO)
-    .font(CUSTOM_FONT)
-    .default_font(font)
-    .run()
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        iced::application(
+            App::new((logger, config.clone(), config_path)),
+            App::update,
+            App::view,
+        )
+        .layer_shell(LayerShellSettings {
+            anchor: match config.position {
+                Position::Top => Anchor::TOP,
+                Position::Bottom => Anchor::BOTTOM,
+            } | Anchor::LEFT
+                | Anchor::RIGHT,
+            layer: iced_layer,
+            exclusive_zone: height as i32,
+            size: Some((0, height as u32)),
+            keyboard_interactivity: KeyboardInteractivity::None,
+            namespace: "ashell-main-layer".into(),
+            ..Default::default()
+        })
+        .subscription(App::subscription)
+        .theme(App::theme)
+        .scale_factor(App::scale_factor)
+        .font(NERD_FONT)
+        .font(NERD_FONT_MONO)
+        .font(CUSTOM_FONT)
+        .default_font(font)
+        .run()
+    }));
+
+    match result {
+        Ok(run_result) => run_result,
+        Err(payload) => {
+            // The default panic hook already logged the panic + backtrace via
+            // the panic::set_hook above. Convert the payload into something
+            // we can log a second time at error level (some hooks run before
+            // the logger is ready in tests) and return an EventLoop error so
+            // systemd/user-service managers can decide to restart us.
+            let msg = if let Some(s) = payload.downcast_ref::<&'static str>() {
+                (*s).to_string()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "non-string panic payload".to_string()
+            };
+            error!("ashell run loop panicked: {msg}");
+            Err(iced::Error::EventLoop(format!("run loop panicked: {msg}")))
+        }
+    }
 }

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -218,61 +218,7 @@ impl Outputs {
     ) -> Task<Message> {
         let target = Self::name_in_config(name, request_outputs);
 
-        if target {
-            debug!("Found target output, creating a new layer surface");
-
-            let (id, task) =
-                Self::create_output_layers(style, Some(output_id), position, layer, scale_factor);
-
-            let destroy_task = match self
-                .entries
-                .iter()
-                .position(|(key, _, _)| key.as_str() == name)
-            {
-                Some(index) => {
-                    let old_output = self.entries.swap_remove(index);
-
-                    match old_output.1 {
-                        Some(shell_info) => shell_info.destroy_surfaces(),
-                        _ => Task::none(),
-                    }
-                }
-                _ => Task::none(),
-            };
-
-            self.entries.push((
-                name.to_owned(),
-                Some(ShellInfo {
-                    id,
-                    menu: Menu::new(),
-                    position,
-                    layer,
-                    style,
-                    scale_factor,
-                    output_logical_height: None,
-                }),
-                Some(output_id),
-            ));
-
-            // remove fallback layer surface
-            let destroy_fallback_task = match self
-                .entries
-                .iter()
-                .position(|(_, _, output)| output.is_none())
-            {
-                Some(index) => {
-                    let old_output = self.entries.swap_remove(index);
-
-                    match old_output.1 {
-                        Some(shell_info) => shell_info.destroy_surfaces(),
-                        _ => Task::none(),
-                    }
-                }
-                _ => Task::none(),
-            };
-
-            Task::batch(vec![destroy_task, destroy_fallback_task, task])
-        } else {
+        if !target {
             debug!(
                 "Output {:?} does not match configured output target {:?}",
                 name, request_outputs
@@ -280,8 +226,75 @@ impl Outputs {
 
             self.entries.push((name.to_owned(), None, Some(output_id)));
 
-            Task::none()
+            return Task::none();
         }
+
+        // Idempotency: if we already have a live shell on this exact
+        // (name, output_id), do nothing. This guards against double-Added
+        // races (e.g. compositor re-announces an output while a fallback
+        // surface is still being torn down) and avoids needless wgpu
+        // surface churn.
+        if let Some((_, Some(_), Some(existing_output_id))) =
+            self.entries.iter().find(|(key, _, _)| key.as_str() == name)
+            && *existing_output_id == output_id
+        {
+            debug!("Output {name:?} already registered, skipping add()");
+            return Task::none();
+        }
+
+        debug!("Found target output, creating a new layer surface");
+
+        let (id, task) =
+            Self::create_output_layers(style, Some(output_id), position, layer, scale_factor);
+
+        let destroy_task = match self
+            .entries
+            .iter()
+            .position(|(key, _, _)| key.as_str() == name)
+        {
+            Some(index) => {
+                let old_output = self.entries.swap_remove(index);
+
+                match old_output.1 {
+                    Some(shell_info) => shell_info.destroy_surfaces(),
+                    _ => Task::none(),
+                }
+            }
+            _ => Task::none(),
+        };
+
+        self.entries.push((
+            name.to_owned(),
+            Some(ShellInfo {
+                id,
+                menu: Menu::new(),
+                position,
+                layer,
+                style,
+                scale_factor,
+                output_logical_height: None,
+            }),
+            Some(output_id),
+        ));
+
+        // remove fallback layer surface
+        let destroy_fallback_task = match self
+            .entries
+            .iter()
+            .position(|(_, _, output)| output.is_none())
+        {
+            Some(index) => {
+                let old_output = self.entries.swap_remove(index);
+
+                match old_output.1 {
+                    Some(shell_info) => shell_info.destroy_surfaces(),
+                    _ => Task::none(),
+                }
+            }
+            _ => Task::none(),
+        };
+
+        Task::batch(vec![destroy_task, destroy_fallback_task, task])
     }
 
     pub fn remove<Message: 'static>(


### PR DESCRIPTION
Guard against double-Added races in `Outputs::add()`: if a live shell already exists for the exact `(name, output_id)` pair, skip re-creating the layer surface. This prevents needless wgpu surface churn when the compositor re-announces an output while a previous surface is still being torn down.

Also wrap the iced run loop in `catch_unwind` so wgpu/compositor panics produce a clean logged exit (with backtrace from the existing panic hook) instead of a silent core dump, making systemd restarts reliable.


- Depends on MalpenZibo/iced_layershell#23
- Closes #613
