### PR TITLE
fix(iwd): derive AccessPoint state and working from connection status

### DIFF
--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -84,6 +84,17 @@ fn map_iwd_rssi_to_percent(rssi_hundredths: i16) -> u8 {
     percent.round() as u8
 }
 
+/// Maps an IWD network's connection status to the `DeviceState` reported for
+/// its `AccessPoint`. A connected network is `Activated`; everything else is
+/// `Disconnected`.
+fn ap_state_from_connected(connected: bool) -> DeviceState {
+    if connected {
+        DeviceState::Activated
+    } else {
+        DeviceState::Disconnected
+    }
+}
+
 impl<'a> Deref for IwdDbus<'a> {
     type Target = ObjectManagerProxy<'a>;
     fn deref(&self) -> &Self::Target {
@@ -161,11 +172,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
                 strength: map_iwd_rssi_to_percent(signal_strength),
                 max_bitrate: 0,
                 frequency: 0,
-                state: if connected {
-                    DeviceState::Activated
-                } else {
-                    DeviceState::Disconnected
-                },
+                state: ap_state_from_connected(connected),
                 public: n.type_().await? == "open",
                 working: connected,
             };
@@ -629,9 +636,9 @@ impl IwdDbus<'_> {
                     .boxed(),
             );
 
-            // Register signal level agent with thresholds aligned to common bar ranges
-            // Bar ranges: >80% (5 bars), >55% (4 bars), >30% (3 bars), >5% (2 bars), ≤5% (1 bar)
-            // Using linear mapping, this translates to RSSI thresholds:
+            // Register signal level agent with thresholds aligned to NM's bar ranges
+            // NM's bar ranges: >80% (5 bars), >55% (4 bars), >30% (3 bars), >5% (2 bars), ≤5% (1 bar)
+            // Using NM linear mapping, this translates to RSSI thresholds:
             // 80% → -52 dBm, 55% → -67 dBm, 30% → -82 dBm, 5% → -97 dBm
             let signal_thresholds = [-52, -67, -82, -97];
             station
@@ -811,11 +818,7 @@ impl IwdDbus<'_> {
                 let connected = net.connected().await?;
                 aps.push(AccessPoint {
                     ssid,
-                    state: if connected {
-                        DeviceState::Activated
-                    } else {
-                        DeviceState::Disconnected
-                    },
+                    state: ap_state_from_connected(connected),
                     // _s is between 0 and -10000
                     // should be between 0 and 100
                     strength: map_iwd_rssi_to_percent(signal_strength),

--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -153,6 +153,7 @@ impl super::NetworkBackend for IwdDbus<'_> {
             let ssid = n.name().await?;
             let path = n.inner().path().clone().into();
             let device_path = n.device().await?.clone();
+            let connected = n.connected().await?;
             let access_point = AccessPoint {
                 ssid: ssid.clone(),
                 path,
@@ -160,9 +161,13 @@ impl super::NetworkBackend for IwdDbus<'_> {
                 strength: map_iwd_rssi_to_percent(signal_strength),
                 max_bitrate: 0,
                 frequency: 0,
-                state: DeviceState::Unknown, // TODO:
+                state: if connected {
+                    DeviceState::Activated
+                } else {
+                    DeviceState::Disconnected
+                },
                 public: n.type_().await? == "open",
-                working: false, // TODO:
+                working: connected,
             };
 
             // maybe IWD will provide frequency and bitrate in the future
@@ -624,9 +629,9 @@ impl IwdDbus<'_> {
                     .boxed(),
             );
 
-            // Register signal level agent with thresholds aligned to NM's bar ranges
-            // NM's bar ranges: >80% (5 bars), >55% (4 bars), >30% (3 bars), >5% (2 bars), ≤5% (1 bar)
-            // Using NM linear mapping, this translates to RSSI thresholds:
+            // Register signal level agent with thresholds aligned to common bar ranges
+            // Bar ranges: >80% (5 bars), >55% (4 bars), >30% (3 bars), >5% (2 bars), ≤5% (1 bar)
+            // Using linear mapping, this translates to RSSI thresholds:
             // 80% → -52 dBm, 55% → -67 dBm, 30% → -82 dBm, 5% → -97 dBm
             let signal_thresholds = [-52, -67, -82, -97];
             station
@@ -803,16 +808,21 @@ impl IwdDbus<'_> {
                 let public = net.type_().await? == "open";
                 let path = net.inner().path().clone().into();
                 let device_path = net.device().await?.clone();
+                let connected = net.connected().await?;
                 aps.push(AccessPoint {
                     ssid,
-                    state: DeviceState::Unknown, // TODO:
+                    state: if connected {
+                        DeviceState::Activated
+                    } else {
+                        DeviceState::Disconnected
+                    },
                     // _s is between 0 and -10000
                     // should be between 0 and 100
                     strength: map_iwd_rssi_to_percent(signal_strength),
                     max_bitrate: 0,
                     frequency: 0,
                     public,
-                    working: false, // TODO:
+                    working: connected,
                     path,
                     device_path,
                 });


### PR DESCRIPTION
fix(iwd): derive AccessPoint state and working from connection status

Instead of hardcoding `DeviceState::Unknown` and `working: false` for every access point, query `net.connected()` via D-Bus to determine the actual state. Connected networks get `DeviceState::Activated` + `working: true`; others get `Disconnected` + `working: false`. Also extracts a small `ap_state_from_connected` helper to remove the duplicated mapping.

### Note on impact (data hygiene, not a behavioral fix)

Per review: `AccessPoint.working` is currently write-only (never read), and `AccessPoint.state` is never read for access points — the UI decides the connected network via `active_connections` matched by SSID in `src/modules/settings/network.rs`. So this PR does **not** change any user-visible behavior today; its value is correctness of the data model and removing the `// TODO:`s, so anything that reads these fields in the future is correct. The unrelated signal-agent threshold comment hunk was dropped (reverted to the original NM-aligned wording).