### PR TITLE
add indicator controls for direct playback on mediaplayer

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -752,6 +752,7 @@ pub struct MediaPlayerModuleConfig {
     pub indicator_visualizer: Option<MediaPlayerVisualizer>,
     pub menu_visualizer: bool,
     pub visualizer_framerate: u32,
+    pub indicator_controls: bool,
 }
 
 impl Default for MediaPlayerModuleConfig {
@@ -763,6 +764,7 @@ impl Default for MediaPlayerModuleConfig {
             indicator_visualizer: None,
             menu_visualizer: false,
             visualizer_framerate: Self::DEFAULT_VISUALIZER_FRAMERATE,
+            indicator_controls: false,
         }
     }
 }

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -149,6 +149,11 @@ pub enum Message {
     PlayPause(String),
     Next(String),
     SetVolume(String, f64),
+    ActivePrev,
+    ActivePlayPause,
+    ActiveNext,
+    ActiveVolumeUp,
+    ActiveVolumeDown,
     Event(ServiceEvent<MprisPlayerService>),
     ConfigReloaded(MediaPlayerModuleConfig),
     Bars(Vec<f32>),
@@ -161,9 +166,10 @@ pub enum Action {
 }
 
 pub struct MediaPlayer {
-    config: MediaPlayerModuleConfig,
+    pub config: MediaPlayerModuleConfig,
     service: Option<MprisPlayerService>,
     bars: Vec<f32>,
+    last_active: Option<String>,
 }
 
 impl MediaPlayer {
@@ -172,21 +178,38 @@ impl MediaPlayer {
             config,
             service: None,
             bars: Vec::new(),
+            last_active: None,
         }
     }
 
     /// The player to represent in the bar: the one currently playing, or the
-    /// first known player when nothing is playing.
+    /// last one that was playing, or the first known player when nothing is
+    /// playing.
     fn active_player(&self) -> Option<&MprisPlayerData> {
         let players = self.service.as_ref()?.players();
         players
             .iter()
             .find(|p| p.state == PlaybackStatus::Playing)
+            .or_else(|| {
+                players
+                    .iter()
+                    .find(|p| Some(p.service.as_str()) == self.last_active.as_deref())
+            })
             .or_else(|| players.first())
     }
 
     fn is_playing(&self) -> bool {
         self.active_player().map(|p| p.state) == Some(PlaybackStatus::Playing)
+    }
+
+    fn refresh_last_active(&mut self) {
+        if let Some(playing) = self.service.as_ref().and_then(|s| {
+            s.players()
+                .iter()
+                .find(|p| p.state == PlaybackStatus::Playing)
+        }) {
+            self.last_active = Some(playing.service.clone());
+        }
     }
 
     /// `menu_visualizer` only draws inside the menu, so it must not keep cava
@@ -205,15 +228,22 @@ impl MediaPlayer {
             Message::SetVolume(s, v) => {
                 Action::Command(self.handle_command(s, PlayerCommand::Volume(v)))
             }
+            Message::ActivePrev => self.active_command(PlayerCommand::Prev),
+            Message::ActivePlayPause => self.active_command(PlayerCommand::PlayPause),
+            Message::ActiveNext => self.active_command(PlayerCommand::Next),
+            Message::ActiveVolumeUp => self.active_volume_command(5.0),
+            Message::ActiveVolumeDown => self.active_volume_command(-5.0),
             Message::Event(event) => match event {
                 ServiceEvent::Init(s) => {
                     self.service = Some(s);
+                    self.refresh_last_active();
                     Action::None
                 }
                 ServiceEvent::Update(d) => {
                     if let Some(service) = self.service.as_mut() {
                         service.update(d);
                     }
+                    self.refresh_last_active();
                     if !self.is_playing() {
                         self.bars.clear();
                     }
@@ -424,6 +454,28 @@ impl MediaPlayer {
                 })
                 .map(Message::Event),
             _ => Task::none(),
+        }
+    }
+
+    fn active_command(&mut self, command: PlayerCommand) -> Action {
+        match self.active_player().map(|p| p.service.clone()) {
+            Some(service) => Action::Command(self.handle_command(service, command)),
+            None => Action::None,
+        }
+    }
+
+    fn active_volume_command(&mut self, delta: f64) -> Action {
+        match self.active_player() {
+            Some(p) => match p.volume {
+                Some(v) => {
+                    let new_volume = (v + delta).clamp(0.0, 100.0);
+                    Action::Command(
+                        self.handle_command(p.service.clone(), PlayerCommand::Volume(new_volume)),
+                    )
+                }
+                None => Action::None,
+            },
+            None => Action::None,
         }
     }
 

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -308,12 +308,30 @@ impl App {
                 .privacy
                 .view()
                 .map(|view| (view.map(Message::Privacy), None)),
-            ModuleName::MediaPlayer => self.media_player.view().map(|view| {
-                (
-                    view.map(Message::MediaPlayer),
-                    Some(OnModulePress::ToggleMenu(MenuType::MediaPlayer)),
-                )
-            }),
+            ModuleName::MediaPlayer => {
+                let on_press = if self.media_player.config.indicator_controls {
+                    OnModulePress::CustomAction {
+                        on_press: Box::new(Message::MediaPlayer(media_player::Message::ActivePrev)),
+                        on_right_press: Some(Box::new(Message::MediaPlayer(
+                            media_player::Message::ActiveNext,
+                        ))),
+                        on_middle_press: Some(Box::new(Message::MediaPlayer(
+                            media_player::Message::ActivePlayPause,
+                        ))),
+                        on_scroll_up: Some(Box::new(Message::MediaPlayer(
+                            media_player::Message::ActiveVolumeUp,
+                        ))),
+                        on_scroll_down: Some(Box::new(Message::MediaPlayer(
+                            media_player::Message::ActiveVolumeDown,
+                        ))),
+                    }
+                } else {
+                    OnModulePress::ToggleMenu(MenuType::MediaPlayer)
+                };
+                self.media_player
+                    .view()
+                    .map(|view| (view.map(Message::MediaPlayer), Some(on_press)))
+            }
             ModuleName::Settings => Some((
                 self.settings.view(id).map(Message::Settings),
                 Some(OnModulePress::ToggleMenu(MenuType::Settings)),

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -110,6 +110,7 @@ alert_threshold = 85
 # indicator_visualizer = "Background" # (default: None = disabled), "Before", or "After"
 # menu_visualizer = false       # (default) bars behind the menu cards; cava runs only while the menu is open
 # visualizer_framerate = 30     # (default) cava frames per second, clamped to 1-144
+# indicator_controls = false    # (default) direct playback controls on the bar indicator
 
 # ── Tray ──────────────────────────────────────────────────────────────────────
 

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -84,6 +84,28 @@ than redrawn, so silence costs nothing.
 > **Requires** `cava` to be installed and available on your `$PATH`. If `cava`
 > is missing the visualizer stays hidden.
 
+### Indicator Controls
+
+By default, clicking the indicator opens the media menu. Set
+`indicator_controls = true` to control playback directly from the bar without
+opening the menu:
+
+| Input       | Action                          |
+| ----------- | ------------------------------- |
+| Left click  | Previous track                  |
+| Middle click | Play/Pause                     |
+| Right click | Next track                      |
+| Scroll up/down | Volume up/down (5% steps)    |
+
+Controls target the currently playing player, or the last player that was
+playing when nothing is playing. While this option is enabled the media menu
+cannot be opened from the bar.
+
+```toml
+[media_player]
+indicator_controls = true
+```
+
 ## Menu
 
 The menu shows all active media players with playback controls:


### PR DESCRIPTION
Adds `indicator_controls` configuration option to enable direct media
playback controls on the bar indicator without opening the media menu.

When enabled, the indicator responds to left/middle/right clicks and
scroll wheel for previous, play/pause, next, and volume (5% steps).

Controls target the currently playing player, **falling back to the last
active player when nothing is playing**. The media menu cannot be opened
from the bar when this option is enabled.


closes https://github.com/MalpenZibo/ashell/issues/884