### PR TITLE
fix(hyprland) Switch main keyboard only

### DIFF
--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -57,7 +57,7 @@ fn dispatch_hyprlang(cmd: CompositorCommand) -> Result<()> {
         }
         CompositorCommand::NextLayout => {
             hyprland::ctl::switch_xkb_layout::call(
-                "all",
+                "main",
                 hyprland::ctl::switch_xkb_layout::SwitchXKBLayoutCmdTypes::Next,
             )?;
         }
@@ -90,7 +90,7 @@ async fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
         }
         CompositorCommand::NextLayout => {
             hyprland::ctl::switch_xkb_layout::call(
-                "all",
+                "main",
                 hyprland::ctl::switch_xkb_layout::SwitchXKBLayoutCmdTypes::Next,
             )?;
             return Ok(());


### PR DESCRIPTION
When querying the keyboard layout, we only consider the `main` keyboard:
https://github.com/MalpenZibo/ashell/blob/0eb6587827f36a34933889cf3375eaad31759295/src/services/compositor/hyprland.rs#L271-L279
Similarly, when changing the keyboard layout, we should apply the change only to the `main` keyboard.