### PR TITLE
fix(workspaces): use equality instead of substring for monitor visibility

### DIFF
--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -443,14 +443,12 @@ impl Workspaces {
                         let show = match self.config.visibility_mode {
                             WorkspaceVisibilityMode::All => true,
                             WorkspaceVisibilityMode::MonitorSpecific => {
-                                monitor_name
-                                    .unwrap_or_else(|| &w.monitor)
-                                    .contains(&w.monitor)
+                                monitor_name.is_none_or(|name| name == w.monitor)
                                     || !outputs.has_name(&w.monitor)
                             }
-                            WorkspaceVisibilityMode::MonitorSpecificExclusive => monitor_name
-                                .unwrap_or_else(|| &w.monitor)
-                                .contains(&w.monitor),
+                            WorkspaceVisibilityMode::MonitorSpecificExclusive => {
+                                monitor_name.is_none_or(|name| name == w.monitor)
+                            }
                         };
 
                         if show {


### PR DESCRIPTION
Fixes #804

## Problem

`MonitorSpecific` / `MonitorSpecificExclusive` visibility mode used `str::contains()` to decide whether a workspace belongs to the current monitor. When one output name is a substring of another (e.g. `eDP-1` contains `DP-1`), the laptop bar accepts every workspace owned by the dock's DisplayPort as if it were its own.

## Fix

Replace `.unwrap_or_else(..).contains(..)` with `.is_none_or(|name| name == w.monitor)`. Both `monitor_name` and `w.monitor` are canonical output names at this point — exact equality is the correct relation. The `is_none_or` fallback preserves the original behavior of showing everything when the monitor name is unknown.

## Testing

`make check` passes (fmt + cargo check + clippy -D warnings).