### PR TITLE
refactor(widget): replace bare unwrap with expect in layout children access

### DIFF
--- a/src/components/animated_size.rs
+++ b/src/components/animated_size.rs
@@ -190,7 +190,10 @@ where
         self.content.as_widget_mut().update(
             &mut tree.children[0],
             event,
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .expect("AnimatedSize: expected at least one child layout node"),
             cursor,
             renderer,
             clipboard,
@@ -227,7 +230,10 @@ where
                 renderer,
                 theme,
                 style,
-                layout.children().next().unwrap(),
+                layout
+                    .children()
+                    .next()
+                    .expect("AnimatedSize: expected at least one child layout node"),
                 cursor,
                 viewport,
             );
@@ -243,7 +249,10 @@ where
     ) {
         self.content.as_widget_mut().operate(
             &mut tree.children[0],
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .expect("AnimatedSize: expected at least one child layout node"),
             renderer,
             operation,
         );
@@ -259,7 +268,10 @@ where
     ) -> mouse::Interaction {
         self.content.as_widget().mouse_interaction(
             &tree.children[0],
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .expect("AnimatedSize: expected at least one child layout node"),
             cursor,
             viewport,
             renderer,

--- a/src/components/collapsible.rs
+++ b/src/components/collapsible.rs
@@ -246,7 +246,10 @@ where
                 renderer,
                 theme,
                 style,
-                layout.children().next().unwrap(),
+                layout
+                    .children()
+                    .next()
+                    .expect("Collapsible: expected at least one child layout node"),
                 cursor,
                 &child_viewport,
             );

--- a/src/components/menu_wrapper.rs
+++ b/src/components/menu_wrapper.rs
@@ -187,7 +187,10 @@ where
         operation.traverse(&mut |operation| {
             self.content.as_widget_mut().operate(
                 &mut tree.children[0],
-                layout.children().next().unwrap(),
+                layout
+                    .children()
+                    .next()
+                    .expect("MenuWrapper: expected at least one child layout node"),
                 renderer,
                 operation,
             );
@@ -208,7 +211,10 @@ where
         self.content.as_widget_mut().update(
             &mut tree.children[0],
             event,
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .expect("MenuWrapper: expected at least one child layout node"),
             cursor,
             renderer,
             clipboard,
@@ -234,7 +240,11 @@ where
             && let event::Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
             | event::Event::Touch(touch::Event::FingerLifted { .. }) = event
         {
-            let bounds = layout.children().next().unwrap().bounds();
+            let bounds = layout
+                .children()
+                .next()
+                .expect("MenuWrapper: expected at least one child layout node")
+                .bounds();
             let cursor_over_scrollable = cursor.is_over(bounds);
             if !cursor_over_scrollable {
                 shell.publish(on_click_outside.clone());
@@ -291,7 +301,10 @@ where
             return;
         }
 
-        let content_layout = layout.children().next().unwrap();
+        let content_layout = layout
+            .children()
+            .next()
+            .expect("MenuWrapper: expected at least one child layout node");
         let content_bounds = content_layout.bounds();
 
         // Clip-reveal: content is drawn at full size, but a growing clip rect
@@ -338,7 +351,10 @@ where
     ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
         self.content.as_widget_mut().overlay(
             &mut tree.children[0],
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .expect("MenuWrapper: expected at least one child layout node"),
             renderer,
             viewport,
             translation,

--- a/src/components/position_button.rs
+++ b/src/components/position_button.rs
@@ -276,7 +276,10 @@ where
         operation.traverse(&mut |operation| {
             self.content.as_widget_mut().operate(
                 &mut tree.children[0],
-                layout.children().next().unwrap(),
+                layout
+                    .children()
+                    .next()
+                    .expect("PositionButton: expected at least one child layout node"),
                 renderer,
                 operation,
             );
@@ -297,7 +300,10 @@ where
         self.content.as_widget_mut().update(
             &mut tree.children[0],
             event,
-            layout.children().next().unwrap(),
+            layout
+                .children()
+                .next()
+                .expect("PositionButton: expected at least one child layout node"),
             cursor,
             renderer,
             clipboard,
@@ -478,7 +484,10 @@ where
         viewport: &Rectangle,
     ) {
         let bounds = layout.bounds();
-        let content_layout = layout.children().next().unwrap();
+        let content_layout = layout
+            .children()
+            .next()
+            .expect("PositionButton: expected at least one child layout node");
         let state = tree.state.downcast_ref::<State>();
 
         let status = if self.on_press.is_none() && self.on_hover.is_none() {


### PR DESCRIPTION
Replaces 13 occurrences of `layout.children().next().unwrap()` across 4 custom iced widgets with `.expect()` calls containing descriptive messages about which widget failed. This turns potentially silent panics into actionable error messages if the layout invariant (exactly one child) is ever violated.