### PR TITLE
Add PercentageAndTime + icon variant for battery

### DIFF
--- a/src/components/format_indicator.rs
+++ b/src/components/format_indicator.rs
@@ -50,12 +50,14 @@ impl<'a, Msg: 'static + Clone> From<FormatIndicator<'a, Msg>> for Element<'a, Ms
 
         let content = match fi.format {
             SettingsFormat::Icon => fi.icon.to_text().into(),
-            SettingsFormat::Percentage | SettingsFormat::Time | SettingsFormat::Name => {
-                fi.label_element
-            }
+            SettingsFormat::Percentage
+            | SettingsFormat::Time
+            | SettingsFormat::Name
+            | SettingsFormat::PercentageAndTime => fi.label_element,
             SettingsFormat::IconAndPercentage
             | SettingsFormat::IconAndTime
-            | SettingsFormat::IconAndName => row![fi.icon.to_text(), fi.label_element]
+            | SettingsFormat::IconAndName
+            | SettingsFormat::IconAndPercentageAndTime => row![fi.icon.to_text(), fi.label_element]
                 .spacing(space.xxs)
                 .align_y(Alignment::Center)
                 .into(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -595,6 +595,8 @@ pub enum SettingsFormat {
     IconAndTime,
     Name,
     IconAndName,
+    PercentageAndTime,
+    IconAndPercentageAndTime,
 }
 
 #[derive(Deserialize, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -637,6 +637,8 @@ pub enum SettingsFormat {
     IconAndTime,
     Name,
     IconAndName,
+    PercentageAndTime,
+    IconAndPercentageAndTime,
 }
 
 #[derive(Deserialize, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -292,6 +292,21 @@ impl PowerSettings {
                     SettingsFormat::Name | SettingsFormat::IconAndName => {
                         convert::Into::<Element<'a, Message>>::into(icon(p.get_icon_state()))
                     }
+                    SettingsFormat::PercentageAndTime => row!(
+                        text(format!("{}%", p.data.capacity)),
+                        text(format_time_for_battery(&p.data))
+                    )
+                    .spacing(space.xxs)
+                    .align_y(Alignment::Center)
+                    .into(),
+                    SettingsFormat::IconAndPercentageAndTime => row!(
+                        icon(p.get_icon_state()),
+                        text(format!("{}%", p.data.capacity)),
+                        text(format_time_for_battery(&p.data))
+                    )
+                    .spacing(space.xxs)
+                    .align_y(Alignment::Center)
+                    .into(),
                 })
                 .style(move |theme: &Theme| container::Style {
                     text_color: Some(match state {
@@ -333,6 +348,12 @@ impl PowerSettings {
                     SettingsFormat::Time | SettingsFormat::IconAndTime => {
                         format_time_for_battery(&battery)
                     }
+                    SettingsFormat::PercentageAndTime
+                    | SettingsFormat::IconAndPercentageAndTime => format!(
+                        "{}% {}",
+                        battery.capacity,
+                        format_time_for_battery(&battery)
+                    ),
                     _ => format!("{}%", battery.capacity),
                 };
 

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -24,8 +24,10 @@ use iced::{
 fn format_time_for_battery(battery: &BatteryData) -> String {
     match battery.status {
         BatteryStatus::Charging(duration) => {
-            if battery.capacity >= 100 || duration.is_zero() {
+            if battery.capacity >= 100 {
                 "100%".to_string()
+            } else if duration.is_zero() {
+                format!("{}%", battery.capacity)
             } else {
                 format_duration(&duration)
             }
@@ -39,10 +41,25 @@ fn format_time_for_battery(battery: &BatteryData) -> String {
                 format_duration(&duration)
             }
         }
-        BatteryStatus::NotCharging => format!("{}%", battery.capacity),
-        BatteryStatus::Unknown => String::new(),
+        BatteryStatus::NotCharging | BatteryStatus::Unknown => format!("{}%", battery.capacity),
         BatteryStatus::Full => "100%".to_string(),
     }
+}
+
+fn format_percentage_and_time(battery: &BatteryData) -> String {
+    let capacity = format!("{}%", battery.capacity);
+    let time = match battery.status {
+        BatteryStatus::Charging(duration) | BatteryStatus::Discharging(duration)
+            if battery.capacity < 100 && !duration.is_zero() =>
+        {
+            format_duration(&duration)
+        }
+        BatteryStatus::Discharging(_) if battery.capacity < 100 => {
+            t!("settings-power-calculating")
+        }
+        _ => return capacity,
+    };
+    format!("{capacity} {time}")
 }
 
 #[derive(Debug, Clone)]
@@ -267,13 +284,7 @@ impl PowerSettings {
                     SettingsFormat::Icon => {
                         convert::Into::<Element<'a, Message>>::into(icon(p.get_icon_state()))
                     }
-                    SettingsFormat::Percentage => row!(
-                        icon(p.kind.get_icon()),
-                        text(format!("{}%", p.data.capacity))
-                    )
-                    .spacing(space.xxs)
-                    .align_y(Alignment::Center)
-                    .into(),
+                    SettingsFormat::Percentage => text(format!("{}%", p.data.capacity)).into(),
                     SettingsFormat::IconAndPercentage => row!(
                         icon(p.get_icon_state()),
                         text(format!("{}%", p.data.capacity))
@@ -289,29 +300,20 @@ impl PowerSettings {
                     .spacing(space.xxs)
                     .align_y(Alignment::Center)
                     .into(),
-                    SettingsFormat::Name | SettingsFormat::IconAndName => {
-                        convert::Into::<Element<'a, Message>>::into(icon(p.get_icon_state()))
+                    SettingsFormat::Name => text(p.name.to_string()).into(),
+                    SettingsFormat::IconAndName => {
+                        row!(icon(p.get_icon_state()), text(p.name.to_string()))
+                            .spacing(space.xxs)
+                            .align_y(Alignment::Center)
+                            .into()
                     }
-                    SettingsFormat::PercentageAndTime => row!(
-                        text(format!("{}%", p.data.capacity)),
-                        text(format_time_for_battery(&p.data))
+                    SettingsFormat::PercentageAndTime => {
+                        text(format_percentage_and_time(&p.data)).into()
+                    }
+                    SettingsFormat::IconAndPercentageAndTime => row!(
+                        icon(p.get_icon_state()),
+                        text(format_percentage_and_time(&p.data))
                     )
-                    .spacing(space.xxs)
-                    .align_y(Alignment::Center)
-                    .into(),
-                    SettingsFormat::IconAndPercentageAndTime => {
-                        let battery_capacity = format!("{}%", p.data.capacity);
-                        let battery_time = format_time_for_battery(&p.data);
-                        if battery_time == "100%" || battery_time == battery_capacity {
-                            row!(icon(p.get_icon_state()), text(battery_capacity))
-                        } else {
-                            row!(
-                                icon(p.get_icon_state()),
-                                text(battery_capacity),
-                                text(battery_time)
-                            )
-                        }
-                    }
                     .spacing(space.xxs)
                     .align_y(Alignment::Center)
                     .into(),
@@ -358,13 +360,7 @@ impl PowerSettings {
                     }
                     SettingsFormat::PercentageAndTime
                     | SettingsFormat::IconAndPercentageAndTime => {
-                        let battery_time = format_time_for_battery(&battery);
-                        let battery_capacity = format!("{}%", battery.capacity);
-                        if battery_time == "100%" || battery_time == battery_capacity {
-                            battery_capacity
-                        } else {
-                            battery_capacity + " " + &battery_time
-                        }
+                        format_percentage_and_time(&battery)
                     }
                     _ => format!("{}%", battery.capacity),
                 };

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -349,11 +349,15 @@ impl PowerSettings {
                         format_time_for_battery(&battery)
                     }
                     SettingsFormat::PercentageAndTime
-                    | SettingsFormat::IconAndPercentageAndTime => format!(
-                        "{}% {}",
-                        battery.capacity,
-                        format_time_for_battery(&battery)
-                    ),
+                    | SettingsFormat::IconAndPercentageAndTime => {
+                        let battery_time = format_time_for_battery(&battery);
+                        let battery_capacity = format!("{}%", battery.capacity);
+                        if battery_time != "100%" || battery_time != battery_capacity {
+                            format!("{}% {}", battery_capacity, battery_time)
+                        } else {
+                            format!("{}%", battery_capacity,)
+                        }
+                    }
                     _ => format!("{}%", battery.capacity),
                 };
 

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -353,9 +353,9 @@ impl PowerSettings {
                         let battery_time = format_time_for_battery(&battery);
                         let battery_capacity = format!("{}%", battery.capacity);
                         if battery_time != "100%" || battery_time != battery_capacity {
-                            format!("{}% {}", battery_capacity, battery_time)
+                            battery_capacity + " " + &battery_time
                         } else {
-                            format!("{}%", battery_capacity,)
+                            battery_capacity
                         }
                     }
                     _ => format!("{}%", battery.capacity),

--- a/src/modules/settings/power.rs
+++ b/src/modules/settings/power.rs
@@ -299,11 +299,19 @@ impl PowerSettings {
                     .spacing(space.xxs)
                     .align_y(Alignment::Center)
                     .into(),
-                    SettingsFormat::IconAndPercentageAndTime => row!(
-                        icon(p.get_icon_state()),
-                        text(format!("{}%", p.data.capacity)),
-                        text(format_time_for_battery(&p.data))
-                    )
+                    SettingsFormat::IconAndPercentageAndTime => {
+                        let battery_capacity = format!("{}%", p.data.capacity);
+                        let battery_time = format_time_for_battery(&p.data);
+                        if battery_time == "100%" || battery_time == battery_capacity {
+                            row!(icon(p.get_icon_state()), text(battery_capacity))
+                        } else {
+                            row!(
+                                icon(p.get_icon_state()),
+                                text(battery_capacity),
+                                text(battery_time)
+                            )
+                        }
+                    }
                     .spacing(space.xxs)
                     .align_y(Alignment::Center)
                     .into(),
@@ -352,10 +360,10 @@ impl PowerSettings {
                     | SettingsFormat::IconAndPercentageAndTime => {
                         let battery_time = format_time_for_battery(&battery);
                         let battery_capacity = format!("{}%", battery.capacity);
-                        if battery_time != "100%" || battery_time != battery_capacity {
-                            battery_capacity + " " + &battery_time
-                        } else {
+                        if battery_time == "100%" || battery_time == battery_capacity {
                             battery_capacity
+                        } else {
+                            battery_capacity + " " + &battery_time
                         }
                     }
                     _ => format!("{}%", battery.capacity),

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -166,7 +166,7 @@ audio_sources_more_cmd = "pavucontrol -t 4"
 wifi_more_cmd = "nm-connection-editor"
 vpn_more_cmd = "nm-connection-editor"
 bluetooth_more_cmd = "blueberry"
-battery_format = "IconAndPercentage"  # (default), "Icon", "Percentage", "Time", "IconAndTime"
+battery_format = "IconAndPercentage"  # (default), "Icon", "Percentage", "Time", "IconAndTime", "PercentageAndTime", "IconAndPercentageAndTime"
 # battery_hide_when_full = false  # (default)
 # peripheral_indicators = "All"   # (default) or { Specific = ["Keyboard", "Mouse", "Headphones", "Gamepad"] }
 peripheral_battery_format = "Icon"  # (default), "IconAndPercentage", "Percentage", etc.

--- a/website/docs/configuration/modules/settings.md
+++ b/website/docs/configuration/modules/settings.md
@@ -101,6 +101,8 @@ The possible values are:
 - `IconAndPercentage` - Show both the battery icon and percentage (default)
 - `Time` - Show smart time display (time to full when charging, time to empty when discharging, "100%" when full)
 - `IconAndTime` - Show battery icon with smart time display
+- `PercentageAndTime` - Show the battery percentage along with smart time display
+- `IconAndPercentageAndTime` - Show battery icon with battery percentage and smart time display
 
 ```toml
 [settings]


### PR DESCRIPTION
Closes #868 

Adds the two formats: `PercentageAndTime` and `IconAndPercentageAndTime`. 

I'm not super familiar with the codebase, so let me know if things can be done in a better way. 