### PR TITLE
feat(custom_module): tooltips

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -304,13 +304,22 @@ impl App {
                     .close_menu(id, None, self.general_config.enable_esc_key)
             }
             Message::FinishCloseMenu(id) => self.outputs.finish_close_menu(id),
-            Message::Custom(name, msg) => {
-                if let Some(custom) = self.custom.get_mut(&name) {
-                    custom.update(msg);
+            Message::Custom(name, msg) => match msg {
+                modules::custom_module::Message::TooltipHover(ui_ref, id) => self
+                    .outputs
+                    .toggle_menu(id, MenuType::CustomTooltip(name), ui_ref, false),
+                modules::custom_module::Message::TooltipUnhover(id) => self.outputs.close_menu(
+                    id,
+                    Some(MenuType::CustomTooltip(name)),
+                    self.general_config.enable_esc_key,
+                ),
+                other => {
+                    if let Some(custom) = self.custom.get_mut(&name) {
+                        custom.update(other);
+                    }
+                    Task::none()
                 }
-
-                Task::none()
-            }
+            },
             Message::Updates(msg) => {
                 if let Some(updates) = self.updates.as_mut() {
                     match updates.update(msg) {
@@ -706,6 +715,18 @@ impl App {
                         self.settings
                             .tooltip_view(&open_menu.menu_type)
                             .map(Message::Settings),
+                        ui_ref,
+                    ),
+                    MenuType::CustomTooltip(name) => self.menu_wrapper(
+                        id,
+                        self.custom
+                            .get(name)
+                            .map(|custom| {
+                                custom
+                                    .tooltip_view()
+                                    .map(|msg| Message::Custom(name.clone(), msg))
+                            })
+                            .unwrap_or_else(|| Row::new().into()),
                         ui_ref,
                     ),
                 }

--- a/src/components/menu.rs
+++ b/src/components/menu.rs
@@ -29,6 +29,7 @@ pub enum MenuType {
     VpnTooltip,
     BatteryTooltip,
     PeripheralBatteryTooltip(usize),
+    CustomTooltip(String),
 }
 
 #[derive(Clone, Debug)]
@@ -203,6 +204,7 @@ impl Menu {
                 | MenuType::VpnTooltip
                 | MenuType::BatteryTooltip
                 | MenuType::PeripheralBatteryTooltip(_)
+                | MenuType::CustomTooltip(_)
         );
         match &mut self.open {
             None => self.open(menu_type, button_ui_ref, request_keyboard, output_id),
@@ -223,6 +225,7 @@ impl Menu {
                         | MenuType::VpnTooltip
                         | MenuType::BatteryTooltip
                         | MenuType::PeripheralBatteryTooltip(_)
+                        | MenuType::CustomTooltip(_)
                 ) && menu_is_tooltip =>
             {
                 Task::none()

--- a/src/config.rs
+++ b/src/config.rs
@@ -1365,7 +1365,7 @@ pub struct CustomModuleDef {
     #[serde(default)]
     pub icon: Option<String>,
 
-    /// yields json lines containing text, alt, (pot tooltip)
+    /// yields json lines containing text, alt, (optionally tooltip)
     #[serde(default, deserialize_with = "empty_string_as_none")]
     pub listen_cmd: Option<String>,
     /// map of regex -> icon

--- a/src/modules/custom_module.rs
+++ b/src/modules/custom_module.rs
@@ -1,14 +1,15 @@
 use crate::{
     components::icons::{DynamicIcon, StaticIcon, icon},
+    components::{ButtonHierarchy, ButtonKind, ButtonUIRef, position_button},
     config::CustomModuleDef,
     theme::use_theme,
     utils::launcher::execute_command,
 };
 use iced::widget::canvas;
 use iced::{
-    Element, Length, Subscription, Theme,
+    Element, Length, Subscription, SurfaceId, Theme,
     stream::channel,
-    widget::{Space, Stack, row, text},
+    widget::{Space, Stack, column, row, text},
 };
 use iced::{
     mouse::Cursor,
@@ -35,6 +36,8 @@ pub struct Custom {
 pub struct CustomListenData {
     pub alt: String,
     pub text: Option<String>,
+    #[serde(default)]
+    pub tooltip: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +48,8 @@ pub enum Message {
     LaunchScrollUpCommand,
     LaunchScrollDownCommand,
     Update(CustomListenData),
+    TooltipHover(ButtonUIRef, SurfaceId),
+    TooltipUnhover(SurfaceId),
 }
 
 // Define a struct for the canvas program
@@ -116,12 +121,13 @@ impl Custom {
             Message::Update(data) => {
                 self.data = data;
             }
+            Message::TooltipHover(..) | Message::TooltipUnhover(..) => {}
         }
     }
 
-    pub fn view(&'_ self) -> Element<'_, Message> {
+    pub fn view(&'_ self, id: SurfaceId) -> Element<'_, Message> {
         let space = use_theme(|theme| theme.space);
-        match self.config.r#type {
+        let content = match self.config.r#type {
             crate::config::CustomModuleType::Text => self
                 .data
                 .text
@@ -194,7 +200,38 @@ impl Custom {
                     icon_with_alert
                 }
             }
+        };
+
+        if let Some(tooltip) = self.data.tooltip.as_deref()
+            && !tooltip.is_empty()
+        {
+            let hover_style = use_theme(|theme| {
+                theme.button_style(ButtonKind::Transparent, ButtonHierarchy::Secondary)
+            });
+            position_button(content)
+                .width(Length::Shrink)
+                .height(Length::Shrink)
+                .padding(0)
+                .style(hover_style)
+                .on_hover_with_position(move |ui_ref| Message::TooltipHover(ui_ref, id))
+                .on_unhover(Message::TooltipUnhover(id))
+                .into()
+        } else {
+            content
         }
+    }
+
+    pub fn tooltip_view(&'_ self) -> Element<'_, Message> {
+        let space = use_theme(|theme| theme.space);
+        let lines: Vec<Element<'_, Message>> = self
+            .data
+            .tooltip
+            .as_deref()
+            .unwrap_or_default()
+            .lines()
+            .map(|line| text(line).into())
+            .collect();
+        column(lines).spacing(space.xs).into()
     }
 
     pub fn subscription(&self) -> Subscription<(String, Message)> {

--- a/src/modules/mod.rs
+++ b/src/modules/mod.rs
@@ -249,7 +249,9 @@ impl App {
                     }
                 };
                 (
-                    custom.view().map(|msg| Message::Custom(name.clone(), msg)),
+                    custom
+                        .view(id)
+                        .map(|msg| Message::Custom(name.clone(), msg)),
                     action,
                 )
             }),


### PR DESCRIPTION
Renders Waybar-style `tooltip` fields in custom module events, with the caveat that `tooltip-format` is ignored:

<img width="865" height="379" alt="image" src="https://github.com/user-attachments/assets/b7f76384-9041-4bf3-9b60-216932467aa2" />

<details><summary>Complete configuration</summary>

```toml
[[CustomModule]]
command = "/nix/store/mgzqjp2k7wfrhf1ygsq4skz8cvz5lay7-tardy-0.1.0/bin/tardy open"
listen_cmd = "/nix/store/mgzqjp2k7wfrhf1ygsq4skz8cvz5lay7-tardy-0.1.0/bin/tardy daemon --format=ashell"
name = "Tardy"
type = "Button"

[appearance]
font_name = "Inter"
opacity = 0.8
primary_color = "#7aa2f7"
success_color = "#9ece6a"
text_color = "#a9b1d6"

[appearance.background_color]
base = "#1a1b26"
strong = "#414868"
weak = "#24273a"

[appearance.danger_color]
base = "#f7768e"
weak = "#e0af68"

[appearance.menu]
opacity = 0.8

[appearance.secondary_color]
base = "#0c0d14"

[[appearance.workspace_colors]]
base = "#ffffff"
strong = "#ffffff"
text = "#24273a"
weak = "#24273a"

[modules]
center = ["Privacy", "SystemInfo", "MediaPlayer"]
left = ["Workspaces"]
right = ["Tempo", "Tardy", ["Settings", "Tray"]]

[system_info]
indicators = ["Cpu", "Memory", "Temperature", "DownloadSpeed", "UploadSpeed"]

[workspaces]
visibility_mode = "MonitorSpecific"
```

</details>

<details><summary>Sample custom module output</summary>

```console
❯ tardy daemon --format ashell
{"text":"11:00 · eMed X AWS | DevOps Agent Demo","alt":"scheduled","class":"scheduled","tooltip":"11:00–12:00 · eMed X AWS | DevOps Agent Demo\n13:00–14:30 · Company & Strategy Update: Building What’s Next\n15:30–16:00 · eMed Engineering and Data + AI 🦾\n15:30–16:00 · eMed Engineering and Data + AI 🦾\n16:00–17:00 · [HOLD] AWS DevOps AI Agent Demo\n17:00–19:00 · Engineering Social\n09:30–10:00 · Crumpet 2nd vaccination\n15:30–16:30 · Engineering Friday Demos\n15:30–16:30 · Engineering Demos"}
```

</details>