### PR TITLE
Implement separator normalization

### DIFF
--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -23,6 +23,32 @@ use log::debug;
 
 const MENU_MAX_HEIGHT: f32 = 600.;
 
+fn is_separator(layout: &Layout) -> bool {
+    layout.1.type_.as_deref() == Some("separator")
+}
+
+fn is_visible(layout: &Layout) -> bool {
+    layout.1.visible != Some(false)
+}
+
+fn renderable_children(children: &[Layout]) -> impl Iterator<Item = &Layout> {
+    let end = children
+        .iter()
+        .rposition(|child| is_visible(child) && !is_separator(child))
+        .map_or(0, |last| last + 1);
+
+    children[..end]
+        .iter()
+        .filter(|child| is_visible(child))
+        .scan(true, |prev_sep, child| {
+            let sep = is_separator(child);
+            let keep = !(sep && *prev_sep);
+            *prev_sep = sep;
+            Some(keep.then_some(child))
+        })
+        .flatten()
+}
+
 #[derive(Debug, Clone)]
 pub enum Message {
     Event(Box<ServiceEvent<TrayService>>),
@@ -209,12 +235,8 @@ impl TrayModule {
                     .push(if is_open {
                         Some(
                             Column::with_children(
-                                layout
-                                    .2
-                                    .iter()
-                                    .filter(|menu| menu.1.visible != Some(false))
-                                    .map(|menu| self.menu_voice(name, menu))
-                                    .collect::<Vec<_>>(),
+                                renderable_children(&layout.2)
+                                    .map(|menu| self.menu_voice(name, menu)),
                             )
                             .padding(Padding::default().left(space.md))
                             .spacing(space.xxs),
@@ -302,11 +324,7 @@ impl TrayModule {
             .and_then(|service| service.data.iter().find(|item| item.name == name))
         {
             Some(item) => Column::with_children(
-                item.menu
-                    .2
-                    .iter()
-                    .filter(|menu| menu.1.visible != Some(false))
-                    .map(|menu| self.menu_voice(name, menu)),
+                renderable_children(&item.menu.2).map(|menu| self.menu_voice(name, menu)),
             )
             .spacing(space.xs),
             _ => Column::new(),


### PR DESCRIPTION
Hi,
I've noticed that "Blueman" sends two consecutive separators for some reason, and I think they look ugly:

<img width="456" height="611" alt="image" src="https://github.com/user-attachments/assets/b9940707-b2b4-4876-993c-0db62d70dade" />

Waybar doesn't show them either:

<img width="238" height="284" alt="image" src="https://github.com/user-attachments/assets/3b2859de-e507-4db6-8ad7-022115f127fd" />

I've written a function that normalizes the layout, for now it just collapses consecutive separators.
I also wasn't sure whether I should just create a wrapper function for `get_layout`, if so, let me know and I'll update the PR.

Before:
```
Layout(
        1310720,
        LayoutProps {
            children_display: None,
            label: Some(
                "_Make Discoverable",
            ),
            type_: None,
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
    Layout(
        1376256,
        LayoutProps {
            children_display: None,
            label: None,
            type_: Some(
                "separator",
            ),
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
    Layout(
        2031616,
        LayoutProps {
            children_display: None,
            label: None,
            type_: Some(
                "separator",
            ),
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
    Layout(
        2621440,
        LayoutProps {
            children_display: None,
            label: Some(
                "Send _Files to Device…",
            ),
            type_: None,
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
```

After:
```
Layout(
        1310720,
        LayoutProps {
            children_display: None,
            label: Some(
                "_Make Discoverable",
            ),
            type_: None,
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
    Layout(
        1376256,
        LayoutProps {
            children_display: None,
            label: None,
            type_: Some(
                "separator",
            ),
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
    Layout(
        2621440,
        LayoutProps {
            children_display: None,
            label: Some(
                "Send _Files to Device…",
            ),
            type_: None,
            toggle_type: None,
            toggle_state: None,
            visible: None,
        },
        [],
    ),
```