### PR TITLE
Auto highlight active workspace using color palette

### DIFF
--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -257,6 +257,7 @@ fn workspace_button<'a>(
     font_size: f32,
     empty: bool,
     urgent: bool,
+    active: bool,
     color: Option<Option<AppearanceColor>>,
     width: Length,
     padding: f32,
@@ -268,7 +269,7 @@ fn workspace_button<'a>(
             .align_x(alignment::Horizontal::Center)
             .align_y(alignment::Vertical::Center),
     )
-    .style(theme.workspace_button_style(empty, urgent, color))
+    .style(theme.workspace_button_style(empty, urgent, active, color))
     .padding([0.0, padding])
     .on_press(on_press)
     .width(width)
@@ -456,6 +457,7 @@ impl Workspaces {
                         if show {
                             let empty = w.windows == 0;
                             let urgent = w.has_urgent;
+                            let active = w.displayed == Displayed::Active;
                             let color_index = if self.config.enable_virtual_desktops {
                                 Some(w.id as i128)
                             } else {
@@ -507,6 +509,7 @@ impl Workspaces {
                                                     font_size,
                                                     empty,
                                                     urgent,
+                                                    active,
                                                     color,
                                                     Length::Fixed(width),
                                                     0.0,
@@ -525,6 +528,7 @@ impl Workspaces {
                                             font_size,
                                             empty,
                                             urgent,
+                                            active,
                                             color,
                                             Length::Fixed(target_width),
                                             0.0,
@@ -550,6 +554,7 @@ impl Workspaces {
                                                     font_size,
                                                     empty,
                                                     urgent,
+                                                    active,
                                                     color,
                                                     Length::Shrink,
                                                     padding,
@@ -568,6 +573,7 @@ impl Workspaces {
                                             font_size,
                                             empty,
                                             urgent,
+                                            active,
                                             color,
                                             Length::Shrink,
                                             target_padding,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -612,11 +612,7 @@ impl AshellTheme {
                 })),
                 border: Border {
                     width: if is_urgent || is_empty { 1.0 } else { 0.0 },
-                    color: if is_urgent {
-                        urgent_color
-                    } else {
-                        bg_color
-                    },
+                    color: if is_urgent { urgent_color } else { bg_color },
                     radius: radius_lg.into(),
                 },
                 text_color: if is_urgent && is_empty {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -519,84 +519,34 @@ impl AshellTheme {
     ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
         let radius_lg = self.radius.lg;
         move |theme: &Theme, status: Status| {
-            let (bg_color, fg_color) = colors.map_or_else(
-                || {
-                    (
-                        theme.extended_palette().background.weak.color,
-                        theme.palette().text,
-                    )
-                },
-                |c| {
-                    c.map_or_else(
-                        || {
-                            (
-                                theme.extended_palette().primary.base.color,
-                                theme.extended_palette().primary.base.text,
-                            )
-                        },
-                        |c| {
-                            let color = palette::Primary::generate(
-                                c.get_base(),
-                                theme.palette().background,
-                                c.get_text().unwrap_or_else(|| theme.palette().text),
-                            );
-                            (color.base.color, color.base.text)
-                        },
-                    )
-                },
-            );
-            let (bg_strong, fg_strong) = colors.map_or_else(
-                || {
-                    (
-                        theme.extended_palette().background.strong.color,
-                        theme.palette().text,
-                    )
-                },
-                |c| {
-                    c.map_or_else(
-                        || {
-                            (
-                                theme.extended_palette().primary.strong.color,
-                                theme.extended_palette().primary.strong.text,
-                            )
-                        },
-                        |c| {
-                            let color = palette::Primary::generate(
-                                c.get_base(),
-                                theme.palette().background,
-                                c.get_text().unwrap_or_else(|| theme.palette().text),
-                            );
-                            (color.strong.color, color.strong.text)
-                        },
-                    )
-                },
-            );
-            let (bg_weak, fg_weak) = colors.map_or_else(
-                || {
-                    (
-                        theme.extended_palette().background.weak.color,
-                        theme.palette().text,
-                    )
-                },
-                |c| {
-                    c.map_or_else(
-                        || {
-                            (
-                                theme.extended_palette().primary.weak.color,
-                                theme.extended_palette().primary.weak.text,
-                            )
-                        },
-                        |c| {
-                            let color = palette::Primary::generate(
-                                c.get_base(),
-                                theme.palette().background,
-                                c.get_text().unwrap_or_else(|| theme.palette().text),
-                            );
-                            (color.weak.color, color.weak.text)
-                        },
-                    )
-                },
-            );
+            let primary = colors.map(|c| {
+                c.map_or_else(
+                    || theme.extended_palette().primary,
+                    |c| {
+                        palette::Primary::generate(
+                            c.get_base(),
+                            theme.palette().background,
+                            c.get_text().unwrap_or_else(|| theme.palette().text),
+                        )
+                    },
+                )
+            });
+            let resolve = |bg: fn(&palette::Background) -> palette::Pair,
+                           pr: fn(&palette::Primary) -> palette::Pair| {
+                match primary {
+                    Some(p) => {
+                        let pair = pr(&p);
+                        (pair.color, pair.text)
+                    }
+                    None => {
+                        let pair = bg(&theme.extended_palette().background);
+                        (pair.color, theme.palette().text)
+                    }
+                }
+            };
+            let (bg_color, fg_color) = resolve(|b| b.weak, |p| p.base);
+            let (bg_strong, fg_strong) = resolve(|b| b.strong, |p| p.strong);
+            let (bg_weak, fg_weak) = resolve(|b| b.weak, |p| p.weak);
             let urgent_color = theme.palette().danger;
             let mut base = button::Style {
                 background: Some(Background::Color(if is_urgent && is_empty {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -547,22 +547,27 @@ impl AshellTheme {
             let (bg_color, fg_color) = resolve(|b| b.weak, |p| p.base);
             let (bg_strong, fg_strong) = resolve(|b| b.strong, |p| p.strong);
             let (bg_weak, fg_weak) = resolve(|b| b.weak, |p| p.weak);
-            let urgent_color = theme.palette().danger;
             let mut base = button::Style {
                 background: Some(Background::Color(if is_urgent && is_empty {
-                    urgent_color
+                    theme.extended_palette().danger.base.color
                 } else if is_empty && is_active {
                     theme.extended_palette().background.strong.color
                 } else if is_empty {
                     theme.extended_palette().background.weak.color
                 } else if is_active {
-                    bg_strong
-                } else {
                     bg_color
+                } else {
+                    bg_weak
                 })),
                 border: Border {
                     width: if is_urgent || is_empty { 1.0 } else { 0.0 },
-                    color: if is_urgent { urgent_color } else { bg_color },
+                    color: if is_urgent {
+                        theme.extended_palette().danger.base.color
+                    } else if is_active {
+                        bg_color
+                    } else {
+                        bg_weak
+                    },
                     radius: radius_lg.into(),
                 },
                 text_color: if is_urgent && is_empty {
@@ -572,9 +577,9 @@ impl AshellTheme {
                 } else if is_empty {
                     theme.extended_palette().background.weak.text
                 } else if is_active {
-                    fg_strong
-                } else {
                     fg_color
+                } else {
+                    fg_weak
                 },
                 ..button::Style::default()
             };
@@ -584,16 +589,29 @@ impl AshellTheme {
                     base.background = Some(Background::Color(if is_urgent && is_empty {
                         theme.extended_palette().danger.strong.color
                     } else if is_empty {
-                        theme.extended_palette().background.base.color
+                        theme.extended_palette().background.strong.color
+                    } else if is_active {
+                        bg_color
                     } else {
-                        bg_weak
+                        bg_strong
                     }));
+                    base.border.color = if is_urgent && is_active {
+                        theme.extended_palette().danger.base.color
+                    } else if is_urgent {
+                        theme.extended_palette().danger.strong.color
+                    } else if is_active {
+                        bg_color
+                    } else {
+                        bg_strong
+                    };
                     base.text_color = if is_urgent && is_empty {
                         theme.extended_palette().danger.strong.text
                     } else if is_empty {
-                        theme.extended_palette().background.weak.text
+                        theme.extended_palette().background.strong.text
+                    } else if is_active {
+                        fg_color
                     } else {
-                        fg_weak
+                        fg_strong
                     };
                     base
                 }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -514,6 +514,7 @@ impl AshellTheme {
         &self,
         is_empty: bool,
         is_urgent: bool,
+        is_active: bool,
         colors: Option<Option<AppearanceColor>>,
     ) -> impl Fn(&Theme, Status) -> button::Style + use<> {
         let radius_lg = self.radius.lg;
@@ -544,24 +545,88 @@ impl AshellTheme {
                     )
                 },
             );
+            let (bg_strong, fg_strong) = colors.map_or_else(
+                || {
+                    (
+                        theme.extended_palette().background.strong.color,
+                        theme.palette().text,
+                    )
+                },
+                |c| {
+                    c.map_or_else(
+                        || {
+                            (
+                                theme.extended_palette().primary.strong.color,
+                                theme.extended_palette().primary.strong.text,
+                            )
+                        },
+                        |c| {
+                            let color = palette::Primary::generate(
+                                c.get_base(),
+                                theme.palette().background,
+                                c.get_text().unwrap_or_else(|| theme.palette().text),
+                            );
+                            (color.strong.color, color.strong.text)
+                        },
+                    )
+                },
+            );
+            let (bg_weak, fg_weak) = colors.map_or_else(
+                || {
+                    (
+                        theme.extended_palette().background.weak.color,
+                        theme.palette().text,
+                    )
+                },
+                |c| {
+                    c.map_or_else(
+                        || {
+                            (
+                                theme.extended_palette().primary.weak.color,
+                                theme.extended_palette().primary.weak.text,
+                            )
+                        },
+                        |c| {
+                            let color = palette::Primary::generate(
+                                c.get_base(),
+                                theme.palette().background,
+                                c.get_text().unwrap_or_else(|| theme.palette().text),
+                            );
+                            (color.weak.color, color.weak.text)
+                        },
+                    )
+                },
+            );
             let urgent_color = theme.palette().danger;
             let mut base = button::Style {
                 background: Some(Background::Color(if is_urgent && is_empty {
                     urgent_color
+                } else if is_empty && is_active {
+                    theme.extended_palette().background.strong.color
                 } else if is_empty {
                     theme.extended_palette().background.weak.color
+                } else if is_active {
+                    bg_strong
                 } else {
                     bg_color
                 })),
                 border: Border {
                     width: if is_urgent || is_empty { 1.0 } else { 0.0 },
-                    color: if is_urgent { urgent_color } else { bg_color },
+                    color: if is_urgent {
+                        urgent_color
+                    } else {
+                        bg_color
+                    },
                     radius: radius_lg.into(),
                 },
                 text_color: if is_urgent && is_empty {
                     theme.extended_palette().danger.base.text
+                } else if is_empty && is_active {
+                    theme.extended_palette().background.strong.text
                 } else if is_empty {
                     theme.extended_palette().background.weak.text
+                } else if is_active {
+                    fg_strong
                 } else {
                     fg_color
                 },
@@ -570,46 +635,19 @@ impl AshellTheme {
             match status {
                 Status::Active => base,
                 Status::Hovered => {
-                    let (bg_color, fg_color) = colors.map_or_else(
-                        || {
-                            (
-                                theme.extended_palette().background.strong.color,
-                                theme.palette().text,
-                            )
-                        },
-                        |c| {
-                            c.map_or_else(
-                                || {
-                                    (
-                                        theme.extended_palette().primary.strong.color,
-                                        theme.extended_palette().primary.strong.text,
-                                    )
-                                },
-                                |c| {
-                                    let color = palette::Primary::generate(
-                                        c.get_base(),
-                                        theme.palette().background,
-                                        c.get_text().unwrap_or_else(|| theme.palette().text),
-                                    );
-                                    (color.strong.color, color.strong.text)
-                                },
-                            )
-                        },
-                    );
-
                     base.background = Some(Background::Color(if is_urgent && is_empty {
                         theme.extended_palette().danger.strong.color
                     } else if is_empty {
-                        theme.extended_palette().background.strong.color
+                        theme.extended_palette().background.base.color
                     } else {
-                        bg_color
+                        bg_weak
                     }));
                     base.text_color = if is_urgent && is_empty {
                         theme.extended_palette().danger.strong.text
                     } else if is_empty {
                         theme.extended_palette().background.weak.text
                     } else {
-                        fg_color
+                        fg_weak
                     };
                     base
                 }


### PR DESCRIPTION
Automatically highlight the active workspace with a different color from the specified colorpalette. (Alternative to #814 )

e.g.: 
<img width="669" height="42" alt="image" src="https://github.com/user-attachments/assets/2f6dc8ad-1b0a-486a-b7fe-71d456a96ab1" />

My biggest gripe with it is that the contrast is not super strong, but when taken together with the size difference its manageble for me, and at least a lot more legible than without it.