### PR TITLE
feat(appearance): replace bar AppearanceStyle with dedicated settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,7 @@ src/
 ├── app.rs               # App state, Elm update/view cycle
 ├── config.rs            # configuration types (TOML deserialization)
 ├── ipc.rs               # Unix socket IPC (client + server + subscription)
-├── theme.rs             # theming (Islands/Solid/Gradient styles)
+├── theme.rs             # theming (transparent/solid bar surface, radius, margin)
 ├── menu.rs              # menu UI
 ├── outputs.rs           # multi-monitor output management
 ├── components/          # shared UI components, icons

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - Multi-monitor support (all monitors, active monitor, or specific targets)
 - Hot-reload configuration (changes apply automatically via file watch)
 - Bar positioning (top or bottom) with configurable layer (Bottom, Top, Overlay)
-- Theming: Islands, Solid, and Gradient styles with custom colors, opacity, scale, and fonts
+- Theming: transparent (islands) or solid bar surface with custom radius, margin, colors, opacity, scale, and fonts
 - OS Updates indicator with configurable check interval
 - Active Window (title, class, or initial title/class)
 - Workspaces with naming, color coding, and per-monitor visibility
@@ -93,17 +93,13 @@ For the full AI contribution guide, see the
 I will try my best to keep these screenshots as updated as possible but some details
 could be different
 
-#### default style
+#### transparent surface (default)
 
 <img src="https://raw.githubusercontent.com/MalpenZibo/ashell/main/website/static/img/gallery/ashell.png"></img>
 
-#### solid style
+#### solid surface
 
 <img src="https://raw.githubusercontent.com/MalpenZibo/ashell/main/website/static/img/gallery/ashell-solid.png"></img>
-
-#### gradient style
-
-<img src="https://raw.githubusercontent.com/MalpenZibo/ashell/main/website/static/img/gallery/ashell-gradient.png"></img>
 
 #### opacity settings
 

--- a/docs/src/core/config-system.md
+++ b/docs/src/core/config-system.md
@@ -103,10 +103,14 @@ interval = 3600
 
 ```toml
 [appearance]
-style = "Islands"          # Islands, Solid, or Gradient
-opacity = 0.9
 font_name = "JetBrains Mono"
 scale_factor = 1.0
+
+[appearance.bar]
+surface = "transparent"    # transparent or solid
+radius = "md"              # none|sm|md|lg|xl, CSS border-radius shorthand
+margin = "sm"              # none|xxs..xxl, CSS margin shorthand
+opacity = 0.9
 
 [appearance.background]
 base = "#1e1e2e"

--- a/docs/src/core/config-system.md
+++ b/docs/src/core/config-system.md
@@ -59,7 +59,7 @@ pub enum ModuleDef {
 }
 ```
 
-Groups are rendered together in a single container, which is especially visible with the `Islands` bar style.
+Groups are rendered together in a single container, which is especially visible with the `transparent` (islands) bar surface.
 
 ## Hot-Reload
 

--- a/docs/src/core/outputs-and-surfaces.md
+++ b/docs/src/core/outputs-and-surfaces.md
@@ -23,7 +23,7 @@ pub struct ShellInfo {
     pub id: Id,                  // Main surface window ID
     pub position: Position,      // Top or Bottom
     pub layer: config::Layer,    // Wayland layer
-    pub style: AppearanceStyle,  // Bar style
+    pub layout: BarLayout,       // Surface mode + resolved outer margin
     pub menu: Menu,              // Menu surface state
     pub scale_factor: f64,
 }
@@ -35,7 +35,7 @@ Each output gets two layer surfaces created via `create_output_layers()`:
 
 ```rust
 pub fn create_output_layers(
-    style: AppearanceStyle,
+    layout: BarLayout,
     wl_output: Option<WlOutput>,
     position: Position,
     layer: config::Layer,

--- a/docs/src/core/theme-system.md
+++ b/docs/src/core/theme-system.md
@@ -11,7 +11,9 @@ pub struct AshellTheme {
     pub radius: Radius,                                       // Border radius tokens
     pub font_size: FontSize,                                  // Font size tokens
     pub bar_position: Position,                               // Top or Bottom
-    pub bar_style: AppearanceStyle,                           // Islands, Solid, or Gradient
+    pub bar_surface: BarSurface,                              // transparent or solid
+    pub bar_radius: BarRadius,                                // per-corner radius (CSS shorthand)
+    pub bar_margin: BarMargin,                                // per-edge margin (CSS shorthand)
     pub opacity: f32,                                         // Bar opacity (0.0-1.0)
     pub menu: MenuAppearance,                                 // Menu-specific styling
     pub workspace_colors: Vec<AppearanceColor>,               // Per-workspace color cycling
@@ -61,13 +63,14 @@ pub struct FontSize {
 }
 ```
 
-## Bar Styles
+## Bar Surface
 
-ashell supports three visual styles:
+The `[appearance.bar].surface` field controls where the background is painted:
 
-- **`Solid`**: Flat background color across the entire bar width.
-- **`Gradient`**: The background fades from solid to transparent, away from the bar's edge. The gradient direction is determined by the bar position (top = downward fade, bottom = upward fade).
-- **`Islands`**: No continuous background. Each module (or module group) gets its own rounded container with the background color, creating a "floating islands" look.
+- **`transparent`**: No continuous background. Each module (or module group) gets its own rounded container with the background color, creating a "floating islands" look. This is the default.
+- **`solid`**: Flat background color across the entire bar width; module groups render pass-through so the bar reads as a single surface.
+
+The bar surface can additionally be rounded (`radius`) and inset from the screen edges (`margin`); both use CSS shorthand over the radius/spacing scales.
 
 ## Color System
 
@@ -104,7 +107,7 @@ Each method returns a closure compatible with iced's button styling API:
 ```rust
 pub fn module_button_style(&self, grouped: bool) -> impl Fn(&Theme, Status) -> button::Style {
     // Returns different styles for hovered, pressed, and default states
-    // Handles Islands vs Solid/Gradient backgrounds differently
+    // Handles transparent (islands) vs solid backgrounds differently
 }
 ```
 

--- a/docs/src/core/theme-system.md
+++ b/docs/src/core/theme-system.md
@@ -121,8 +121,10 @@ impl AshellTheme {
             radius: Radius::default(),
             font_size: FontSize::default(),
             bar_position: position,
-            bar_style: appearance.style,
-            opacity: appearance.opacity,
+            bar_surface: appearance.bar.surface,
+            bar_radius: appearance.bar.radius,
+            bar_margin: appearance.bar.margin,
+            opacity: appearance.bar.opacity,
             // ...
         }
     }

--- a/docs/src/modules/module-registry.md
+++ b/docs/src/modules/module-registry.md
@@ -107,11 +107,11 @@ pub fn modules_section(&self, id: Id, theme: &AshellTheme) -> [Element<Message>;
 Wraps a single module:
 - If the module has an `OnModulePress` action, it's wrapped in a `PositionButton`
 - Otherwise, it's wrapped in a plain `container`
-- In `Islands` style, non-interactive modules get a rounded background
+- With the `transparent` (islands) surface, non-interactive modules get a rounded background
 
 ### group_module_wrapper
 
 Wraps a group of modules:
 - All modules in the group are placed in a `Row`
-- In `Islands` style, the entire group shares one rounded background container
+- With the `transparent` (islands) surface, the entire group shares one rounded background container
 - Each module within the group still has its own click handler if applicable

--- a/docs/src/modules/overview.md
+++ b/docs/src/modules/overview.md
@@ -40,7 +40,7 @@ right = [["SystemInfo", "Settings"], "Tray"]
 #         └── group ──────────────┘   └── single
 ```
 
-In the `Islands` bar style, grouped modules share a single background container. In `Solid`/`Gradient` styles, grouping has no visual effect.
+With the `transparent` (islands) bar surface, grouped modules share a single background container. With the `solid` surface, grouping has no visual effect.
 
 The config uses the `ModuleDef` enum:
 

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -32,10 +32,14 @@ Module names: `"Workspaces"`, `"WindowTitle"`, `"SystemInfo"`, `"KeyboardLayout"
 
 ```toml
 [appearance]
-style = "Islands"               # "Islands", "Solid", or "Gradient"
-opacity = 0.9                   # 0.0-1.0
 font_name = "JetBrains Mono"   # Optional custom font
 scale_factor = 1.0              # DPI scale factor
+
+[appearance.bar]
+surface = "transparent"         # "transparent" or "solid"
+radius = "none"                 # none|sm|md|lg|xl, CSS border-radius shorthand (solid only)
+margin = "none"                 # none|xxs..xxl, CSS margin shorthand
+opacity = 0.9                   # 0.0-1.0
 ```
 
 ### Colors

--- a/docs/src/reference/glossary.md
+++ b/docs/src/reference/glossary.md
@@ -33,9 +33,7 @@
 |------|-----------|
 | **Module** | A self-contained UI component displayed in the bar (e.g., Clock, Workspaces, Settings) |
 | **Service** | A backend integration that communicates with system APIs (e.g., audio, bluetooth, compositor) |
-| **Islands** | A bar style where each module group has its own rounded background container |
-| **Solid** | A bar style with a continuous flat background |
-| **Gradient** | A bar style where the background fades from solid to transparent |
+| **Bar surface** | Where the bar background is painted: `transparent` (each module group gets its own rounded container, the "islands" look) or `solid` (a continuous flat background across the bar) |
 | **Menu** | A popup panel that appears when clicking certain modules |
 | **Centerbox** | Custom widget providing a three-column layout with true centering |
 | **ButtonUIRef** | Position and size information of a button, used for menu placement |

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,7 @@
 use crate::{
     HEIGHT,
     components::{Centerbox, menu::MenuType},
-    config::{self, AppearanceStyle, Config, Modules, Position},
+    config::{self, BarSurface, Config, Modules},
     get_log_spec,
     i18n::{Localizer, init_localizer},
     ipc::IpcCommand,
@@ -24,20 +24,18 @@ use crate::{
     osd::{self, Osd},
     outputs::{HasOutput, Outputs},
     services::ReadOnlyService,
-    theme::{AshellTheme, backdrop_color, darken_color, init_theme, use_theme},
+    theme::{AshellTheme, BarLayout, backdrop_color, darken_color, init_theme, use_theme},
 };
 use flexi_logger::LoggerHandle;
 use iced::futures::StreamExt;
 use iced::{
-    Alignment, Color, Element, Gradient, Length, OutputEvent, Radians, Subscription, SurfaceId,
-    Task, Theme,
+    Alignment, Element, Length, OutputEvent, Subscription, SurfaceId, Task, Theme,
     event::listen_with,
-    gradient::Linear,
     keyboard, set_exclusive_zone,
     widget::{Row, container, mouse_area},
 };
 use log::{debug, info, warn};
-use std::{collections::HashMap, f32::consts::PI, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 
 const OSD_WIDTH: u32 = 250;
 const OSD_HEIGHT: u32 = 64;
@@ -86,7 +84,7 @@ impl App {
     ) -> impl FnOnce() -> (Self, Task<Message>) {
         move || {
             let mut outputs = Outputs::new(
-                config.appearance.style,
+                BarLayout::from_appearance(&config.appearance.bar),
                 config.position,
                 config.layer,
                 config.appearance.scale_factor,
@@ -223,17 +221,18 @@ impl App {
                     "Current outputs: {:?}, new outputs: {:?}",
                     self.general_config.outputs, config.outputs
                 );
-                let (bar_position, bar_style, scale_factor) =
-                    use_theme(|t| (t.bar_position, t.bar_style, t.scale_factor));
+                let (bar_position, bar_layout, scale_factor) =
+                    use_theme(|t| (t.bar_position, t.bar_layout(), t.scale_factor));
+                let new_layout = BarLayout::from_appearance(&config.appearance.bar);
                 if self.general_config.outputs != config.outputs
                     || bar_position != config.position
-                    || bar_style != config.appearance.style
+                    || bar_layout != new_layout
                     || scale_factor != config.appearance.scale_factor
                     || self.general_config.layer != config.layer
                 {
                     warn!("Outputs changed, syncing");
                     tasks.push(self.outputs.sync(
-                        config.appearance.style,
+                        new_layout,
                         &config.outputs,
                         config.position,
                         config.layer,
@@ -382,10 +381,10 @@ impl App {
                     info!("Output created: {info:?}");
                     let name = &format!("{} {} {}", info.name, info.make, info.model);
 
-                    let (bar_style, bar_position, scale_factor) =
-                        use_theme(|t| (t.bar_style, t.bar_position, t.scale_factor));
+                    let (bar_layout, bar_position, scale_factor) =
+                        use_theme(|t| (t.bar_layout(), t.bar_position, t.scale_factor));
                     let task = self.outputs.add(
-                        bar_style,
+                        bar_layout,
                         &self.general_config.outputs,
                         bar_position,
                         self.general_config.layer,
@@ -403,10 +402,10 @@ impl App {
                 }
                 OutputEvent::Removed(output_id) => {
                     info!("Output destroyed");
-                    let (bar_style, bar_position, scale_factor) =
-                        use_theme(|t| (t.bar_style, t.bar_position, t.scale_factor));
+                    let (bar_layout, bar_position, scale_factor) =
+                        use_theme(|t| (t.bar_layout(), t.bar_position, t.scale_factor));
                     self.outputs.remove(
-                        bar_style,
+                        bar_layout,
                         bar_position,
                         self.general_config.layer,
                         output_id,
@@ -435,10 +434,10 @@ impl App {
                 }
             }
             Message::ResumeFromSleep => {
-                let (bar_style, bar_position, scale_factor) =
-                    use_theme(|t| (t.bar_style, t.bar_position, t.scale_factor));
+                let (bar_layout, bar_position, scale_factor) =
+                    use_theme(|t| (t.bar_layout(), t.bar_position, t.scale_factor));
                 self.outputs.sync(
-                    bar_style,
+                    bar_layout,
                     &self.general_config.outputs,
                     bar_position,
                     self.general_config.layer,
@@ -522,16 +521,12 @@ impl App {
             Message::None => Task::none(),
             Message::ToggleVisibility => {
                 self.visible = !self.visible;
-                let (bar_style, scale_factor) = use_theme(|t| (t.bar_style, t.scale_factor));
-                let height = if self.visible {
-                    (crate::HEIGHT
-                        - match bar_style {
-                            AppearanceStyle::Solid | AppearanceStyle::Gradient => 8.,
-                            AppearanceStyle::Islands => 0.,
-                        })
-                        * scale_factor
+                let (bar_layout, bar_position, scale_factor) =
+                    use_theme(|t| (t.bar_layout(), t.bar_position, t.scale_factor));
+                let zone = if self.visible {
+                    Outputs::exclusive_zone(bar_layout, bar_position, scale_factor)
                 } else {
-                    0.0
+                    0
                 };
 
                 Task::batch(
@@ -540,7 +535,7 @@ impl App {
                         .filter_map(|(_, shell_info, _)| {
                             shell_info
                                 .as_ref()
-                                .map(|info| set_exclusive_zone(info.id, height as i32))
+                                .map(|info| set_exclusive_zone(info.id, zone))
                         })
                         .collect::<Vec<_>>(),
                 )
@@ -557,15 +552,15 @@ impl App {
 
                 let [left, center, right] = self.modules_section(id);
 
-                let (space, bar_style, bar_position, opacity, menu, animations_enabled) =
+                let (space, bar_surface, opacity, menu, animations_enabled, bar_radius) =
                     use_theme(|t| {
                         (
                             t.space,
-                            t.bar_style,
-                            t.bar_position,
+                            t.bar_surface,
                             t.opacity,
                             t.menu,
                             t.animations_enabled,
+                            t.bar_border_radius(),
                         )
                     });
                 let centerbox = Centerbox::new([left, center, right])
@@ -573,12 +568,12 @@ impl App {
                     .spacing(space.xxs)
                     .width(Length::Fill)
                     .align_items(Alignment::Center)
-                    .height(if bar_style == AppearanceStyle::Islands {
+                    .height(if bar_surface == BarSurface::Transparent {
                         HEIGHT
                     } else {
                         HEIGHT - space.xs as f64
                     } as f32)
-                    .padding(if bar_style == AppearanceStyle::Islands {
+                    .padding(if bar_surface == BarSurface::Transparent {
                         [space.xxs, space.xxs]
                     } else {
                         [0.0, 0.0]
@@ -586,42 +581,8 @@ impl App {
 
                 let menu_is_open = self.outputs.menu_is_open();
                 let status_bar = container(centerbox).style(move |t: &Theme| container::Style {
-                    background: match bar_style {
-                        AppearanceStyle::Gradient => Some({
-                            let start_color = t.palette().background.scale_alpha(opacity);
-
-                            let start_color = if menu_is_open {
-                                darken_color(start_color, menu.backdrop)
-                            } else {
-                                start_color
-                            };
-
-                            let end_color = if menu_is_open {
-                                backdrop_color(menu.backdrop)
-                            } else {
-                                Color::TRANSPARENT
-                            };
-
-                            Gradient::Linear(
-                                Linear::new(Radians(PI))
-                                    .add_stop(
-                                        0.0,
-                                        match bar_position {
-                                            Position::Top => start_color,
-                                            Position::Bottom => end_color,
-                                        },
-                                    )
-                                    .add_stop(
-                                        1.0,
-                                        match bar_position {
-                                            Position::Top => end_color,
-                                            Position::Bottom => start_color,
-                                        },
-                                    ),
-                            )
-                            .into()
-                        }),
-                        AppearanceStyle::Solid => Some({
+                    background: match bar_surface {
+                        BarSurface::Solid => Some({
                             let bg = t.palette().background.scale_alpha(opacity);
                             if menu_is_open {
                                 darken_color(bg, menu.backdrop)
@@ -630,13 +591,17 @@ impl App {
                             }
                             .into()
                         }),
-                        AppearanceStyle::Islands => {
+                        BarSurface::Transparent => {
                             if menu_is_open {
                                 Some(backdrop_color(menu.backdrop).into())
                             } else {
                                 None
                             }
                         }
+                    },
+                    border: iced::Border {
+                        radius: bar_radius,
+                        ..Default::default()
                     },
                     ..Default::default()
                 });

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -1,6 +1,6 @@
 use crate::app::{self, App};
 use crate::components::{self, ButtonUIRef};
-use crate::config::{AppearanceStyle, Position};
+use crate::config::{BarSurface, Position};
 use crate::theme::{backdrop_color, use_theme};
 use iced::alignment::Vertical;
 use iced::widget::container::Style;
@@ -298,13 +298,13 @@ impl App {
         content: Element<'a, app::Message>,
         button_ui_ref: ButtonUIRef,
     ) -> Element<'a, app::Message> {
-        let (space, menu_opacity, radius, bar_style, bar_position, menu_backdrop) =
+        let (space, menu_opacity, radius, bar_surface, bar_position, menu_backdrop) =
             use_theme(|t| {
                 (
                     t.space,
                     t.menu.opacity,
                     t.radius,
-                    t.bar_style,
+                    t.bar_surface,
                     t.bar_position,
                     t.menu.backdrop,
                 )
@@ -332,9 +332,9 @@ impl App {
                 .into(),
         )
         .padding({
-            let v_padding = match bar_style {
-                AppearanceStyle::Solid | AppearanceStyle::Gradient => 2,
-                AppearanceStyle::Islands => 0,
+            let v_padding = match bar_surface {
+                BarSurface::Solid => 2,
+                BarSurface::Transparent => 0,
             };
 
             Padding::new(0.)

--- a/src/components/module_group.rs
+++ b/src/components/module_group.rs
@@ -1,17 +1,17 @@
-use crate::{config::AppearanceStyle, theme::use_theme};
+use crate::{config::BarSurface, theme::use_theme};
 use iced::{Border, Color, Element, widget::container};
 
-/// Wraps content with the appropriate bar style container.
+/// Wraps content with the appropriate bar surface container.
 ///
-/// - `Solid | Gradient` → pass through as-is
-/// - `Islands` → wrap in a container with background color + rounded border
+/// - `Solid` → pass through as-is (the bar itself carries the background)
+/// - `Transparent` → wrap in a container with background color + rounded border
 pub fn module_group<'a, Msg: 'static>(content: Element<'a, Msg>) -> Element<'a, Msg> {
-    let (bar_style, opacity, radius) =
-        use_theme(|theme| (theme.bar_style, theme.opacity, theme.radius));
+    let (bar_surface, opacity, radius) =
+        use_theme(|theme| (theme.bar_surface, theme.opacity, theme.radius));
 
-    match bar_style {
-        AppearanceStyle::Solid | AppearanceStyle::Gradient => content,
-        AppearanceStyle::Islands => container(content)
+    match bar_surface {
+        BarSurface::Solid => content,
+        BarSurface::Transparent => container(content)
             .style(move |iced_theme: &iced::Theme| container::Style {
                 background: Some(iced_theme.palette().background.scale_alpha(opacity).into()),
                 border: Border {

--- a/src/config.rs
+++ b/src/config.rs
@@ -862,11 +862,126 @@ pub enum BackgroundLevel {
 }
 
 #[derive(Deserialize, Default, Copy, Clone, Eq, PartialEq, Debug)]
-pub enum AppearanceStyle {
+#[serde(rename_all = "lowercase")]
+pub enum BarSurface {
     #[default]
-    Islands,
+    Transparent,
     Solid,
-    Gradient,
+}
+
+#[derive(Deserialize, Default, Copy, Clone, Eq, PartialEq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum RadiusSize {
+    #[default]
+    None,
+    Sm,
+    Md,
+    Lg,
+    Xl,
+}
+
+#[derive(Deserialize, Default, Copy, Clone, Eq, PartialEq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum SpaceSize {
+    #[default]
+    None,
+    Xxs,
+    Xs,
+    Sm,
+    Md,
+    Lg,
+    Xl,
+    Xxl,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum CssShorthand<T> {
+    One(T),
+    Many(Vec<T>),
+}
+
+impl<T: Copy> CssShorthand<T> {
+    fn expand<E: serde::de::Error>(self) -> Result<[T; 4], E> {
+        let values = match self {
+            CssShorthand::One(v) => return Ok([v, v, v, v]),
+            CssShorthand::Many(v) => v,
+        };
+        match values.as_slice() {
+            [a] => Ok([*a, *a, *a, *a]),
+            [a, b] => Ok([*a, *b, *a, *b]),
+            [a, b, c, d] => Ok([*a, *b, *c, *d]),
+            _ => Err(E::custom("expected 1, 2 or 4 values (CSS shorthand)")),
+        }
+    }
+}
+
+/// Per-corner radius selection, deserialized with CSS `border-radius` shorthand:
+/// 1 value = all corners, 2 = `[top-left+bottom-right, top-right+bottom-left]`,
+/// 4 = `[top-left, top-right, bottom-right, bottom-left]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct BarRadius {
+    pub top_left: RadiusSize,
+    pub top_right: RadiusSize,
+    pub bottom_right: RadiusSize,
+    pub bottom_left: RadiusSize,
+}
+
+impl<'de> Deserialize<'de> for BarRadius {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let [top_left, top_right, bottom_right, bottom_left] =
+            CssShorthand::<RadiusSize>::deserialize(deserializer)?.expand()?;
+        Ok(Self {
+            top_left,
+            top_right,
+            bottom_right,
+            bottom_left,
+        })
+    }
+}
+
+/// Per-edge margin selection, deserialized with CSS `margin` shorthand:
+/// 1 value = all edges, 2 = `[vertical, horizontal]`, 4 = `[top, right, bottom, left]`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct BarMargin {
+    pub top: SpaceSize,
+    pub right: SpaceSize,
+    pub bottom: SpaceSize,
+    pub left: SpaceSize,
+}
+
+impl<'de> Deserialize<'de> for BarMargin {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let [top, right, bottom, left] =
+            CssShorthand::<SpaceSize>::deserialize(deserializer)?.expand()?;
+        Ok(Self {
+            top,
+            right,
+            bottom,
+            left,
+        })
+    }
+}
+
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq)]
+#[serde(default)]
+pub struct BarAppearance {
+    pub surface: BarSurface,
+    #[serde(deserialize_with = "opacity_deserializer")]
+    pub opacity: f32,
+    pub radius: BarRadius,
+    pub margin: BarMargin,
+}
+
+impl Default for BarAppearance {
+    fn default() -> Self {
+        Self {
+            surface: BarSurface::default(),
+            opacity: default_opacity(),
+            radius: BarRadius::default(),
+            margin: BarMargin::default(),
+        }
+    }
 }
 
 #[derive(Deserialize, Clone, Copy, Debug)]
@@ -892,9 +1007,7 @@ pub struct Appearance {
     pub font_name: Option<String>,
     #[serde(deserialize_with = "scale_factor_deserializer")]
     pub scale_factor: f64,
-    pub style: AppearanceStyle,
-    #[serde(deserialize_with = "opacity_deserializer")]
-    pub opacity: f32,
+    pub bar: BarAppearance,
     pub menu: MenuAppearance,
     pub background_color: BackgroundAppearanceColor,
     pub primary_color: AppearanceColor,
@@ -957,8 +1070,7 @@ impl Default for Appearance {
         Self {
             font_name: None,
             scale_factor: 1.0,
-            style: AppearanceStyle::default(),
-            opacity: default_opacity(),
+            bar: BarAppearance::default(),
             menu: MenuAppearance::default(),
             background_color: BackgroundAppearanceColor::Complete {
                 base: HexColor::rgb(26, 27, 38),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 use crate::config::{Position, get_config};
 use crate::outputs::Outputs;
+use crate::theme::BarLayout;
 use app::App;
 use clap::Parser;
 use flexi_logger::{
@@ -127,7 +128,8 @@ fn main() -> iced::Result {
         Font::DEFAULT
     };
 
-    let height = Outputs::get_height(config.appearance.style, config.appearance.scale_factor);
+    let bar_layout = BarLayout::from_appearance(&config.appearance.bar);
+    let height = Outputs::get_height(bar_layout.surface, config.appearance.scale_factor);
 
     let iced_layer = match config.layer {
         config::Layer::Top => Layer::Top,
@@ -147,7 +149,12 @@ fn main() -> iced::Result {
         } | Anchor::LEFT
             | Anchor::RIGHT,
         layer: iced_layer,
-        exclusive_zone: height as i32,
+        exclusive_zone: Outputs::exclusive_zone(
+            bar_layout,
+            config.position,
+            config.appearance.scale_factor,
+        ),
+        margin: Outputs::margin(bar_layout, config.appearance.scale_factor),
         size: Some((0, height as u32)),
         keyboard_interactivity: KeyboardInteractivity::None,
         namespace: "ashell-main-layer".into(),

--- a/src/outputs.rs
+++ b/src/outputs.rs
@@ -1,7 +1,7 @@
 use iced::{
     Anchor, InputRegionRect, KeyboardInteractivity, Layer, LayerShellSettings, OutputId, SurfaceId,
     Task, destroy_layer_surface, new_layer_surface, set_anchor, set_exclusive_zone,
-    set_input_region, set_keyboard_interactivity, set_size,
+    set_input_region, set_keyboard_interactivity, set_margin, set_size,
 };
 use log::debug;
 
@@ -9,7 +9,8 @@ use crate::{
     HEIGHT,
     components::ButtonUIRef,
     components::menu::{Menu, MenuType, OpenMenu},
-    config::{self, AppearanceStyle, Position},
+    config::{self, BarSurface, Position},
+    theme::BarLayout,
 };
 
 #[derive(Debug, Clone)]
@@ -17,7 +18,7 @@ pub struct ShellInfo {
     pub id: SurfaceId,
     pub position: Position,
     pub layer: config::Layer,
-    pub style: AppearanceStyle,
+    pub layout: BarLayout,
     pub menu: Menu,
     pub scale_factor: f64,
     /// Logical height of this output (for computing toast input regions).
@@ -89,7 +90,7 @@ impl Outputs {
     }
 
     pub fn new(
-        style: AppearanceStyle,
+        layout: BarLayout,
         position: Position,
         layer: config::Layer,
         scale_factor: f64,
@@ -105,7 +106,7 @@ impl Outputs {
                     menu: Menu::new(),
                     position,
                     layer,
-                    style,
+                    layout,
                     scale_factor,
                     output_logical_height: None,
                 }),
@@ -123,23 +124,43 @@ impl Outputs {
         Menu::with_animations(self.animations_enabled)
     }
 
-    pub fn get_height(style: AppearanceStyle, scale_factor: f64) -> f64 {
+    pub fn get_height(surface: BarSurface, scale_factor: f64) -> f64 {
         (HEIGHT
-            - match style {
-                AppearanceStyle::Solid | AppearanceStyle::Gradient => 8.,
-                AppearanceStyle::Islands => 0.,
+            - match surface {
+                BarSurface::Solid => 8.,
+                BarSurface::Transparent => 0.,
             })
             * scale_factor
     }
 
+    /// Layer-shell outer margin scaled to physical pixels, ordered
+    /// `(top, right, bottom, left)` to match `set_margin`/`LayerShellSettings`.
+    pub fn margin(layout: BarLayout, scale_factor: f64) -> (i32, i32, i32, i32) {
+        let (top, right, bottom, left) = layout.margin;
+        let scale = |v: f32| (f64::from(v) * scale_factor) as i32;
+        (scale(top), scale(right), scale(bottom), scale(left))
+    }
+
+    /// Space reserved on the anchored edge: the bar height plus the margin that
+    /// pushes the bar away from that edge.
+    pub fn exclusive_zone(layout: BarLayout, position: Position, scale_factor: f64) -> i32 {
+        let height = Self::get_height(layout.surface, scale_factor);
+        let (top, _, bottom, _) = Self::margin(layout, scale_factor);
+        height as i32
+            + match position {
+                Position::Top => top,
+                Position::Bottom => bottom,
+            }
+    }
+
     pub fn create_output_layers<Message: 'static>(
-        style: AppearanceStyle,
+        layout: BarLayout,
         output_id: Option<OutputId>,
         position: Position,
         layer: config::Layer,
         scale_factor: f64,
     ) -> (SurfaceId, Task<Message>) {
-        let height = Self::get_height(style, scale_factor);
+        let height = Self::get_height(layout.surface, scale_factor);
 
         let iced_layer = match layer {
             config::Layer::Top => Layer::Top,
@@ -152,14 +173,14 @@ impl Outputs {
             size: Some((0, height as u32)),
             layer: iced_layer,
             keyboard_interactivity: KeyboardInteractivity::None,
-            exclusive_zone: height as i32,
+            exclusive_zone: Self::exclusive_zone(layout, position, scale_factor),
+            margin: Self::margin(layout, scale_factor),
             output: output_id,
             anchor: match position {
                 Position::Top => Anchor::TOP,
                 Position::Bottom => Anchor::BOTTOM,
             } | Anchor::LEFT
                 | Anchor::RIGHT,
-            ..Default::default()
         });
 
         (id, main_task)
@@ -216,7 +237,7 @@ impl Outputs {
     #[allow(clippy::too_many_arguments)]
     pub fn add<Message: 'static>(
         &mut self,
-        style: AppearanceStyle,
+        layout: BarLayout,
         request_outputs: &config::Outputs,
         position: Position,
         layer: config::Layer,
@@ -230,7 +251,7 @@ impl Outputs {
             debug!("Found target output, creating a new layer surface");
 
             let (id, task) =
-                Self::create_output_layers(style, Some(output_id), position, layer, scale_factor);
+                Self::create_output_layers(layout, Some(output_id), position, layer, scale_factor);
 
             let destroy_task = match self
                 .entries
@@ -256,7 +277,7 @@ impl Outputs {
                     menu,
                     position,
                     layer,
-                    style,
+                    layout,
                     scale_factor,
                     output_logical_height: None,
                 }),
@@ -295,7 +316,7 @@ impl Outputs {
 
     pub fn remove<Message: 'static>(
         &mut self,
-        style: AppearanceStyle,
+        layout: BarLayout,
         position: Position,
         layer: config::Layer,
         output_id: OutputId,
@@ -333,7 +354,7 @@ impl Outputs {
                     debug!("No outputs left, creating a fallback layer surface");
 
                     let (id, task) =
-                        Self::create_output_layers(style, None, position, layer, scale_factor);
+                        Self::create_output_layers(layout, None, position, layer, scale_factor);
 
                     let menu = self.make_menu();
                     self.entries.push((
@@ -343,7 +364,7 @@ impl Outputs {
                             menu,
                             position,
                             layer,
-                            style,
+                            layout,
                             scale_factor,
                             output_logical_height: None,
                         }),
@@ -359,7 +380,7 @@ impl Outputs {
 
     pub fn sync<Message: 'static>(
         &mut self,
-        style: AppearanceStyle,
+        layout: BarLayout,
         request_outputs: &config::Outputs,
         position: Position,
         layer: config::Layer,
@@ -398,7 +419,7 @@ impl Outputs {
         for (name, output_id) in to_add {
             if let Some(output_id) = output_id {
                 tasks.push(self.add(
-                    style,
+                    layout,
                     request_outputs,
                     position,
                     layer,
@@ -410,7 +431,7 @@ impl Outputs {
         }
 
         for output_id in to_remove {
-            tasks.push(self.remove(style, position, layer, output_id, scale_factor));
+            tasks.push(self.remove(layout, position, layer, output_id, scale_factor));
         }
 
         for shell_info in self.entries.iter_mut().filter_map(|(_, shell_info, _)| {
@@ -447,11 +468,11 @@ impl Outputs {
                 let destroy_task = old.destroy_surfaces();
 
                 let (id, create_task) =
-                    Self::create_output_layers(style, *output_id, position, layer, scale_factor);
+                    Self::create_output_layers(layout, *output_id, position, layer, scale_factor);
 
                 shell_info.id = id;
                 shell_info.menu = Menu::with_animations(animations_enabled);
-                shell_info.style = style;
+                shell_info.layout = layout;
                 shell_info.scale_factor = scale_factor;
 
                 tasks.push(Task::batch(vec![destroy_task, create_task]));
@@ -460,7 +481,7 @@ impl Outputs {
 
         for shell_info in self.entries.iter_mut().filter_map(|(_, shell_info, _)| {
             if let Some(shell_info) = shell_info
-                && (shell_info.style != style || shell_info.scale_factor != scale_factor)
+                && (shell_info.layout != layout || shell_info.scale_factor != scale_factor)
             {
                 Some(shell_info)
             } else {
@@ -468,15 +489,19 @@ impl Outputs {
             }
         }) {
             debug!(
-                "Change style or scale_factor for output: {:?}, new style {:?}, new scale_factor {:?}",
-                shell_info.id, style, scale_factor
+                "Change layout or scale_factor for output: {:?}, new layout {:?}, new scale_factor {:?}",
+                shell_info.id, layout, scale_factor
             );
-            shell_info.style = style;
+            shell_info.layout = layout;
             shell_info.scale_factor = scale_factor;
-            let height = Self::get_height(style, scale_factor);
+            let height = Self::get_height(layout.surface, scale_factor);
             tasks.push(Task::batch(vec![
                 set_size(shell_info.id, (0, height as u32)),
-                set_exclusive_zone(shell_info.id, height as i32),
+                set_exclusive_zone(
+                    shell_info.id,
+                    Self::exclusive_zone(layout, position, scale_factor),
+                ),
+                set_margin(shell_info.id, Self::margin(layout, scale_factor)),
             ]));
         }
 
@@ -762,7 +787,7 @@ impl Outputs {
             if *oid == Some(target) {
                 info.as_ref().and_then(|i| {
                     i.output_logical_height.map(|h| {
-                        let bar = Self::get_height(i.style, i.scale_factor) as u32;
+                        let bar = Self::get_height(i.layout.surface, i.scale_factor) as u32;
                         h.saturating_sub(bar)
                     })
                 })

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -3,11 +3,12 @@ use std::cell::RefCell;
 use crate::{
     components::button::{ButtonHierarchy, ButtonKind},
     config::{
-        Appearance, AppearanceColor, AppearanceStyle, BackgroundLevel, MenuAppearance, Position,
+        Appearance, AppearanceColor, BackgroundLevel, BarAppearance, BarMargin, BarRadius,
+        BarSurface, MenuAppearance, Position, RadiusSize, SpaceSize,
     },
 };
 use iced::{
-    Background, Border, Color, Theme,
+    Background, Border, Color, Theme, border,
     theme::{Palette, palette},
     widget::{
         button::{self, Status},
@@ -53,6 +54,21 @@ impl Default for Space {
     }
 }
 
+impl Space {
+    pub fn resolve(&self, size: SpaceSize) -> f32 {
+        match size {
+            SpaceSize::None => 0.0,
+            SpaceSize::Xxs => self.xxs,
+            SpaceSize::Xs => self.xs,
+            SpaceSize::Sm => self.sm,
+            SpaceSize::Md => self.md,
+            SpaceSize::Lg => self.lg,
+            SpaceSize::Xl => self.xl,
+            SpaceSize::Xxl => self.xxl,
+        }
+    }
+}
+
 #[allow(unused)]
 #[derive(Debug, Clone, Copy)]
 pub struct Radius {
@@ -69,6 +85,46 @@ impl Default for Radius {
             md: 8.0,
             lg: 16.0,
             xl: 32.0,
+        }
+    }
+}
+
+impl Radius {
+    pub fn resolve(&self, size: RadiusSize) -> f32 {
+        match size {
+            RadiusSize::None => 0.0,
+            RadiusSize::Sm => self.sm,
+            RadiusSize::Md => self.md,
+            RadiusSize::Lg => self.lg,
+            RadiusSize::Xl => self.xl,
+        }
+    }
+}
+
+/// Bar geometry the layer-surface layer needs: which surface mode drives the
+/// bar height, plus the resolved outer margin in logical (unscaled) pixels
+/// ordered `(top, right, bottom, left)`.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct BarLayout {
+    pub surface: BarSurface,
+    pub margin: (f32, f32, f32, f32),
+}
+
+impl BarLayout {
+    pub fn from_appearance(bar: &BarAppearance) -> Self {
+        Self::new(bar.surface, bar.margin)
+    }
+
+    fn new(surface: BarSurface, margin: BarMargin) -> Self {
+        let space = Space::default();
+        Self {
+            surface,
+            margin: (
+                space.resolve(margin.top),
+                space.resolve(margin.right),
+                space.resolve(margin.bottom),
+                space.resolve(margin.left),
+            ),
         }
     }
 }
@@ -106,7 +162,9 @@ pub struct AshellTheme {
     pub radius: Radius,
     pub font_size: FontSize,
     pub bar_position: Position,
-    pub bar_style: AppearanceStyle,
+    pub bar_surface: BarSurface,
+    pub bar_radius: BarRadius,
+    pub bar_margin: BarMargin,
     pub opacity: f32,
     pub menu: MenuAppearance,
     pub workspace_colors: Vec<AppearanceColor>,
@@ -240,8 +298,10 @@ fn base_theme_from_appearance(
         radius: Radius::default(),
         font_size: FontSize::default(),
         bar_position,
-        bar_style: appearance.style,
-        opacity: appearance.opacity,
+        bar_surface: appearance.bar.surface,
+        bar_radius: appearance.bar.radius,
+        bar_margin: appearance.bar.margin,
+        opacity: appearance.bar.opacity,
         menu: appearance.menu,
         workspace_colors: appearance.workspace_colors.clone(),
         special_workspace_colors: appearance.special_workspace_colors.clone(),
@@ -258,6 +318,19 @@ impl AshellTheme {
         animations: &crate::config::AnimationsConfig,
     ) -> Self {
         base_theme_from_appearance(appearance, position, animations.enabled)
+    }
+
+    pub fn bar_layout(&self) -> BarLayout {
+        BarLayout::new(self.bar_surface, self.bar_margin)
+    }
+
+    pub fn bar_border_radius(&self) -> border::Radius {
+        border::Radius {
+            top_left: self.radius.resolve(self.bar_radius.top_left),
+            top_right: self.radius.resolve(self.bar_radius.top_right),
+            bottom_right: self.radius.resolve(self.bar_radius.bottom_right),
+            bottom_left: self.radius.resolve(self.bar_radius.bottom_left),
+        }
     }
 
     pub fn button_style(
@@ -651,7 +724,7 @@ impl AshellTheme {
     }
 
     /// Module button style: transparent base with hover highlight.
-    /// The Islands background is handled by `module_group`, not the button.
+    /// The module-group background is handled by `module_group`, not the button.
     pub fn module_button_style(&self) -> impl Fn(&Theme, Status) -> button::Style + use<> {
         let radius_lg = self.radius.lg;
         let opacity = self.opacity;

--- a/website/docs/configuration/appearance/general.md
+++ b/website/docs/configuration/appearance/general.md
@@ -34,59 +34,82 @@ The default value is `1.0`.
 scale_factor = 1.5
 ```
 
-## Status Bar Style
+## Status Bar
 
-You can change the style of the status bar using the `style` field.
+The look of the status bar is configured under the `[appearance.bar]` section.
 
-You can choose between:
+### Surface
 
-- `Islands`: This is the default style. Each module or module group is displayed
-  in a rounded rectangle using the background color.
-- `Solid`: The status bar has a solid background color.
-- `Gradient`: The status bar has a gradient background color.
+The `surface` field controls where the background color is painted:
 
-### Example
+- `transparent`: This is the default. The bar itself is see-through and each
+  module group is painted with the background color, giving the "islands" look.
+- `solid`: The bar is painted with the background color as a single continuous
+  surface.
 
 ```toml
-[appearance]
-style = "Gradient"
+[appearance.bar]
+surface = "solid"
 ```
 
-## Opacity
+### Radius
 
-You can change the opacity of the status bar components using the `opacity` field.
+The `radius` field rounds the corners of the bar surface (it only has an effect
+with `surface = "solid"`). Values are steps of the radius scale: `none` (square),
+`sm`, `md`, `lg`, `xl`.
 
-The value should be a float between `0.0` and `1.0`, where `0.0` is fully transparent.
-The default value is `1.0`.
+It uses CSS `border-radius` shorthand: a single value applies to all corners, two
+values are `[top-left+bottom-right, top-right+bottom-left]`, and four values are
+`[top-left, top-right, bottom-right, bottom-left]`.
 
-It's also possible to define the opacity of status bar menus and whether they should
-include a backdrop effect.
+```toml
+[appearance.bar]
+surface = "solid"
+radius = "md"                       # all corners
+# radius = ["none", "none", "md", "md"]  # square top, rounded bottom
+```
 
-The `backdrop` effect adds a blur/transparent background to menus, making them appear
-semi-transparent over the content behind them. The value should be a float between `0.0`
-and `1.0`, where `0.0` disables the effect and `1.0` applies maximum blur.
+### Margin
+
+The `margin` field insets the bar from the screen edges, turning it into a
+floating bar. Values are steps of the spacing scale: `none` (default), `xxs`,
+`xs`, `sm`, `md`, `lg`, `xl`, `xxl`.
+
+It uses CSS `margin` shorthand: a single value applies to all edges, two values
+are `[vertical, horizontal]`, and four values are `[top, right, bottom, left]`.
+
+```toml
+[appearance.bar]
+margin = "sm"              # all edges
+# margin = ["xs", "md"]    # vertical, horizontal
+```
+
+### Opacity
+
+The `opacity` field sets the opacity of the status bar components. The value
+should be a float between `0.0` (fully transparent) and `1.0` (fully opaque,
+the default).
+
+```toml
+[appearance.bar]
+opacity = 0.8
+```
+
+## Menu Opacity
+
+It's also possible to define the opacity of status bar menus and whether they
+should include a backdrop effect.
+
+The `backdrop` effect adds a blur/transparent background to menus, making them
+appear semi-transparent over the content behind them. The value should be a float
+between `0.0` (disabled) and `1.0` (maximum blur).
 
 **Default values:**
 
-- `opacity`: `1.0` (fully opaque)
 - `menu.opacity`: `1.0` (fully opaque)
 - `menu.backdrop`: `0.0` (disabled)
 
-## Examples
-
-Setting the opacity of the status bar components:
-
 ```toml
-[appearance]
-opacity = 0.8
-```
-
-Also setting the opacity of the status bar menus and adding a backdrop effect:
-
-```toml
-[appearance]
-opacity = 0.8
-
 [appearance.menu]
 opacity = 0.7
 backdrop = 0.3

--- a/website/docs/configuration/appearance/index.md
+++ b/website/docs/configuration/appearance/index.md
@@ -12,6 +12,6 @@ You can customize things like:
 - The color palette
 - The font used
 - The scaling factor of the status bar
-- The style of the status bar
+- The surface, radius and margin of the status bar
 - The opacity of the status bar components
 - The opacity of the status bar menus

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -162,10 +162,8 @@ show_brightness_percentage = false  # (default) show numeric brightness value in
 enabled = false   # (default)
 
 [appearance]
-style = "Islands"  # (default), "Solid", or "Gradient"
 # font_name = "Sans"           # (default: None) custom font family
 # scale_factor = 1.0           # (default) range: 0.0 < x <= 2.0
-# opacity = 1.0                # (default) range: 0.0 to 1.0
 primary_color = "#7aa2f7"
 success_color = "#9ece6a"
 warning_color = "#e0af68"
@@ -173,6 +171,12 @@ danger_color = "#f7768e"
 text_color = "#a9b1d6"
 workspace_colors = [ "#7aa2f7", "#9ece6a" ]
 # special_workspace_colors = [ "#7aa2f7", "#9ece6a" ]  # (default: None, falls back to workspace_colors)
+
+[appearance.bar]
+surface = "transparent"  # (default) or "solid"
+# radius = "none"          # (default) none|sm|md|lg|xl, CSS border-radius shorthand (solid only)
+# margin = "none"          # (default) none|xxs|xs|sm|md|lg|xl|xxl, CSS margin shorthand
+# opacity = 1.0            # (default) range: 0.0 to 1.0
 
 [appearance.menu]
 # opacity = 1.0   # (default) menu background opacity


### PR DESCRIPTION
## Breaking
- Drop style config
- drop gradient style
- move `opacity` config under `[appearance.bar]` section
- Add the following settings for styling the app bar:
  - surface - transparent or solid
  - radius 
  - margin
