### PR TITLE
fix(audio): reconnect to PulseAudio on connection loss instead of hanging

### DIFF
--- a/src/services/audio.rs
+++ b/src/services/audio.rs
@@ -2,7 +2,7 @@ use super::{ReadOnlyService, Service, ServiceEvent};
 use crate::utils::remote_value::Remote;
 use iced::{
     Subscription, Task,
-    futures::{SinkExt, StreamExt, channel::mpsc::Sender, stream::pending},
+    futures::{SinkExt, channel::mpsc::Sender},
     stream::channel,
 };
 use itertools::Either;
@@ -34,8 +34,12 @@ use std::{
     rc::Rc,
     sync::Arc,
     thread::{self, JoinHandle},
+    time::Duration,
 };
-use tokio::sync::mpsc::{UnboundedReceiver, UnboundedSender};
+use tokio::{
+    sync::mpsc::{UnboundedReceiver, UnboundedSender},
+    time::sleep,
+};
 
 #[derive(Debug, Clone)]
 pub struct Device {
@@ -204,13 +208,17 @@ impl AudioService {
 
                     State::Active(handle)
                 }
-                None => State::Active(handle),
+                None => {
+                    error!("PulseAudio connection lost");
+                    State::Error
+                }
             },
             State::Error => {
-                error!("Audio service error");
+                error!("Audio service error, retrying in 5 seconds");
 
-                let _ = pending::<u8>().next().await;
-                State::Error
+                sleep(Duration::from_secs(5)).await;
+
+                State::Init
             }
         }
     }
@@ -465,11 +473,13 @@ impl PulseAudioServer {
                 IterateResult::Quit(_) | IterateResult::Err(_) => {
                     return Err(anyhow::anyhow!("PulseAudio: iterate state was not success"));
                 }
-                IterateResult::Success(_) => {
-                    if context.get_state() == context::State::Ready {
-                        break;
+                IterateResult::Success(_) => match context.get_state() {
+                    context::State::Ready => break,
+                    context::State::Failed | context::State::Terminated => {
+                        return Err(anyhow::anyhow!("PulseAudio: connection failed"));
                     }
-                }
+                    _ => {}
+                },
             }
         }
 
@@ -528,6 +538,7 @@ impl PulseAudioServer {
                         Err(e) => {
                             error!("Failed to get server info: {e}");
                             let _ = from_server_tx.send(PulseAudioServerEvent::Error);
+                            return;
                         }
                     };
 
@@ -543,6 +554,7 @@ impl PulseAudioServer {
                         Err(e) => {
                             error!("Failed to get sink info: {e}");
                             let _ = from_server_tx.send(PulseAudioServerEvent::Error);
+                            return;
                         }
                     };
 
@@ -558,10 +570,12 @@ impl PulseAudioServer {
                         Err(e) => {
                             error!("Failed to get source info: {e}");
                             let _ = from_server_tx.send(PulseAudioServerEvent::Error);
+                            return;
                         }
                     };
 
                     let introspector = server.context.introspect();
+                    let error_tx = from_server_tx.clone();
                     server.context.set_subscribe_callback(Some(Box::new(
                         move |_facility, _operation, _idx| {
                             server.introspector.get_server_info({
@@ -617,6 +631,19 @@ impl PulseAudioServer {
                         let data = server.mainloop.iterate(true);
                         if let IterateResult::Quit(_) | IterateResult::Err(_) = data {
                             error!("PulseAudio mainloop error");
+                            let _ = error_tx.send(PulseAudioServerEvent::Error);
+                            break;
+                        }
+
+                        // A server restart (e.g. `systemctl --user restart pipewire`) drops the
+                        // connection without making `iterate` fail: the context just moves out of
+                        // `Ready`. Every context/introspector call below would then get a null
+                        // operation back from libpulse and panic, so bail out and let the
+                        // subscription reconnect instead.
+                        let context_state = server.context.get_state();
+                        if context_state != context::State::Ready {
+                            error!("PulseAudio context is no longer ready: {context_state:?}");
+                            let _ = error_tx.send(PulseAudioServerEvent::Error);
                             break;
                         }
 
@@ -678,11 +705,16 @@ impl PulseAudioServer {
                     error!("PulseAudio: iterate state was not success");
                     return Err(anyhow::anyhow!("PulseAudio: iterate state was not success"));
                 }
-                IterateResult::Success(_) => {
-                    if operation.get_state() == operation::State::Done {
-                        break;
+                IterateResult::Success(_) => match operation.get_state() {
+                    operation::State::Done => break,
+                    // Losing the connection cancels every pending operation. Without this the
+                    // loop would wait for a `Done` that can never arrive.
+                    operation::State::Cancelled => {
+                        error!("PulseAudio: operation was cancelled");
+                        return Err(anyhow::anyhow!("PulseAudio: operation was cancelled"));
                     }
-                }
+                    operation::State::Running => {}
+                },
             }
         }
 


### PR DESCRIPTION
Fixes #893. 

With `panic = "abort"` set for this build, any Rust panic in the audio thread
kills the whole ashell process. After `systemctl --user restart pipewire wireplumber pipewire-pulse`, 
the PulseAudio `Context` silently drops out of `Ready` without `mainloop.iterate()` itself failing. 
The next introspector call issued against that dead context (e.g. from selecting a different audio
output) makes libpulse return a null operation, which trips
`libpulse-binding`'s `Operation::from_raw` assertion and aborts the process, 
matching the reporter's crash and strace exactly.

**BEFORE**
<img width="1598" height="379" alt="image" src="https://github.com/user-attachments/assets/56ae45ad-2b18-4b66-8bc0-af7d7fbe3cbc" />


**AFTER**
ERROR [ashell::services::audio] PulseAudio context is no longer ready: Failed
ERROR [ashell::services::audio] PulseAudio server error
ERROR [ashell::services::audio] Audio service error, retrying in 5 seconds
