### PR TITLE
Fix empty tray shown when all icons blocked

### DIFF
--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -269,7 +269,7 @@ impl TrayModule {
 
         self.service
             .as_ref()
-            .filter(|s| !s.data.is_empty())
+            .filter(|s| s.data.iter().any(|item| !self.is_blocklisted(&item.name)))
             .map(|service| {
                 Into::<Element<_>>::into(
                     Row::with_children(


### PR DESCRIPTION
The tray should be hidden when there are no icons to show, but the filter only checked if the `TrayData` was empty rather than if there was at least one not blocked tray item.

### Before
<img width="239" height="42" alt="image" src="https://github.com/user-attachments/assets/95ad9112-73b3-4952-a6a9-bc8b56878b47" />

### After
<img width="239" height="40" alt="image" src="https://github.com/user-attachments/assets/64e83739-6d0b-429c-9689-3bae46253b3d" />

