### PR TITLE
only listen for Escape while it can close a menu

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -715,18 +715,25 @@ impl App {
                 _ => Message::None,
             }),
             iced::output_events().map(Message::OutputEvent),
-            listen_with(move |evt, _, _| match evt {
-                iced::event::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
-                    debug!("Keyboard event received: {key:?}");
-                    if matches!(key, keyboard::Key::Named(keyboard::key::Named::Escape)) {
-                        debug!("ESC key pressed, closing all menus");
-                        Some(Message::CloseAllMenus)
-                    } else {
-                        None
+            // Only listen while Escape can close a menu; an idle listener
+            // subscription still receives every interaction event and would
+            // overflow iced's fixed-size event channel for nothing.
+            if self.general_config.enable_esc_key && self.outputs.menu_is_open() {
+                listen_with(|evt, _, _| match evt {
+                    iced::event::Event::Keyboard(keyboard::Event::KeyPressed { key, .. }) => {
+                        debug!("Keyboard event received: {key:?}");
+                        if matches!(key, keyboard::Key::Named(keyboard::key::Named::Escape)) {
+                            debug!("ESC key pressed, closing all menus");
+                            Some(Message::CloseAllMenus)
+                        } else {
+                            None
+                        }
                     }
-                }
-                _ => None,
-            }),
+                    _ => None,
+                })
+            } else {
+                Subscription::none()
+            },
             Subscription::run(|| match signal_hook_tokio::Signals::new([libc::SIGUSR1]) {
                 Ok(signals) => signals
                     .filter_map(|sig| {


### PR DESCRIPTION
fix 1/X
related to #895

The Escape-key subscription was always active, even though it can only do
something when `enable_esc_key` is set and a menu is open. An idle
`listen_with` subscription is not free: iced copies every interaction event
into a fixed-size channel per subscription and warns when it overflows.
