### PR TITLE
feat(media_player): add optional cava audio visualizer

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -721,6 +721,7 @@ pub enum MediaPlayerFormat {
 pub struct MediaPlayerModuleConfig {
     pub max_title_length: u32,
     pub indicator_format: MediaPlayerFormat,
+    pub show_visualizer: bool,
 }
 
 impl Default for MediaPlayerModuleConfig {
@@ -728,6 +729,7 @@ impl Default for MediaPlayerModuleConfig {
         MediaPlayerModuleConfig {
             max_title_length: 100,
             indicator_format: MediaPlayerFormat::default(),
+            show_visualizer: false,
         }
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -307,15 +307,21 @@ impl MediaPlayer {
                         Stack::new()
                             .push(content)
                             .push_under(
-                                Canvas::new(VisualizerCanvas {
-                                    bars: self.bars.clone(),
-                                    low: palette.primary,
-                                    mid: palette.warning,
-                                    high: palette.danger,
-                                    opacity: 0.2,
-                                })
-                                .width(Length::Fill)
-                                .height(Length::Fill),
+                                // iced clips to a rectangle, not to the card's
+                                // rounded border, so inset the canvas by the corner
+                                // radius to keep the bars inside the rounded shape.
+                                container(
+                                    Canvas::new(VisualizerCanvas {
+                                        bars: self.bars.clone(),
+                                        low: palette.primary,
+                                        mid: palette.warning,
+                                        high: palette.danger,
+                                        opacity: 0.2,
+                                    })
+                                    .width(Length::Fill)
+                                    .height(Length::Fill),
+                                )
+                                .padding(radius.lg),
                             )
                             .into()
                     } else {
@@ -335,7 +341,6 @@ impl MediaPlayer {
                             border: Border::default().rounded(radius.lg),
                             ..container::Style::default()
                         })
-                        .clip(true)
                         .width(Length::Fill)
                         .into()
                 }))

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -29,7 +29,6 @@ use std::any::TypeId;
 
 const VISUALIZER_BAR_COUNT: usize = 12;
 const VISUALIZER_FRAMERATE: u32 = 60;
-const VISUALIZER_PADDING: u16 = 3;
 
 struct VisualizerCanvas {
     bars: Vec<f32>,
@@ -37,6 +36,9 @@ struct VisualizerCanvas {
     mid: Color,
     high: Color,
     opacity: f32,
+    // Corner radius of the surface behind the bars; the outermost bars round
+    // their outer corners to match it (0 to keep square bars).
+    radius: f32,
 }
 
 impl<M> canvas::Program<M> for VisualizerCanvas {
@@ -57,12 +59,11 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
         }
 
         let n = VISUALIZER_BAR_COUNT.min(self.bars.len());
-        let bar_width = (bounds.width / (n as f32 * 4.0 / 3.0)).max(1.0);
-        let gap = (bar_width / 3.0).max(1.0);
+        // Fill the full width edge to edge: `n` bars plus `n - 1` gaps span the
+        // whole width, with each gap a third of a bar.
+        let bar_width = (bounds.width / (n as f32 + (n as f32 - 1.0) / 3.0)).max(1.0);
+        let gap = bar_width / 3.0;
         let step = bar_width + gap;
-        // Center the whole bar group horizontally within the available width.
-        let total_width = n as f32 * step - gap;
-        let x_offset = ((bounds.width - total_width) / 2.0).max(0.0);
 
         // The gradient is vertical, so its colour depends only on `y`: every bar
         // shares the same fill. Build it once instead of per bar.
@@ -91,10 +92,35 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
 
         for i in 0..n {
             let height = self.bars[i] * bounds.height;
-            let x = x_offset + i as f32 * step;
+            let x = i as f32 * step;
             let y = bounds.height - height;
+            let position = iced::Point::new(x, y);
+            let size = iced::Size::new(bar_width, height);
 
-            let rect = Path::rectangle(iced::Point::new(x, y), iced::Size::new(bar_width, height));
+            let is_first = i == 0;
+            let is_last = i == n - 1;
+            let rect = if self.radius > 0.0 && (is_first || is_last) {
+                // Match the outer corners of the first/last bar to the surface
+                // rounding; top corners only when the bar reaches the top edge.
+                let reaches_top = y <= self.radius;
+                let radius = iced::border::Radius {
+                    top_left: if is_first && reaches_top {
+                        self.radius
+                    } else {
+                        0.0
+                    },
+                    bottom_left: if is_first { self.radius } else { 0.0 },
+                    top_right: if is_last && reaches_top {
+                        self.radius
+                    } else {
+                        0.0
+                    },
+                    bottom_right: if is_last { self.radius } else { 0.0 },
+                };
+                Path::rounded_rectangle(position, size, radius)
+            } else {
+                Path::rectangle(position, size)
+            };
 
             frame.fill(&rect, fill);
         }
@@ -297,31 +323,23 @@ impl MediaPlayer {
                                 .into()
                         }
                     };
-                    // Use the visualizer as the background of the card that is
-                    // currently playing; keep the other cards untouched.
                     let card_playing = self.config.show_visualizer
                         && d.state == PlaybackStatus::Playing
                         && !self.bars.is_empty();
-                    let card_alpha = if card_playing { opacity * 0.9 } else { opacity };
                     let body: Element<'_, _> = if card_playing {
                         Stack::new()
                             .push(content)
                             .push_under(
-                                // iced clips to a rectangle, not to the card's
-                                // rounded border, so inset the canvas by the corner
-                                // radius to keep the bars inside the rounded shape.
-                                container(
-                                    Canvas::new(VisualizerCanvas {
-                                        bars: self.bars.clone(),
-                                        low: palette.primary,
-                                        mid: palette.warning,
-                                        high: palette.danger,
-                                        opacity: 0.2,
-                                    })
-                                    .width(Length::Fill)
-                                    .height(Length::Fill),
-                                )
-                                .padding(radius.lg),
+                                Canvas::new(VisualizerCanvas {
+                                    bars: self.bars.clone(),
+                                    low: palette.primary,
+                                    mid: palette.warning,
+                                    high: palette.danger,
+                                    opacity: 0.2,
+                                    radius: radius.lg,
+                                })
+                                .width(Length::Fill)
+                                .height(Length::Fill),
                             )
                             .into()
                     } else {
@@ -335,7 +353,7 @@ impl MediaPlayer {
                                     .background
                                     .weak
                                     .color
-                                    .scale_alpha(card_alpha),
+                                    .scale_alpha(opacity),
                             )
                             .into(),
                             border: Border::default().rounded(radius.lg),
@@ -398,12 +416,12 @@ impl MediaPlayer {
                             mid: palette.warning,
                             high: palette.danger,
                             opacity: 1.,
+                            radius: 0.0,
                         })
                         .width(Length::Fixed((VISUALIZER_BAR_COUNT * 4) as f32))
                         .height(Length::Fill),
                     )
-                    .padding([VISUALIZER_PADDING, 0])
-                    .height(Length::Fill)
+                    .padding(space.xxs)
                 });
 
                 row![icon(StaticIcon::MusicNote)]

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -60,6 +60,9 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
         let bar_width = (bounds.width / (n as f32 * 4.0 / 3.0)).max(1.0);
         let gap = (bar_width / 3.0).max(1.0);
         let step = bar_width + gap;
+        // Center the whole bar group horizontally within the available width.
+        let total_width = n as f32 * step - gap;
+        let x_offset = ((bounds.width - total_width) / 2.0).max(0.0);
 
         // The gradient is vertical, so its colour depends only on `y`: every bar
         // shares the same fill. Build it once instead of per bar.
@@ -88,7 +91,7 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
 
         for i in 0..n {
             let height = self.bars[i] * bounds.height;
-            let x = i as f32 * step;
+            let x = x_offset + i as f32 * step;
             let y = bounds.height - height;
 
             let rect = Path::rectangle(iced::Point::new(x, y), iced::Size::new(bar_width, height));
@@ -272,6 +275,7 @@ impl MediaPlayer {
                     let content: Element<'_, _> = match (volume_slider, cover) {
                         (None, None) => row![description, buttons]
                             .spacing(space.md)
+                            .padding(space.md)
                             .align_y(Vertical::Center)
                             .into(),
                         (Some(v), cover) => {
@@ -279,6 +283,7 @@ impl MediaPlayer {
                                 row![v, buttons].spacing(space.md).align_y(Vertical::Center);
                             column![metadata(description, cover), controls]
                                 .spacing(space.md)
+                                .padding(space.md)
                                 .into()
                         }
                         (None, cover) => {
@@ -288,6 +293,7 @@ impl MediaPlayer {
                                     .align_y(Vertical::Center);
                             column![metadata(description, cover), controls]
                                 .spacing(space.md)
+                                .padding(space.md)
                                 .into()
                         }
                     };
@@ -306,7 +312,7 @@ impl MediaPlayer {
                                     low: palette.primary,
                                     mid: palette.warning,
                                     high: palette.danger,
-                                    opacity: 0.6,
+                                    opacity: 0.2,
                                 })
                                 .width(Length::Fill)
                                 .height(Length::Fill),
@@ -329,7 +335,7 @@ impl MediaPlayer {
                             border: Border::default().rounded(radius.lg),
                             ..container::Style::default()
                         })
-                        .padding(space.md)
+                        .clip(true)
                         .width(Length::Fill)
                         .into()
                 }))

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -160,11 +160,18 @@ impl MediaPlayer {
         }
     }
 
+    /// The player to represent in the bar: the one currently playing, or the
+    /// first known player when nothing is playing.
+    fn active_player(&self) -> Option<&MprisPlayerData> {
+        let players = self.service.as_ref()?.players();
+        players
+            .iter()
+            .find(|p| p.state == PlaybackStatus::Playing)
+            .or_else(|| players.first())
+    }
+
     fn is_playing(&self) -> bool {
-        self.service
-            .as_ref()
-            .and_then(|s| s.players().first().map(|p| p.state))
-            == Some(PlaybackStatus::Playing)
+        self.active_player().map(|p| p.state) == Some(PlaybackStatus::Playing)
     }
 
     pub fn update(&mut self, message: Message) -> Action {
@@ -335,7 +342,7 @@ impl MediaPlayer {
                                     low: palette.primary,
                                     mid: palette.warning,
                                     high: palette.danger,
-                                    opacity: 0.2,
+                                    opacity: 0.1,
                                     radius: radius.lg,
                                 })
                                 .width(Length::Fill)
@@ -393,44 +400,42 @@ impl MediaPlayer {
     pub fn view(&'_ self) -> Option<Element<'_, Message>> {
         let (space, font_size, palette) =
             use_theme(|theme| (theme.space, theme.font_size, theme.iced_theme.palette()));
-        self.service.as_ref().and_then(|s| {
-            s.players().first().map(|player| {
-                let title =
-                    (self.config.indicator_format == MediaPlayerFormat::IconAndTitle).then(|| {
-                        container(
-                            text(self.get_title(player))
-                                .wrapping(text::Wrapping::None)
-                                .size(font_size.sm),
-                        )
-                        .clip(true)
-                    });
-
-                let visualizer = (self.config.show_visualizer
-                    && player.state == PlaybackStatus::Playing
-                    && !self.bars.is_empty())
-                .then(|| {
+        self.active_player().map(|player| {
+            let title =
+                (self.config.indicator_format == MediaPlayerFormat::IconAndTitle).then(|| {
                     container(
-                        Canvas::new(VisualizerCanvas {
-                            bars: self.bars.clone(),
-                            low: palette.primary,
-                            mid: palette.warning,
-                            high: palette.danger,
-                            opacity: 1.,
-                            radius: 0.0,
-                        })
-                        .width(Length::Fixed((VISUALIZER_BAR_COUNT * 4) as f32))
-                        .height(Length::Fill),
+                        text(self.get_title(player))
+                            .wrapping(text::Wrapping::None)
+                            .size(font_size.sm),
                     )
-                    .padding(space.xxs)
+                    .clip(true)
                 });
 
-                row![icon(StaticIcon::MusicNote)]
-                    .push(title)
-                    .push(visualizer)
-                    .align_y(Vertical::Center)
-                    .spacing(space.xs)
-                    .into()
-            })
+            let visualizer = (self.config.show_visualizer
+                && player.state == PlaybackStatus::Playing
+                && !self.bars.is_empty())
+            .then(|| {
+                container(
+                    Canvas::new(VisualizerCanvas {
+                        bars: self.bars.clone(),
+                        low: palette.primary,
+                        mid: palette.warning,
+                        high: palette.danger,
+                        opacity: 1.,
+                        radius: 0.0,
+                    })
+                    .width(Length::Fixed((VISUALIZER_BAR_COUNT * 4) as f32))
+                    .height(Length::Fill),
+                )
+                .padding(space.xxs)
+            });
+
+            row![icon(StaticIcon::MusicNote)]
+                .push(title)
+                .push(visualizer)
+                .align_y(Vertical::Center)
+                .spacing(space.xs)
+                .into()
         })
     }
 

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -31,85 +31,12 @@ const VISUALIZER_BAR_COUNT: usize = 12;
 const VISUALIZER_FRAMERATE: u32 = 60;
 const VISUALIZER_PADDING: u16 = 3;
 
-fn cava_subscription() -> Subscription<Vec<f32>> {
-    struct Cava;
-
-    Subscription::run_with(TypeId::of::<Cava>(), |_| {
-        channel(16, async move |mut output| {
-            let cava_config = format!(
-                "[general]\nbars = {VISUALIZER_BAR_COUNT}\nframerate = {VISUALIZER_FRAMERATE}\n\n\
-                 [output]\nmethod = raw\nraw_target = /dev/stdout\ndata_format = ascii\nascii_max_range = 1000\n\n\
-                 [smoothing]\nmonstercat = 1\n"
-            );
-
-            let config_path = std::env::temp_dir().join("ashell_cava.cfg");
-            if let Err(e) = tokio::fs::write(&config_path, &cava_config).await {
-                log::error!("cava: failed to write config: {e}");
-                return;
-            }
-
-            let mut child = match tokio::process::Command::new("cava")
-                .arg("-p")
-                .arg(&config_path)
-                .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::piped())
-                .kill_on_drop(true)
-                .spawn()
-            {
-                Ok(c) => c,
-                Err(e) => {
-                    log::warn!("cava: failed to spawn process: {e}");
-                    return;
-                }
-            };
-
-            let stdout = match child.stdout.take() {
-                Some(s) => s,
-                None => {
-                    log::error!("cava: no stdout");
-                    return;
-                }
-            };
-            let stderr = child.stderr.take();
-
-            use tokio::io::{AsyncBufReadExt, BufReader};
-            let reader = BufReader::new(stdout);
-            let mut lines = reader.lines();
-
-            while let Ok(Some(line)) = lines.next_line().await {
-                let bars: Vec<f32> = line
-                    .split(';')
-                    .filter(|s| !s.is_empty())
-                    .filter_map(|s| s.trim().parse::<f32>().ok())
-                    .map(|v| v / 1000.0)
-                    .collect();
-
-                if !bars.is_empty() {
-                    let _ = output.send(bars).await;
-                }
-            }
-
-            // stdout closed: cava exited on its own. Surface why, so a rejected
-            // config or an incompatible version is not a silent no-op.
-            if let Ok(status) = child.wait().await
-                && !status.success()
-            {
-                let mut err = String::new();
-                if let Some(mut stderr) = stderr {
-                    use tokio::io::AsyncReadExt;
-                    let _ = stderr.read_to_string(&mut err).await;
-                }
-                log::warn!("cava exited ({status}): {}", err.trim());
-            }
-        })
-    })
-}
-
 struct VisualizerCanvas {
     bars: Vec<f32>,
     low: Color,
     mid: Color,
     high: Color,
+    opacity: f32,
 }
 
 impl<M> canvas::Program<M> for VisualizerCanvas {
@@ -143,15 +70,15 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
         .add_stops([
             ColorStop {
                 offset: 0.0,
-                color: self.high,
+                color: self.high.scale_alpha(self.opacity),
             },
             ColorStop {
                 offset: 0.5,
-                color: self.mid,
+                color: self.mid.scale_alpha(self.opacity),
             },
             ColorStop {
                 offset: 1.0,
-                color: self.low,
+                color: self.low.scale_alpha(self.opacity),
             },
         ]);
         let fill = Fill {
@@ -258,163 +185,158 @@ impl MediaPlayer {
                 theme.iced_theme.palette(),
             )
         });
-        // When the visualizer is active use it as the menu background and let the
-        // player cards go translucent so the bars show through.
-        let show_background = self.config.show_visualizer && !self.bars.is_empty();
-        let card_alpha = if show_background {
-            opacity * 0.4
-        } else {
-            opacity
-        };
         container(match &self.service {
             None => Into::<Element<'a, Message>>::into(text(t!("media-player-not-connected"))),
-            Some(service) => {
-                let content = column!(
-                    text(t!("media-player-heading")).size(font_size.lg),
-                    divider(),
-                    column(service.players().iter().map(|d| {
-                        const LEFT_COLUMN_WIDTH: Length = Length::FillPortion(3);
-                        const RIGHT_COLUMN_WIDTH: Length = Length::FillPortion(2);
-                        let m = d.metadata.as_ref();
-                        let title = m
-                            .and_then(|m| m.title.clone())
-                            .unwrap_or_else(|| t!("media-player-no-title"));
-                        let artists = m
-                            .and_then(|m| m.artists.clone())
-                            .map(|a| a.join(", "))
-                            .unwrap_or_else(|| t!("media-player-unknown-artist"));
-                        let album = m
-                            .and_then(|m| m.album.clone())
-                            .unwrap_or_else(|| t!("media-player-unknown-album"));
-                        let title = text(truncate_text(&title, self.config.max_title_length))
-                            .wrapping(text::Wrapping::WordOrGlyph)
-                            .width(Length::Fill);
-                        let artists = text(truncate_text(&artists, self.config.max_title_length))
-                            .wrapping(text::Wrapping::WordOrGlyph)
-                            .size(font_size.sm)
-                            .width(Length::Fill);
-                        let album = text(truncate_text(&album, self.config.max_title_length))
-                            .wrapping(text::Wrapping::WordOrGlyph)
-                            .size(font_size.sm)
-                            .width(Length::Fill);
-                        let description = column![title, artists, album]
-                            .spacing(space.xxs)
-                            .width(LEFT_COLUMN_WIDTH);
+            Some(service) => column!(
+                text(t!("media-player-heading")).size(font_size.lg),
+                divider(),
+                column(service.players().iter().map(|d| {
+                    const LEFT_COLUMN_WIDTH: Length = Length::FillPortion(3);
+                    const RIGHT_COLUMN_WIDTH: Length = Length::FillPortion(2);
+                    let m = d.metadata.as_ref();
+                    let title = m
+                        .and_then(|m| m.title.clone())
+                        .unwrap_or_else(|| t!("media-player-no-title"));
+                    let artists = m
+                        .and_then(|m| m.artists.clone())
+                        .map(|a| a.join(", "))
+                        .unwrap_or_else(|| t!("media-player-unknown-artist"));
+                    let album = m
+                        .and_then(|m| m.album.clone())
+                        .unwrap_or_else(|| t!("media-player-unknown-album"));
+                    let title = text(truncate_text(&title, self.config.max_title_length))
+                        .wrapping(text::Wrapping::WordOrGlyph)
+                        .width(Length::Fill);
+                    let artists = text(truncate_text(&artists, self.config.max_title_length))
+                        .wrapping(text::Wrapping::WordOrGlyph)
+                        .size(font_size.sm)
+                        .width(Length::Fill);
+                    let album = text(truncate_text(&album, self.config.max_title_length))
+                        .wrapping(text::Wrapping::WordOrGlyph)
+                        .size(font_size.sm)
+                        .width(Length::Fill);
+                    let description = column![title, artists, album]
+                        .spacing(space.xxs)
+                        .width(LEFT_COLUMN_WIDTH);
 
-                        let play_pause_icon = match d.state {
-                            PlaybackStatus::Playing => StaticIcon::Pause,
-                            PlaybackStatus::Paused | PlaybackStatus::Stopped => StaticIcon::Play,
-                        };
+                    let play_pause_icon = match d.state {
+                        PlaybackStatus::Playing => StaticIcon::Pause,
+                        PlaybackStatus::Paused | PlaybackStatus::Stopped => StaticIcon::Play,
+                    };
 
-                        let buttons = container(
-                            row![
-                                icon_button(StaticIcon::SkipPrevious)
-                                    .on_press(Message::Prev(d.service.clone()))
-                                    .size(ButtonSize::Large),
-                                icon_button(play_pause_icon)
-                                    .on_press(Message::PlayPause(d.service.clone()))
-                                    .size(ButtonSize::Large),
-                                icon_button(StaticIcon::SkipNext)
-                                    .on_press(Message::Next(d.service.clone()))
-                                    .size(ButtonSize::Large),
-                            ]
-                            .align_y(Vertical::Center)
-                            .spacing(space.xs),
-                        )
-                        .center_x(RIGHT_COLUMN_WIDTH);
-                        let volume_slider: Option<Element<'_, _>> = d.volume.map(|v| {
-                            slider(0.0..=100.0, v, move |v| {
-                                Message::SetVolume(d.service.clone(), v)
-                            })
-                            .width(LEFT_COLUMN_WIDTH)
-                            .into()
-                        });
-                        let cover: Option<Element<'_, _>> = d
-                            .metadata
-                            .as_ref()
-                            .and_then(|m| m.art_url.as_ref())
-                            .map(|url| {
-                                let inner: Element<'_, _> = service
-                                    .get_cover(url)
-                                    .map(|handle| {
-                                        image(handle)
-                                            .filter_method(image::FilterMethod::Linear)
-                                            .into()
-                                    })
-                                    .unwrap_or_else(|| {
-                                        text(t!("media-player-loading-cover")).into()
-                                    });
-                                container(inner).center_x(RIGHT_COLUMN_WIDTH).into()
-                            });
-                        let metadata = |description, cover| -> Element<'_, _> {
-                            row![description]
-                                .push(cover)
-                                .spacing(space.md)
-                                .align_y(Vertical::Center)
-                                .into()
-                        };
-                        let content: Element<'_, _> = match (volume_slider, cover) {
-                            (None, None) => row![description, buttons]
-                                .spacing(space.md)
-                                .align_y(Vertical::Center)
-                                .into(),
-                            (Some(v), cover) => {
-                                let controls =
-                                    row![v, buttons].spacing(space.md).align_y(Vertical::Center);
-                                column![metadata(description, cover), controls]
-                                    .spacing(space.md)
-                                    .into()
-                            }
-                            (None, cover) => {
-                                let controls =
-                                    row![space::horizontal().width(LEFT_COLUMN_WIDTH), buttons]
-                                        .spacing(space.md)
-                                        .align_y(Vertical::Center);
-                                column![metadata(description, cover), controls]
-                                    .spacing(space.md)
-                                    .into()
-                            }
-                        };
-                        container(content)
-                            .style(move |app_theme: &Theme| container::Style {
-                                background: Background::Color(
-                                    app_theme
-                                        .extended_palette()
-                                        .background
-                                        .weak
-                                        .color
-                                        .scale_alpha(card_alpha),
-                                )
-                                .into(),
-                                border: Border::default().rounded(radius.lg),
-                                ..container::Style::default()
-                            })
-                            .padding(space.md)
-                            .width(Length::Fill)
-                            .into()
-                    }))
-                    .spacing(space.md)
-                )
-                .spacing(space.xs);
-
-                if show_background {
-                    Stack::new()
-                        .push(content)
-                        .push_under(
-                            Canvas::new(VisualizerCanvas {
-                                bars: self.bars.clone(),
-                                low: palette.primary,
-                                mid: palette.warning,
-                                high: palette.danger,
-                            })
-                            .width(Length::Fill)
-                            .height(Length::Fill),
-                        )
+                    let buttons = container(
+                        row![
+                            icon_button(StaticIcon::SkipPrevious)
+                                .on_press(Message::Prev(d.service.clone()))
+                                .size(ButtonSize::Large),
+                            icon_button(play_pause_icon)
+                                .on_press(Message::PlayPause(d.service.clone()))
+                                .size(ButtonSize::Large),
+                            icon_button(StaticIcon::SkipNext)
+                                .on_press(Message::Next(d.service.clone()))
+                                .size(ButtonSize::Large),
+                        ]
+                        .align_y(Vertical::Center)
+                        .spacing(space.xs),
+                    )
+                    .center_x(RIGHT_COLUMN_WIDTH);
+                    let volume_slider: Option<Element<'_, _>> = d.volume.map(|v| {
+                        slider(0.0..=100.0, v, move |v| {
+                            Message::SetVolume(d.service.clone(), v)
+                        })
+                        .width(LEFT_COLUMN_WIDTH)
                         .into()
-                } else {
-                    content.into()
-                }
-            }
+                    });
+                    let cover: Option<Element<'_, _>> = d
+                        .metadata
+                        .as_ref()
+                        .and_then(|m| m.art_url.as_ref())
+                        .map(|url| {
+                            let inner: Element<'_, _> = service
+                                .get_cover(url)
+                                .map(|handle| {
+                                    image(handle)
+                                        .filter_method(image::FilterMethod::Linear)
+                                        .into()
+                                })
+                                .unwrap_or_else(|| text(t!("media-player-loading-cover")).into());
+                            container(inner).center_x(RIGHT_COLUMN_WIDTH).into()
+                        });
+                    let metadata = |description, cover| -> Element<'_, _> {
+                        row![description]
+                            .push(cover)
+                            .spacing(space.md)
+                            .align_y(Vertical::Center)
+                            .into()
+                    };
+                    let content: Element<'_, _> = match (volume_slider, cover) {
+                        (None, None) => row![description, buttons]
+                            .spacing(space.md)
+                            .align_y(Vertical::Center)
+                            .into(),
+                        (Some(v), cover) => {
+                            let controls =
+                                row![v, buttons].spacing(space.md).align_y(Vertical::Center);
+                            column![metadata(description, cover), controls]
+                                .spacing(space.md)
+                                .into()
+                        }
+                        (None, cover) => {
+                            let controls =
+                                row![space::horizontal().width(LEFT_COLUMN_WIDTH), buttons]
+                                    .spacing(space.md)
+                                    .align_y(Vertical::Center);
+                            column![metadata(description, cover), controls]
+                                .spacing(space.md)
+                                .into()
+                        }
+                    };
+                    // Use the visualizer as the background of the card that is
+                    // currently playing; keep the other cards untouched.
+                    let card_playing = self.config.show_visualizer
+                        && d.state == PlaybackStatus::Playing
+                        && !self.bars.is_empty();
+                    let card_alpha = if card_playing { opacity * 0.9 } else { opacity };
+                    let body: Element<'_, _> = if card_playing {
+                        Stack::new()
+                            .push(content)
+                            .push_under(
+                                Canvas::new(VisualizerCanvas {
+                                    bars: self.bars.clone(),
+                                    low: palette.primary,
+                                    mid: palette.warning,
+                                    high: palette.danger,
+                                    opacity: 0.6,
+                                })
+                                .width(Length::Fill)
+                                .height(Length::Fill),
+                            )
+                            .into()
+                    } else {
+                        content
+                    };
+                    container(body)
+                        .style(move |app_theme: &Theme| container::Style {
+                            background: Background::Color(
+                                app_theme
+                                    .extended_palette()
+                                    .background
+                                    .weak
+                                    .color
+                                    .scale_alpha(card_alpha),
+                            )
+                            .into(),
+                            border: Border::default().rounded(radius.lg),
+                            ..container::Style::default()
+                        })
+                        .padding(space.md)
+                        .width(Length::Fill)
+                        .into()
+                }))
+                .spacing(space.md)
+            )
+            .spacing(space.xs)
+            .into(),
         })
         .width(MenuSize::Large)
         .into()
@@ -464,6 +386,7 @@ impl MediaPlayer {
                             low: palette.primary,
                             mid: palette.warning,
                             high: palette.danger,
+                            opacity: 1.,
                         })
                         .width(Length::Fixed((VISUALIZER_BAR_COUNT * 4) as f32))
                         .height(Length::Fill),
@@ -484,7 +407,7 @@ impl MediaPlayer {
 
     pub fn subscription(&self) -> Subscription<Message> {
         let cava = (self.config.show_visualizer && self.is_playing())
-            .then(|| cava_subscription().map(Message::Bars));
+            .then(|| self.cava_subscription().map(Message::Bars));
         Subscription::batch(
             [
                 Some(MprisPlayerService::subscribe().map(Message::Event)),
@@ -493,5 +416,79 @@ impl MediaPlayer {
             .into_iter()
             .flatten(),
         )
+    }
+
+    fn cava_subscription(&self) -> Subscription<Vec<f32>> {
+        struct Cava;
+
+        Subscription::run_with(TypeId::of::<Cava>(), |_| {
+            channel(16, async move |mut output| {
+                let cava_config = format!(
+                    "[general]\nbars = {VISUALIZER_BAR_COUNT}\nframerate = {VISUALIZER_FRAMERATE}\n\n\
+                 [output]\nmethod = raw\nraw_target = /dev/stdout\ndata_format = ascii\nascii_max_range = 1000\n\n\
+                 [smoothing]\nmonstercat = 1\n"
+                );
+
+                let config_path = std::env::temp_dir().join("ashell_cava.cfg");
+                if let Err(e) = tokio::fs::write(&config_path, &cava_config).await {
+                    log::error!("cava: failed to write config: {e}");
+                    return;
+                }
+
+                let mut child = match tokio::process::Command::new("cava")
+                    .arg("-p")
+                    .arg(&config_path)
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped())
+                    .kill_on_drop(true)
+                    .spawn()
+                {
+                    Ok(c) => c,
+                    Err(e) => {
+                        log::warn!("cava: failed to spawn process: {e}");
+                        return;
+                    }
+                };
+
+                let stdout = match child.stdout.take() {
+                    Some(s) => s,
+                    None => {
+                        log::error!("cava: no stdout");
+                        return;
+                    }
+                };
+                let stderr = child.stderr.take();
+
+                use tokio::io::{AsyncBufReadExt, BufReader};
+                let reader = BufReader::new(stdout);
+                let mut lines = reader.lines();
+
+                while let Ok(Some(line)) = lines.next_line().await {
+                    let bars: Vec<f32> = line
+                        .split(';')
+                        .filter(|s| !s.is_empty())
+                        .filter_map(|s| s.trim().parse::<f32>().ok())
+                        .map(|v| v / 1000.0)
+                        .collect();
+
+                    if !bars.is_empty() {
+                        let _ = output.send(bars).await;
+                    }
+                }
+
+                // stdout closed: cava exited on its own. Surface why, so a rejected
+                // config or an incompatible version is not a silent no-op.
+                if let Ok(status) = child.wait().await
+                    && !status.success()
+                {
+                    let mut err = String::new();
+                    if let Some(mut stderr) = stderr {
+                        use tokio::io::AsyncReadExt;
+                        let _ = stderr.read_to_string(&mut err).await;
+                    }
+                    log::warn!("cava exited ({status}): {}", err.trim());
+                }
+            })
+        })
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -14,10 +14,158 @@ use crate::{
     utils::truncate_text,
 };
 use iced::{
-    Background, Border, Element, Length, Subscription, Task, Theme,
+    Background, Border, Color, Element, Length, Subscription, Task, Theme,
     alignment::Vertical,
-    widget::{column, container, image, row, slider, space, text},
+    futures::SinkExt,
+    gradient::ColorStop,
+    stream::channel,
+    widget::{
+        canvas::{self, Canvas, Fill, Frame, Geometry, Path},
+        column, container, image, row, slider, space, text,
+    },
 };
+
+const VISUALIZER_BAR_COUNT: usize = 12;
+const VISUALIZER_FRAMERATE: u32 = 60;
+const VISUALIZER_PADDING: u16 = 3;
+
+fn cava_subscription() -> Subscription<Vec<f32>> {
+    Subscription::run(|| {
+        channel(16, async move |mut output| {
+            if tokio::process::Command::new("cava")
+                .arg("--version")
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .status()
+                .await
+                .is_err()
+            {
+                log::warn!("cava: not found, visualizer disabled");
+                return;
+            }
+
+            let cava_config = format!(
+                "[general]\nbars = {VISUALIZER_BAR_COUNT}\nframerate = {VISUALIZER_FRAMERATE}\n\n\
+                 [output]\nmethod = raw\nraw_target = /dev/stdout\ndata_format = ascii\nascii_max_range = 1000\n\n\
+                 [smoothing]\nmonstercat = 1\n"
+            );
+
+            let config_path = std::env::temp_dir().join("ashell_cava.cfg");
+            if let Err(e) = tokio::fs::write(&config_path, &cava_config).await {
+                log::error!("cava: failed to write config: {e}");
+                return;
+            }
+
+            let mut child = match tokio::process::Command::new("cava")
+                .arg("-p")
+                .arg(&config_path)
+                .stdout(std::process::Stdio::piped())
+                .stderr(std::process::Stdio::null())
+                .kill_on_drop(true)
+                .spawn()
+            {
+                Ok(c) => c,
+                Err(e) => {
+                    log::error!("cava: failed to spawn process: {e}");
+                    return;
+                }
+            };
+
+            let stdout = match child.stdout.take() {
+                Some(s) => s,
+                None => {
+                    log::error!("cava: no stdout");
+                    return;
+                }
+            };
+
+            use tokio::io::{AsyncBufReadExt, BufReader};
+            let reader = BufReader::new(stdout);
+            let mut lines = reader.lines();
+
+            while let Ok(Some(line)) = lines.next_line().await {
+                let bars: Vec<f32> = line
+                    .split(';')
+                    .filter(|s| !s.is_empty())
+                    .filter_map(|s| s.trim().parse::<f32>().ok())
+                    .map(|v| v / 1000.0)
+                    .collect();
+
+                if !bars.is_empty() {
+                    let _ = output.send(bars).await;
+                }
+            }
+
+            let _ = child.kill().await;
+        })
+    })
+}
+
+struct VisualizerCanvas {
+    bars: Vec<f32>,
+    low: Color,
+    mid: Color,
+    high: Color,
+}
+
+impl<M> canvas::Program<M> for VisualizerCanvas {
+    type State = ();
+
+    fn draw(
+        &self,
+        _state: &Self::State,
+        renderer: &iced::Renderer,
+        _theme: &iced::Theme,
+        bounds: iced::Rectangle,
+        _cursor: iced::mouse::Cursor,
+    ) -> Vec<Geometry> {
+        let mut frame = Frame::new(renderer, bounds.size());
+
+        if self.bars.is_empty() {
+            return vec![frame.into_geometry()];
+        }
+
+        let n = VISUALIZER_BAR_COUNT.min(self.bars.len());
+        let bar_width = (bounds.width / (n as f32 * 4.0 / 3.0)).max(1.0);
+        let gap = (bar_width / 3.0).max(1.0);
+        let step = bar_width + gap;
+
+        for i in 0..n {
+            let height = self.bars[i] * bounds.height;
+            let x = i as f32 * step;
+            let y = bounds.height - height;
+
+            let rect = Path::rectangle(iced::Point::new(x, y), iced::Size::new(bar_width, height));
+
+            let grad = canvas::gradient::Linear::new(
+                iced::Point::new(x, 0.0),
+                iced::Point::new(x, bounds.height),
+            )
+            .add_stops([
+                ColorStop {
+                    offset: 0.0,
+                    color: self.high,
+                },
+                ColorStop {
+                    offset: 0.5,
+                    color: self.mid,
+                },
+                ColorStop {
+                    offset: 1.0,
+                    color: self.low,
+                },
+            ]);
+            let fill = Fill {
+                style: canvas::Style::Gradient(canvas::Gradient::Linear(grad)),
+                ..Fill::default()
+            };
+
+            frame.fill(&rect, fill);
+        }
+
+        vec![frame.into_geometry()]
+    }
+}
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -27,6 +175,7 @@ pub enum Message {
     SetVolume(String, f64),
     Event(ServiceEvent<MprisPlayerService>),
     ConfigReloaded(MediaPlayerModuleConfig),
+    Bars(Vec<f32>),
 }
 
 pub enum Action {
@@ -37,6 +186,7 @@ pub enum Action {
 pub struct MediaPlayer {
     config: MediaPlayerModuleConfig,
     service: Option<MprisPlayerService>,
+    bars: Vec<f32>,
 }
 
 impl MediaPlayer {
@@ -44,7 +194,15 @@ impl MediaPlayer {
         Self {
             config,
             service: None,
+            bars: Vec::new(),
         }
+    }
+
+    fn is_playing(&self) -> bool {
+        self.service
+            .as_ref()
+            .and_then(|s| s.players().first().map(|p| p.state))
+            == Some(PlaybackStatus::Playing)
     }
 
     pub fn update(&mut self, message: Message) -> Action {
@@ -66,12 +224,19 @@ impl MediaPlayer {
                     if let Some(service) = self.service.as_mut() {
                         service.update(d);
                     }
+                    if !self.is_playing() {
+                        self.bars.clear();
+                    }
                     Action::None
                 }
                 ServiceEvent::Error(_) => Action::None,
             },
             Message::ConfigReloaded(c) => {
                 self.config = c;
+                Action::None
+            }
+            Message::Bars(bars) => {
+                self.bars = bars;
                 Action::None
             }
         }
@@ -233,7 +398,8 @@ impl MediaPlayer {
     }
 
     pub fn view(&'_ self) -> Option<Element<'_, Message>> {
-        let (space, font_size) = use_theme(|theme| (theme.space, theme.font_size));
+        let (space, font_size, palette) =
+            use_theme(|theme| (theme.space, theme.font_size, theme.iced_theme.palette()));
         self.service.as_ref().and_then(|s| {
             s.players().first().map(|player| {
                 let title =
@@ -246,8 +412,27 @@ impl MediaPlayer {
                         .clip(true)
                     });
 
+                let visualizer = (self.config.show_visualizer
+                    && player.state == PlaybackStatus::Playing
+                    && !self.bars.is_empty())
+                .then(|| {
+                    container(
+                        Canvas::new(VisualizerCanvas {
+                            bars: self.bars.clone(),
+                            low: palette.primary,
+                            mid: palette.warning,
+                            high: palette.danger,
+                        })
+                        .width(Length::Fixed((VISUALIZER_BAR_COUNT * 4) as f32))
+                        .height(Length::Fill),
+                    )
+                    .padding([VISUALIZER_PADDING, 0])
+                    .height(Length::Fill)
+                });
+
                 row![icon(StaticIcon::MusicNote)]
                     .push(title)
+                    .push(visualizer)
                     .align_y(Vertical::Center)
                     .spacing(space.xs)
                     .into()
@@ -256,6 +441,15 @@ impl MediaPlayer {
     }
 
     pub fn subscription(&self) -> Subscription<Message> {
-        MprisPlayerService::subscribe().map(Message::Event)
+        let cava = (self.config.show_visualizer && self.is_playing())
+            .then(|| cava_subscription().map(Message::Bars));
+        Subscription::batch(
+            [
+                Some(MprisPlayerService::subscribe().map(Message::Event)),
+                cava,
+            ]
+            .into_iter()
+            .flatten(),
+        )
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -24,26 +24,17 @@ use iced::{
         column, container, image, row, slider, space, text,
     },
 };
+use std::any::TypeId;
 
 const VISUALIZER_BAR_COUNT: usize = 12;
 const VISUALIZER_FRAMERATE: u32 = 60;
 const VISUALIZER_PADDING: u16 = 3;
 
 fn cava_subscription() -> Subscription<Vec<f32>> {
-    Subscription::run(|| {
-        channel(16, async move |mut output| {
-            if tokio::process::Command::new("cava")
-                .arg("--version")
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .status()
-                .await
-                .is_err()
-            {
-                log::warn!("cava: not found, visualizer disabled");
-                return;
-            }
+    struct Cava;
 
+    Subscription::run_with(TypeId::of::<Cava>(), |_| {
+        channel(16, async move |mut output| {
             let cava_config = format!(
                 "[general]\nbars = {VISUALIZER_BAR_COUNT}\nframerate = {VISUALIZER_FRAMERATE}\n\n\
                  [output]\nmethod = raw\nraw_target = /dev/stdout\ndata_format = ascii\nascii_max_range = 1000\n\n\
@@ -60,13 +51,13 @@ fn cava_subscription() -> Subscription<Vec<f32>> {
                 .arg("-p")
                 .arg(&config_path)
                 .stdout(std::process::Stdio::piped())
-                .stderr(std::process::Stdio::null())
+                .stderr(std::process::Stdio::piped())
                 .kill_on_drop(true)
                 .spawn()
             {
                 Ok(c) => c,
                 Err(e) => {
-                    log::error!("cava: failed to spawn process: {e}");
+                    log::warn!("cava: failed to spawn process: {e}");
                     return;
                 }
             };
@@ -78,6 +69,7 @@ fn cava_subscription() -> Subscription<Vec<f32>> {
                     return;
                 }
             };
+            let stderr = child.stderr.take();
 
             use tokio::io::{AsyncBufReadExt, BufReader};
             let reader = BufReader::new(stdout);
@@ -96,7 +88,18 @@ fn cava_subscription() -> Subscription<Vec<f32>> {
                 }
             }
 
-            let _ = child.kill().await;
+            // stdout closed: cava exited on its own. Surface why, so a rejected
+            // config or an incompatible version is not a silent no-op.
+            if let Ok(status) = child.wait().await
+                && !status.success()
+            {
+                let mut err = String::new();
+                if let Some(mut stderr) = stderr {
+                    use tokio::io::AsyncReadExt;
+                    let _ = stderr.read_to_string(&mut err).await;
+                }
+                log::warn!("cava exited ({status}): {}", err.trim());
+            }
         })
     })
 }
@@ -130,35 +133,37 @@ impl<M> canvas::Program<M> for VisualizerCanvas {
         let gap = (bar_width / 3.0).max(1.0);
         let step = bar_width + gap;
 
+        // The gradient is vertical, so its colour depends only on `y`: every bar
+        // shares the same fill. Build it once instead of per bar.
+        let grad = canvas::gradient::Linear::new(
+            iced::Point::new(0.0, 0.0),
+            iced::Point::new(0.0, bounds.height),
+        )
+        .add_stops([
+            ColorStop {
+                offset: 0.0,
+                color: self.high,
+            },
+            ColorStop {
+                offset: 0.5,
+                color: self.mid,
+            },
+            ColorStop {
+                offset: 1.0,
+                color: self.low,
+            },
+        ]);
+        let fill = Fill {
+            style: canvas::Style::Gradient(canvas::Gradient::Linear(grad)),
+            ..Fill::default()
+        };
+
         for i in 0..n {
             let height = self.bars[i] * bounds.height;
             let x = i as f32 * step;
             let y = bounds.height - height;
 
             let rect = Path::rectangle(iced::Point::new(x, y), iced::Size::new(bar_width, height));
-
-            let grad = canvas::gradient::Linear::new(
-                iced::Point::new(x, 0.0),
-                iced::Point::new(x, bounds.height),
-            )
-            .add_stops([
-                ColorStop {
-                    offset: 0.0,
-                    color: self.high,
-                },
-                ColorStop {
-                    offset: 0.5,
-                    color: self.mid,
-                },
-                ColorStop {
-                    offset: 1.0,
-                    color: self.low,
-                },
-            ]);
-            let fill = Fill {
-                style: canvas::Style::Gradient(canvas::Gradient::Linear(grad)),
-                ..Fill::default()
-            };
 
             frame.fill(&rect, fill);
         }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -20,6 +20,7 @@ use iced::{
     gradient::ColorStop,
     stream::channel,
     widget::{
+        Stack,
         canvas::{self, Canvas, Fill, Frame, Geometry, Path},
         column, container, image, row, slider, space, text,
     },
@@ -248,136 +249,172 @@ impl MediaPlayer {
     }
 
     pub fn menu_view<'a>(&'a self) -> Element<'a, Message> {
-        let (space, font_size, opacity, radius) =
-            use_theme(|theme| (theme.space, theme.font_size, theme.opacity, theme.radius));
+        let (space, font_size, opacity, radius, palette) = use_theme(|theme| {
+            (
+                theme.space,
+                theme.font_size,
+                theme.opacity,
+                theme.radius,
+                theme.iced_theme.palette(),
+            )
+        });
+        // When the visualizer is active use it as the menu background and let the
+        // player cards go translucent so the bars show through.
+        let show_background = self.config.show_visualizer && !self.bars.is_empty();
+        let card_alpha = if show_background {
+            opacity * 0.4
+        } else {
+            opacity
+        };
         container(match &self.service {
             None => Into::<Element<'a, Message>>::into(text(t!("media-player-not-connected"))),
-            Some(service) => column!(
-                text(t!("media-player-heading")).size(font_size.lg),
-                divider(),
-                column(service.players().iter().map(|d| {
-                    const LEFT_COLUMN_WIDTH: Length = Length::FillPortion(3);
-                    const RIGHT_COLUMN_WIDTH: Length = Length::FillPortion(2);
-                    let m = d.metadata.as_ref();
-                    let title = m
-                        .and_then(|m| m.title.clone())
-                        .unwrap_or_else(|| t!("media-player-no-title"));
-                    let artists = m
-                        .and_then(|m| m.artists.clone())
-                        .map(|a| a.join(", "))
-                        .unwrap_or_else(|| t!("media-player-unknown-artist"));
-                    let album = m
-                        .and_then(|m| m.album.clone())
-                        .unwrap_or_else(|| t!("media-player-unknown-album"));
-                    let title = text(truncate_text(&title, self.config.max_title_length))
-                        .wrapping(text::Wrapping::WordOrGlyph)
-                        .width(Length::Fill);
-                    let artists = text(truncate_text(&artists, self.config.max_title_length))
-                        .wrapping(text::Wrapping::WordOrGlyph)
-                        .size(font_size.sm)
-                        .width(Length::Fill);
-                    let album = text(truncate_text(&album, self.config.max_title_length))
-                        .wrapping(text::Wrapping::WordOrGlyph)
-                        .size(font_size.sm)
-                        .width(Length::Fill);
-                    let description = column![title, artists, album]
-                        .spacing(space.xxs)
-                        .width(LEFT_COLUMN_WIDTH);
+            Some(service) => {
+                let content = column!(
+                    text(t!("media-player-heading")).size(font_size.lg),
+                    divider(),
+                    column(service.players().iter().map(|d| {
+                        const LEFT_COLUMN_WIDTH: Length = Length::FillPortion(3);
+                        const RIGHT_COLUMN_WIDTH: Length = Length::FillPortion(2);
+                        let m = d.metadata.as_ref();
+                        let title = m
+                            .and_then(|m| m.title.clone())
+                            .unwrap_or_else(|| t!("media-player-no-title"));
+                        let artists = m
+                            .and_then(|m| m.artists.clone())
+                            .map(|a| a.join(", "))
+                            .unwrap_or_else(|| t!("media-player-unknown-artist"));
+                        let album = m
+                            .and_then(|m| m.album.clone())
+                            .unwrap_or_else(|| t!("media-player-unknown-album"));
+                        let title = text(truncate_text(&title, self.config.max_title_length))
+                            .wrapping(text::Wrapping::WordOrGlyph)
+                            .width(Length::Fill);
+                        let artists = text(truncate_text(&artists, self.config.max_title_length))
+                            .wrapping(text::Wrapping::WordOrGlyph)
+                            .size(font_size.sm)
+                            .width(Length::Fill);
+                        let album = text(truncate_text(&album, self.config.max_title_length))
+                            .wrapping(text::Wrapping::WordOrGlyph)
+                            .size(font_size.sm)
+                            .width(Length::Fill);
+                        let description = column![title, artists, album]
+                            .spacing(space.xxs)
+                            .width(LEFT_COLUMN_WIDTH);
 
-                    let play_pause_icon = match d.state {
-                        PlaybackStatus::Playing => StaticIcon::Pause,
-                        PlaybackStatus::Paused | PlaybackStatus::Stopped => StaticIcon::Play,
-                    };
+                        let play_pause_icon = match d.state {
+                            PlaybackStatus::Playing => StaticIcon::Pause,
+                            PlaybackStatus::Paused | PlaybackStatus::Stopped => StaticIcon::Play,
+                        };
 
-                    let buttons = container(
-                        row![
-                            icon_button(StaticIcon::SkipPrevious)
-                                .on_press(Message::Prev(d.service.clone()))
-                                .size(ButtonSize::Large),
-                            icon_button(play_pause_icon)
-                                .on_press(Message::PlayPause(d.service.clone()))
-                                .size(ButtonSize::Large),
-                            icon_button(StaticIcon::SkipNext)
-                                .on_press(Message::Next(d.service.clone()))
-                                .size(ButtonSize::Large),
-                        ]
-                        .align_y(Vertical::Center)
-                        .spacing(space.xs),
-                    )
-                    .center_x(RIGHT_COLUMN_WIDTH);
-                    let volume_slider: Option<Element<'_, _>> = d.volume.map(|v| {
-                        slider(0.0..=100.0, v, move |v| {
-                            Message::SetVolume(d.service.clone(), v)
-                        })
-                        .width(LEFT_COLUMN_WIDTH)
-                        .into()
-                    });
-                    let cover: Option<Element<'_, _>> = d
-                        .metadata
-                        .as_ref()
-                        .and_then(|m| m.art_url.as_ref())
-                        .map(|url| {
-                            let inner: Element<'_, _> = service
-                                .get_cover(url)
-                                .map(|handle| {
-                                    image(handle)
-                                        .filter_method(image::FilterMethod::Linear)
-                                        .into()
-                                })
-                                .unwrap_or_else(|| text(t!("media-player-loading-cover")).into());
-                            container(inner).center_x(RIGHT_COLUMN_WIDTH).into()
-                        });
-                    let metadata = |description, cover| -> Element<'_, _> {
-                        row![description]
-                            .push(cover)
-                            .spacing(space.md)
+                        let buttons = container(
+                            row![
+                                icon_button(StaticIcon::SkipPrevious)
+                                    .on_press(Message::Prev(d.service.clone()))
+                                    .size(ButtonSize::Large),
+                                icon_button(play_pause_icon)
+                                    .on_press(Message::PlayPause(d.service.clone()))
+                                    .size(ButtonSize::Large),
+                                icon_button(StaticIcon::SkipNext)
+                                    .on_press(Message::Next(d.service.clone()))
+                                    .size(ButtonSize::Large),
+                            ]
                             .align_y(Vertical::Center)
+                            .spacing(space.xs),
+                        )
+                        .center_x(RIGHT_COLUMN_WIDTH);
+                        let volume_slider: Option<Element<'_, _>> = d.volume.map(|v| {
+                            slider(0.0..=100.0, v, move |v| {
+                                Message::SetVolume(d.service.clone(), v)
+                            })
+                            .width(LEFT_COLUMN_WIDTH)
                             .into()
-                    };
-                    let content: Element<'_, _> = match (volume_slider, cover) {
-                        (None, None) => row![description, buttons]
-                            .spacing(space.md)
-                            .align_y(Vertical::Center)
-                            .into(),
-                        (Some(v), cover) => {
-                            let controls =
-                                row![v, buttons].spacing(space.md).align_y(Vertical::Center);
-                            column![metadata(description, cover), controls]
+                        });
+                        let cover: Option<Element<'_, _>> = d
+                            .metadata
+                            .as_ref()
+                            .and_then(|m| m.art_url.as_ref())
+                            .map(|url| {
+                                let inner: Element<'_, _> = service
+                                    .get_cover(url)
+                                    .map(|handle| {
+                                        image(handle)
+                                            .filter_method(image::FilterMethod::Linear)
+                                            .into()
+                                    })
+                                    .unwrap_or_else(|| {
+                                        text(t!("media-player-loading-cover")).into()
+                                    });
+                                container(inner).center_x(RIGHT_COLUMN_WIDTH).into()
+                            });
+                        let metadata = |description, cover| -> Element<'_, _> {
+                            row![description]
+                                .push(cover)
                                 .spacing(space.md)
+                                .align_y(Vertical::Center)
                                 .into()
-                        }
-                        (None, cover) => {
-                            let controls =
-                                row![space::horizontal().width(LEFT_COLUMN_WIDTH), buttons]
+                        };
+                        let content: Element<'_, _> = match (volume_slider, cover) {
+                            (None, None) => row![description, buttons]
+                                .spacing(space.md)
+                                .align_y(Vertical::Center)
+                                .into(),
+                            (Some(v), cover) => {
+                                let controls =
+                                    row![v, buttons].spacing(space.md).align_y(Vertical::Center);
+                                column![metadata(description, cover), controls]
                                     .spacing(space.md)
-                                    .align_y(Vertical::Center);
-                            column![metadata(description, cover), controls]
-                                .spacing(space.md)
-                                .into()
-                        }
-                    };
-                    container(content)
-                        .style(move |app_theme: &Theme| container::Style {
-                            background: Background::Color(
-                                app_theme
-                                    .extended_palette()
-                                    .background
-                                    .weak
-                                    .color
-                                    .scale_alpha(opacity),
-                            )
-                            .into(),
-                            border: Border::default().rounded(radius.lg),
-                            ..container::Style::default()
-                        })
-                        .padding(space.md)
-                        .width(Length::Fill)
+                                    .into()
+                            }
+                            (None, cover) => {
+                                let controls =
+                                    row![space::horizontal().width(LEFT_COLUMN_WIDTH), buttons]
+                                        .spacing(space.md)
+                                        .align_y(Vertical::Center);
+                                column![metadata(description, cover), controls]
+                                    .spacing(space.md)
+                                    .into()
+                            }
+                        };
+                        container(content)
+                            .style(move |app_theme: &Theme| container::Style {
+                                background: Background::Color(
+                                    app_theme
+                                        .extended_palette()
+                                        .background
+                                        .weak
+                                        .color
+                                        .scale_alpha(card_alpha),
+                                )
+                                .into(),
+                                border: Border::default().rounded(radius.lg),
+                                ..container::Style::default()
+                            })
+                            .padding(space.md)
+                            .width(Length::Fill)
+                            .into()
+                    }))
+                    .spacing(space.md)
+                )
+                .spacing(space.xs);
+
+                if show_background {
+                    Stack::new()
+                        .push(content)
+                        .push_under(
+                            Canvas::new(VisualizerCanvas {
+                                bars: self.bars.clone(),
+                                low: palette.primary,
+                                mid: palette.warning,
+                                high: palette.danger,
+                            })
+                            .width(Length::Fill)
+                            .height(Length::Fill),
+                        )
                         .into()
-                }))
-                .spacing(space.md)
-            )
-            .spacing(space.xs)
-            .into(),
+                } else {
+                    content.into()
+                }
+            }
         })
         .width(MenuSize::Large)
         .into()

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -183,6 +183,9 @@ impl ReadOnlyService for MprisPlayerService {
 }
 
 const MPRIS_PLAYER_SERVICE_PREFIX: &str = "org.mpris.MediaPlayer2.";
+// playerctld is a proxy that mirrors the currently active player, so it shows
+// up as a duplicate of a real player. Skip it.
+const PLAYERCTLD_SERVICE: &str = "org.mpris.MediaPlayer2.playerctld";
 
 type CoverDownloadFuture = BoxFuture<'static, Result<(String, anyhow::Result<Bytes>), Aborted>>;
 
@@ -207,7 +210,7 @@ impl MprisPlayerService {
             .await?
             .iter()
             .filter_map(|a| {
-                if a.starts_with(MPRIS_PLAYER_SERVICE_PREFIX) {
+                if a.starts_with(MPRIS_PLAYER_SERVICE_PREFIX) && *a != PLAYERCTLD_SERVICE {
                     Some(a.to_string())
                 } else {
                     None

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -21,6 +21,30 @@ the current title. Configure this with the `indicator_format` field:
 
 Use `Icon` if you want a compact indicator or have limited space.
 
+### Visualizer
+
+The module can render an optional audio visualizer powered by
+[CAVA](https://github.com/karlstav/cava). It shows animated bars next to the
+indicator, but only while a player is actively playing. Enable it with the
+`show_visualizer` field (default: `false`):
+
+```toml
+[media_player]
+show_visualizer = true
+```
+
+The bars are coloured with a gradient built from the active theme palette
+(`primary` at the bottom, `warning` in the middle, `danger` at the peak).
+
+CAVA visualizes the system audio output, not the individual stream of the
+active player (MPRIS carries only metadata and playback controls, not audio
+samples). The visualizer is therefore shown only while the active player is
+playing, and `cava` is started on demand and stopped again while playback is
+paused.
+
+> **Requires** `cava` to be installed and available on your `$PATH`. If `cava`
+> is missing the visualizer stays hidden.
+
 ## Menu
 
 The menu shows all active media players with playback controls:
@@ -34,4 +58,5 @@ The menu shows all active media players with playback controls:
 [media_player]
 max_title_length = 50
 indicator_format = "Icon"
+show_visualizer = true
 ```

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -34,7 +34,9 @@ show_visualizer = true
 ```
 
 The bars are coloured with a gradient built from the active theme palette
-(`primary` at the bottom, `warning` in the middle, `danger` at the peak).
+(`primary` at the bottom, `warning` in the middle, `danger` at the peak). While
+playing, the visualizer also fills the background of the media menu, with the
+player cards rendered translucent so the bars show through.
 
 CAVA visualizes the system audio output, not the individual stream of the
 active player (MPRIS carries only metadata and playback controls, not audio

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -34,9 +34,9 @@ show_visualizer = true
 ```
 
 The bars are coloured with a gradient built from the active theme palette
-(`primary` at the bottom, `warning` in the middle, `danger` at the peak). While
-playing, the visualizer also fills the background of the media menu, with the
-player cards rendered translucent so the bars show through.
+(`primary` at the bottom, `warning` in the middle, `danger` at the peak). In the
+media menu, the visualizer also fills the background of the card that is
+currently playing.
 
 CAVA visualizes the system audio output, not the individual stream of the
 active player (MPRIS carries only metadata and playback controls, not audio


### PR DESCRIPTION
Takeover of #542 (original author @ashlcx). 

## What it does

Adds an optional audio visualizer to the media player module, powered by [CAVA](https://github.com/karlstav/cava). It renders animated frequency bars next to the media indicator, visible only while a player is actively playing.

Enable it with a single flag:

```toml
[media_player]
show_visualizer = true
```

If `cava` is not installed / not on `$PATH`, the visualizer stays hidden (a warning is logged once).