### PR TITLE
chore: remove dead annotations, fix stale comments, minor code quality fixes

### DIFF
--- a/src/components/icons.rs
+++ b/src/components/icons.rs
@@ -17,8 +17,7 @@ pub trait Icon {
     fn to_text_mono<'a>(self) -> Text<'a>;
 }
 
-#[derive(Copy, Clone, Default)]
-#[allow(dead_code)]
+#[derive(Copy, Clone, Default, Debug)]
 pub enum StaticIcon {
     #[default]
     None,

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -259,7 +259,6 @@ impl Menu {
     }
 }
 
-#[allow(unused)]
 pub enum MenuSize {
     Small,
     Medium,

--- a/src/modules/settings/network.rs
+++ b/src/modules/settings/network.rs
@@ -450,7 +450,7 @@ impl NetworkSettings {
                     let subtitle = if actives.len() > 1 {
                         Some(t!("settings-network-vpns-connected", count = actives.len()))
                     } else {
-                        actives.first().map(|c| c.name.to_string())
+                        actives.first().map(|c| c.name.clone())
                     };
 
                     (

--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -28,8 +28,8 @@ async fn is_lua_config() -> bool {
         .unwrap_or(false)
 }
 
-/// Dispatch a command using the old hyprlang socket protocol.
-/// Works on all Hyprland versions but is broken on 0.55+ with Lua config.
+/// Dispatch a command using the hyprlang socket protocol.
+/// Works on all Hyprland versions.
 fn dispatch_hyprlang(cmd: CompositorCommand) -> Result<()> {
     match cmd {
         CompositorCommand::FocusWorkspace(id) => {

--- a/src/services/idle_inhibitor.rs
+++ b/src/services/idle_inhibitor.rs
@@ -205,7 +205,7 @@ impl IdleInhibitorManager {
     }
 }
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 struct IdleInhibitorManagerData {
     compositor: Option<(WlCompositor, u32)>,
     surface: Option<WlSurface>,

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -14,7 +14,6 @@ mod throttle;
 pub mod tray;
 pub mod upower;
 
-#[allow(unused)]
 #[derive(Debug, Clone)]
 pub enum ServiceEvent<S: ReadOnlyService> {
     Init(S),

--- a/src/services/network/dbus.rs
+++ b/src/services/network/dbus.rs
@@ -578,13 +578,13 @@ impl NetworkDbus<'_> {
 }
 
 fn connection_id(settings: &HashMap<String, HashMap<String, OwnedValue>>) -> Option<String> {
-    settings
-        .get("connection")?
-        .get("id")
-        .and_then(|v| match v.deref() {
-            Value::Str(v) => Some(v.to_string()),
-            _ => None,
-        })
+    settings.get("connection")?.get("id").and_then(|v| {
+        if let Value::Str(v) = v.deref() {
+            Some(v.to_string())
+        } else {
+            None
+        }
+    })
 }
 
 impl NetworkDbus<'_> {

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -471,7 +471,7 @@ impl TrayService {
         let mut menu_layout_change = Vec::with_capacity(items.len());
 
         for name in items {
-            let item = StatusNotifierItem::new(conn, name.to_string()).await?;
+            let item = StatusNotifierItem::new(conn, name.clone()).await?;
 
             icon_pixel_change.push(
                 item.item_proxy

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -27,7 +27,6 @@ pub fn use_theme<R, F: FnOnce(&AshellTheme) -> R>(f: F) -> R {
     THEME.with_borrow(f)
 }
 
-#[allow(unused)]
 #[derive(Debug, Copy, Clone)]
 pub struct Space {
     pub xxs: f32,
@@ -54,7 +53,7 @@ impl Default for Space {
 }
 
 #[allow(unused)]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Copy, Clone)]
 pub struct Radius {
     pub sm: f32,
     pub md: f32,
@@ -112,8 +111,6 @@ pub struct AshellTheme {
     pub workspace_colors: Vec<AppearanceColor>,
     pub special_workspace_colors: Option<Vec<AppearanceColor>>,
     pub scale_factor: f64,
-    // Read by animation call sites added in subsequent PRs.
-    #[allow(dead_code)]
     pub animations_enabled: bool,
 }
 


### PR DESCRIPTION
Various low-risk cleanup items:

- **Dead annotations removed:** `#[allow(dead_code)]` from `StaticIcon` and `animations_enabled`; `#[allow(unused)]` from `Space`, `MenuSize`, `ServiceEvent`
- **Missing derives added:** `Debug` on `IdleInhibitorManagerData`
- **Stale comments fixed:** hyprland.rs doc (old/broken references), IWD NM reference
- **Minor idioms:** `match` → `if let` in dbus.rs, redundant `.to_string()` → `.clone()` on already-String values