### PR TITLE
[Fix] Center OSD icons vertically/horizontally

### DIFF
--- a/src/osd.rs
+++ b/src/osd.rs
@@ -180,7 +180,7 @@ impl Osd {
         };
 
         let content = row![
-            container(icon.to_text().size(font_size.xxl)).center_x(font_size.xxl),
+            container(icon.to_text().size(font_size.xxl).center()).center_x(font_size.xxl),
             detail,
         ]
         .spacing(space.sm)


### PR DESCRIPTION
Fixes #909 

Before
<img width="293" height="116" alt="ashell_before" src="https://github.com/user-attachments/assets/7f2f5669-3f5d-4992-a408-a74776e61020" />

After
<img width="293" height="116" alt="ashell_after" src="https://github.com/user-attachments/assets/d465c221-851d-462d-8cf3-a7e481ec05de" />
