### PR TITLE
reset network dialog state when menu opens

### DIFF
--- a/src/modules/settings/mod.rs
+++ b/src/modules/settings/mod.rs
@@ -431,6 +431,9 @@ impl Settings {
                 Action::None
             }
             Message::MenuOpened => {
+                self.network_dialog = None;
+                self.network_dialog_show_password = false;
+
                 self.sub_menu = if self.power.config.peripheral_expanded_by_default {
                     Some(SubMenu::PeripheralMenu)
                 } else {


### PR DESCRIPTION
closes the pw input when we click outside or on the bar, so that a subsequent click on the bar opens the settings menu and not the pw input field.

https://github.com/user-attachments/assets/6ed67882-b3fb-4506-b3d3-926ddad50425

