### PR TITLE
chore(docs): unfold configuration sidebar categories by default

### DIFF
--- a/website/docs/configuration/_category_.yml
+++ b/website/docs/configuration/_category_.yml
@@ -1,1 +1,2 @@
 position: 4
+collapsed: false

--- a/website/docs/configuration/appearance/_category_.yml
+++ b/website/docs/configuration/appearance/_category_.yml
@@ -1,1 +1,2 @@
 position: 3
+collapsed: false

--- a/website/docs/configuration/modules/_category_.yml
+++ b/website/docs/configuration/modules/_category_.yml
@@ -1,1 +1,2 @@
 position: 2
+collapsed: false


### PR DESCRIPTION
we don't have so many entries that we need to fold/collapse them 
<img width="592" height="1050" alt="image" src="https://github.com/user-attachments/assets/1b2970be-74f2-464f-a4e0-f11df1608523" />
