### PR TITLE
fix(module_item): remove clip to prevent icon cropping

### DIFF
--- a/src/components/module_item.rs
+++ b/src/components/module_item.rs
@@ -65,8 +65,7 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
             let mut button = position_button(
                 container(item.content)
                     .align_y(Alignment::Center)
-                    .height(Length::Fill)
-                    .clip(true),
+                    .height(Length::Fill),
             )
             .padding([2.0, space.xs])
             .height(Length::Fill)
@@ -94,7 +93,6 @@ impl<'a, Msg: 'static + Clone> From<ModuleItem<'a, Msg>> for Element<'a, Msg> {
                 .padding([2.0, space.xs])
                 .height(Length::Fill)
                 .align_y(Alignment::Center)
-                .clip(true)
                 .into()
         }
     }


### PR DESCRIPTION
Fixes #571

## Problem

`.clip(true)` on the module item container clips child content to the container's bounding box. Nerd Font icon glyphs can slightly overflow their text bounds (especially at certain scale factors or with tinyskia software renderer), causing the icon to appear cropped.

## Fix

Remove `.clip(true)` from both the button path (line 69) and the plain container path (line 97) in `module_item.rs`. This matches the fix on @romanstingler's branch `fix/cropped-module-icon`.

## Testing

`make check` passes (fmt + cargo check + clippy -D warnings).