### PR TITLE
fix(copr): update container to fedora:latest and add proper spec dependencies

### DIFF
--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -10,7 +10,7 @@ jobs:
   copr:
     runs-on: ubuntu-latest
     container:
-      image: fedora:42
+      image: fedora:latest
     env:
       COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
     steps:
@@ -32,7 +32,7 @@ jobs:
         run: cargo install cargo-rpm --locked
       - name: Prepare RPM packaging
         run: |
-          if [ ! -d .rpm ]; then cargo rpm init; fi
+          if [ ! -f .rpm/ashell.spec ]; then cargo rpm init; fi
       - name: Build SRPM
         run: cargo rpm build -v
       - name: Locate SRPM

--- a/.github/workflows/copr-build.yml
+++ b/.github/workflows/copr-build.yml
@@ -10,7 +10,7 @@ jobs:
   copr:
     runs-on: ubuntu-latest
     container:
-      image: fedora:latest
+      image: fedora:44
     env:
       COPR_CONFIG: ${{ secrets.COPR_CONFIG }}
     steps:
@@ -20,7 +20,8 @@ jobs:
           dnf -y install git cargo rust rpm-build copr-cli gcc make pkgconf-pkg-config \
             pipewire-devel libinput-devel systemd-devel dbus-devel wayland-devel \
             libxkbcommon-devel mesa-libEGL-devel pango-devel cairo-devel glib2-devel \
-            openssl-devel fontconfig-devel freetype-devel clang-devel
+            openssl-devel fontconfig-devel freetype-devel clang-devel llvm-devel \
+            pulseaudio-libs-devel
           dnf -y clean all
       - name: Configure copr-cli
         if: env.COPR_CONFIG != ''

--- a/.rpm/ashell.spec
+++ b/.rpm/ashell.spec
@@ -2,31 +2,66 @@
 %define __os_install_post %{_dbpath}/brp-compress
 %define debug_package %{nil}
 
+%global rust_version 1.89
+
 Name: ashell
-Summary: A ready to go Wayland status bar for Hyprland
+Summary: A ready to go Wayland status bar for Hyprland and Niri
 Version: @@VERSION@@
 Release: @@RELEASE@@%{?dist}
 License: GPL-3.0-or-later
-Group: Applications/System
-Source0: %{name}-%{version}.tar.gz
 URL: https://github.com/MalpenZibo/ashell
+Source0: %{name}-%{version}.tar.gz
 
-BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
+BuildRequires:  cargo
+BuildRequires:  rust >= %{rust_version}
+BuildRequires:  gcc
+BuildRequires:  make
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  pipewire-devel
+BuildRequires:  libinput-devel
+BuildRequires:  systemd-devel
+BuildRequires:  dbus-devel
+BuildRequires:  wayland-devel
+BuildRequires:  libxkbcommon-devel
+BuildRequires:  mesa-libEGL-devel
+BuildRequires:  pango-devel
+BuildRequires:  cairo-devel
+BuildRequires:  glib2-devel
+BuildRequires:  openssl-devel
+BuildRequires:  fontconfig-devel
+BuildRequires:  freetype-devel
+BuildRequires:  clang-devel
+BuildRequires:  llvm-devel
+BuildRequires:  systemd-rpm-macros
+
+Requires:       libwayland-client
+Requires:       pipewire-libs
+Requires:       pulseaudio-libs
 
 %description
-%{summary}
+A ready to go Wayland status bar for Hyprland and Niri.
 
 %prep
 %setup -q
 
+%build
+cargo build --release
+
 %install
-rm -rf %{buildroot}
-mkdir -p %{buildroot}
-cp -a * %{buildroot}
+install -Dm755 target/release/ashell %{buildroot}%{_bindir}/ashell
+
+%check
+%{_bindir}/ashell --help
 
 %clean
 rm -rf %{buildroot}
 
 %files
-%defattr(-,root,root,-)
-%{_bindir}/*
+%{_bindir}/ashell
+
+%license LICENSE
+%doc README.md
+
+%changelog
+* Mon Jun 22 2026 Simone Camito <scamito@outlook.it> - @@VERSION@@-@@RELEASE@@
+- Initial COPR build

--- a/.rpm/ashell.spec
+++ b/.rpm/ashell.spec
@@ -2,67 +2,27 @@
 %define __os_install_post %{_dbpath}/brp-compress
 %define debug_package %{nil}
 
-%global rust_version 1.89
-
 Name: ashell
-Summary: A ready to go Wayland status bar for Hyprland and Niri
+Summary: A ready to go Wayland status bar for Hyprland
 Version: @@VERSION@@
 Release: @@RELEASE@@%{?dist}
 License: GPL-3.0-or-later
-URL: https://github.com/MalpenZibo/ashell
 Source0: %{name}-%{version}.tar.gz
-
-BuildRequires:  cargo
-BuildRequires:  rust >= %{rust_version}
-BuildRequires:  gcc
-BuildRequires:  make
-BuildRequires:  pkgconf-pkg-config
-BuildRequires:  pipewire-devel
-BuildRequires:  libinput-devel
-BuildRequires:  systemd-devel
-BuildRequires:  dbus-devel
-BuildRequires:  wayland-devel
-BuildRequires:  libxkbcommon-devel
-BuildRequires:  mesa-libEGL-devel
-BuildRequires:  pango-devel
-BuildRequires:  cairo-devel
-BuildRequires:  glib2-devel
-BuildRequires:  openssl-devel
-BuildRequires:  fontconfig-devel
-BuildRequires:  freetype-devel
-BuildRequires:  clang-devel
-BuildRequires:  llvm-devel
-BuildRequires:  pulseaudio-libs-devel
-BuildRequires:  systemd-rpm-macros
-
-Requires:       libwayland-client
-Requires:       pipewire-libs
-Requires:       pulseaudio-libs
+URL: https://github.com/MalpenZibo/ashell
 
 %description
-A ready to go Wayland status bar for Hyprland and Niri.
+%{summary}
 
 %prep
 %setup -q
 
-%build
-cargo build --release
-
 %install
-install -Dm755 target/release/ashell %{buildroot}%{_bindir}/ashell
-
-%check
-test -x %{buildroot}%{_bindir}/ashell
+rm -rf %{buildroot}
+mkdir -p %{buildroot}
+cp -a * %{buildroot}
 
 %clean
 rm -rf %{buildroot}
 
 %files
-%{_bindir}/ashell
-
-%license LICENSE
-%doc README.md
-
-%changelog
-* Mon Jun 22 2026 Simone Camito <scamito@outlook.it> - @@VERSION@@-@@RELEASE@@
-- Initial COPR build
+%{_bindir}/*

--- a/.rpm/ashell.spec
+++ b/.rpm/ashell.spec
@@ -32,6 +32,7 @@ BuildRequires:  fontconfig-devel
 BuildRequires:  freetype-devel
 BuildRequires:  clang-devel
 BuildRequires:  llvm-devel
+BuildRequires:  pulseaudio-libs-devel
 BuildRequires:  systemd-rpm-macros
 
 Requires:       libwayland-client
@@ -51,7 +52,7 @@ cargo build --release
 install -Dm755 target/release/ashell %{buildroot}%{_bindir}/ashell
 
 %check
-%{_bindir}/ashell --help
+test -x %{buildroot}%{_bindir}/ashell
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
fix(copr): pin Fedora and ensure host build deps

Addresses review feedback on the COPR build pipeline.

### Changes

**`.github/workflows/copr-build.yml`**
- Container pinned to `fedora:42` → `fedora:44` (specific release, not `:latest`, so a future Fedora can't silently break the workflow).
- Init guard: check for `.rpm/ashell.spec` (file) instead of `.rpm` (directory).
- Added `pulseaudio-libs-devel` and `llvm-devel` to the workflow's `dnf install` so the host compile of `libpulse-binding` (via `cargo rpm build`) succeeds.

### Spec reverted to the cargo-rpm binary model

`Cargo.toml` still drives packaging through `[package.metadata.rpm]`, which packs only the **prebuilt** binary into `Source0`. The previous `%build`/`%install` assumed full source and would fail in mock with "could not find Cargo.toml". The spec is reverted to the working `cp -a * %{buildroot}` binary-repackaging install, keeping only the harmless modernizations (no `Group:`/`BuildRoot:`/`%defattr`). No `BuildRequires`/`Requires` are needed because rpmbuild does not compile in this model.

The COPR project config (dropped aarch64 chroots, Niri in description) is unchanged.