### PR TITLE
prevent duplicate notification toasts from being queued

### DIFF
--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -47,20 +47,20 @@ fn invoke_and_close_task(
     connection: Option<Connection>,
     id: u32,
     action_key: Option<String>,
+    revision: Option<u64>,
 ) -> Task<Message> {
     Task::perform(
         async move {
-            if let Some(connection) = connection {
-                if let Some(action_key) = action_key
-                    && let Err(e) =
-                        NotificationDaemon::invoke_action(&connection, id, action_key).await
-                {
-                    error!("Failed to invoke notification action for id {}: {}", id, e);
-                }
-                if let Err(e) = NotificationDaemon::close_notification_by_id(&connection, id).await
-                {
-                    error!("Failed to close notification id {}: {}", id, e);
-                }
+            if let Some(connection) = connection
+                && let Err(e) = NotificationDaemon::close_notification_by_id(
+                    &connection,
+                    id,
+                    action_key,
+                    revision,
+                )
+                .await
+            {
+                error!("Failed to close notification id {}: {}", id, e);
             }
         },
         |_| Message::NotificationClosed,
@@ -70,18 +70,26 @@ fn invoke_and_close_task(
 async fn close_notification_ids(connection: Option<Connection>, notification_ids: &[u32]) {
     if let Some(connection) = connection {
         for id in notification_ids {
-            if let Err(e) = NotificationDaemon::close_notification_by_id(&connection, *id).await {
+            if let Err(e) =
+                NotificationDaemon::close_notification_by_id(&connection, *id, None, None).await
+            {
                 error!("Failed to close notification id {}: {}", id, e);
             }
         }
     }
 }
 
-fn close_notification_by_id_task(connection: Option<Connection>, id: u32) -> Task<Message> {
+fn close_notification_by_id_task(
+    connection: Option<Connection>,
+    id: u32,
+    revision: Option<u64>,
+) -> Task<Message> {
     Task::perform(
         async move {
             if let Some(connection) = connection
-                && let Err(e) = NotificationDaemon::close_notification_by_id(&connection, id).await
+                && let Err(e) =
+                    NotificationDaemon::close_notification_by_id(&connection, id, None, revision)
+                        .await
             {
                 error!("Failed to close notification id {}: {}", id, e);
             }
@@ -197,6 +205,10 @@ impl Notifications {
         self.notifications.iter().find(|n| n.id == id)
     }
 
+    fn revision_of(&self, id: u32) -> Option<u64> {
+        self.find_notification(id).map(|n| n.revision)
+    }
+
     fn find_first_action_key(&self, id: u32) -> Option<String> {
         self.find_notification(id)
             .filter(|n| !n.actions.is_empty())
@@ -276,9 +288,7 @@ impl Notifications {
                 }
 
                 // A replace cancels an in-flight dismissal so the replacement is
-                // shown instead of being swallowed by the slide-out. A dismissal
-                // already forwarded over D-Bus can still race its own trailing
-                // `Closed` past here and take the replacement down with it.
+                // shown instead of being swallowed by the slide-out.
                 self.dismiss_phases.remove(&notification.id);
 
                 // Critical notifications are persistent per the freedesktop
@@ -368,7 +378,8 @@ impl Notifications {
             Message::NotificationClicked(id) => {
                 let connection = self.connection.clone();
                 let action_key = self.find_first_action_key(id);
-                Action::Task(invoke_and_close_task(connection, id, action_key))
+                let revision = self.revision_of(id);
+                Action::Task(invoke_and_close_task(connection, id, action_key, revision))
             }
             Message::NotificationClosed => Action::None,
             Message::ClearNotifications => {
@@ -441,17 +452,19 @@ impl Notifications {
             }
             Message::CloseNotificationById(id) => {
                 let connection = self.connection.clone();
+                let revision = self.revision_of(id);
                 let had_toasts = self.remove_toast(id);
                 self.dismiss_phases.remove(&id);
 
-                let task = close_notification_by_id_task(connection, id);
+                let task = close_notification_by_id_task(connection, id, revision);
                 self.hide_toasts_if_empty_with_task(had_toasts, task)
             }
             Message::DismissToast(id) => {
                 if self.toasts.contains(&id) && !self.dismiss_phases.contains_key(&id) {
                     let connection = self.connection.clone();
                     let action_key = self.find_first_action_key(id);
-                    let invoke_task = invoke_and_close_task(connection, id, action_key);
+                    let revision = self.revision_of(id);
+                    let invoke_task = invoke_and_close_task(connection, id, action_key, revision);
                     if !self.animations_enabled {
                         let had_toasts = self.remove_toast(id);
                         let hide_action =

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -8,7 +8,7 @@ use crate::{
         ReadOnlyService, ServiceEvent,
         notifications::{
             Notification, NotificationIcon, NotificationsService, Urgency,
-            dbus::{NotificationDaemon, NotificationEvent},
+            dbus::{CloseGuard, NotificationDaemon, NotificationEvent},
         },
     },
     t,
@@ -47,18 +47,13 @@ fn invoke_and_close_task(
     connection: Option<Connection>,
     id: u32,
     action_key: Option<String>,
-    revision: Option<u64>,
+    guard: CloseGuard,
 ) -> Task<Message> {
     Task::perform(
         async move {
             if let Some(connection) = connection
-                && let Err(e) = NotificationDaemon::close_notification_by_id(
-                    &connection,
-                    id,
-                    action_key,
-                    revision,
-                )
-                .await
+                && let Err(e) =
+                    NotificationDaemon::invoke_and_close(&connection, id, action_key, guard).await
             {
                 error!("Failed to close notification id {}: {}", id, e);
             }
@@ -71,31 +66,12 @@ async fn close_notification_ids(connection: Option<Connection>, notification_ids
     if let Some(connection) = connection {
         for id in notification_ids {
             if let Err(e) =
-                NotificationDaemon::close_notification_by_id(&connection, *id, None, None).await
+                NotificationDaemon::invoke_and_close(&connection, *id, None, CloseGuard::Any).await
             {
                 error!("Failed to close notification id {}: {}", id, e);
             }
         }
     }
-}
-
-fn close_notification_by_id_task(
-    connection: Option<Connection>,
-    id: u32,
-    revision: Option<u64>,
-) -> Task<Message> {
-    Task::perform(
-        async move {
-            if let Some(connection) = connection
-                && let Err(e) =
-                    NotificationDaemon::close_notification_by_id(&connection, id, None, revision)
-                        .await
-            {
-                error!("Failed to close notification id {}: {}", id, e);
-            }
-        },
-        |_| Message::NotificationClosed,
-    )
 }
 
 fn delayed_toast_message(delay: Duration, id: u32, msg: fn(u32) -> Message) -> Task<Message> {
@@ -205,8 +181,9 @@ impl Notifications {
         self.notifications.iter().find(|n| n.id == id)
     }
 
-    fn revision_of(&self, id: u32) -> Option<u64> {
-        self.find_notification(id).map(|n| n.revision)
+    fn close_guard(&self, id: u32) -> CloseGuard {
+        self.find_notification(id)
+            .map_or(CloseGuard::Any, |n| CloseGuard::Revision(n.revision))
     }
 
     fn find_first_action_key(&self, id: u32) -> Option<String> {
@@ -235,9 +212,7 @@ impl Notifications {
         let had_toasts = !self.toasts.is_empty();
         let ids: HashSet<u32> = ids.iter().copied().collect();
         self.toasts.retain(|toast_id| !ids.contains(toast_id));
-        for id in &ids {
-            self.toast_timers.remove(id);
-        }
+        self.toast_timers.retain(|id, _| !ids.contains(id));
         had_toasts
     }
 
@@ -278,11 +253,11 @@ impl Notifications {
                 }
 
                 if !self.toasts.contains(&notification.id) {
-                    while self.toasts.len() >= self.config.toast_limit {
-                        if let Some(evicted) = self.toasts.pop_front() {
-                            self.dismiss_phases.remove(&evicted);
-                            self.toast_timers.remove(&evicted);
-                        }
+                    while self.toasts.len() >= self.config.toast_limit
+                        && let Some(evicted) = self.toasts.pop_front()
+                    {
+                        self.dismiss_phases.remove(&evicted);
+                        self.toast_timers.remove(&evicted);
                     }
                     self.toasts.push_back(notification.id);
                 }
@@ -336,9 +311,7 @@ impl Notifications {
                 self.notifications.push_front(*notification);
             }
             NotificationEvent::Closed(id) => {
-                if let Some(pos) = self.notifications.iter().position(|n| n.id == id) {
-                    self.notifications.remove(pos);
-                }
+                self.notifications.retain(|n| n.id != id);
             }
         }
     }
@@ -378,8 +351,8 @@ impl Notifications {
             Message::NotificationClicked(id) => {
                 let connection = self.connection.clone();
                 let action_key = self.find_first_action_key(id);
-                let revision = self.revision_of(id);
-                Action::Task(invoke_and_close_task(connection, id, action_key, revision))
+                let guard = self.close_guard(id);
+                Action::Task(invoke_and_close_task(connection, id, action_key, guard))
             }
             Message::NotificationClosed => Action::None,
             Message::ClearNotifications => {
@@ -452,19 +425,19 @@ impl Notifications {
             }
             Message::CloseNotificationById(id) => {
                 let connection = self.connection.clone();
-                let revision = self.revision_of(id);
+                let guard = self.close_guard(id);
                 let had_toasts = self.remove_toast(id);
                 self.dismiss_phases.remove(&id);
 
-                let task = close_notification_by_id_task(connection, id, revision);
+                let task = invoke_and_close_task(connection, id, None, guard);
                 self.hide_toasts_if_empty_with_task(had_toasts, task)
             }
             Message::DismissToast(id) => {
                 if self.toasts.contains(&id) && !self.dismiss_phases.contains_key(&id) {
                     let connection = self.connection.clone();
                     let action_key = self.find_first_action_key(id);
-                    let revision = self.revision_of(id);
-                    let invoke_task = invoke_and_close_task(connection, id, action_key, revision);
+                    let guard = self.close_guard(id);
+                    let invoke_task = invoke_and_close_task(connection, id, action_key, guard);
                     if !self.animations_enabled {
                         let had_toasts = self.remove_toast(id);
                         let hide_action =

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -261,8 +261,8 @@ impl Notifications {
         match update_event {
             NotificationEvent::Received(notification) => {
                 if self.config.toast_limit == 0 {
-                    self.clear_toasts();
-                    return Action::None;
+                    let had_toasts = self.clear_toasts();
+                    return self.hide_toasts_if_empty(had_toasts);
                 }
 
                 if !self.toasts.contains(&notification.id) {

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -275,12 +275,10 @@ impl Notifications {
                     self.toasts.push_back(notification.id);
                 }
 
-                // A replace cancels an in-flight dismissal: the replacement has
-                // to be shown even if the previous instance was sliding out.
-                // A user dismissal we already forwarded over D-Bus can still
-                // race its own trailing `Closed` event past this point, but a
-                // client replacing an id it was just told was closed is odd
-                // enough to leave alone.
+                // A replace cancels an in-flight dismissal so the replacement is
+                // shown instead of being swallowed by the slide-out. A dismissal
+                // already forwarded over D-Bus can still race its own trailing
+                // `Closed` past here and take the replacement down with it.
                 self.dismiss_phases.remove(&notification.id);
 
                 // Critical notifications are persistent per the freedesktop
@@ -294,12 +292,10 @@ impl Notifications {
                 let task = if let Some(timeout) = timeout {
                     let deadline = Instant::now() + timeout;
                     let previous = self.toast_timers.insert(notification.id, deadline);
-                    // A stored deadline always has a sleep in flight for it:
-                    // every wakeup either expires the toast, removing the
-                    // deadline, or reschedules itself. So a new sleep is only
-                    // needed when there was no deadline (a first notification,
-                    // or a critical one being replaced by a normal one) or when
-                    // the new deadline lands before the pending wakeup.
+                    // Every wakeup either expires the toast, dropping the
+                    // deadline, or reschedules itself, so a stored deadline always
+                    // has a sleep in flight: one is only needed when there was no
+                    // deadline, or when the new one lands before the pending wakeup.
                     if previous.is_none_or(|previous| deadline < previous) {
                         delayed_toast_message(timeout, notification.id, Message::ExpireToast)
                     } else {
@@ -419,8 +415,7 @@ impl Notifications {
                 };
                 let now = Instant::now();
                 if now < deadline {
-                    // Replaced with a later deadline after this sleep started:
-                    // wait out the remainder instead of expiring early.
+                    // Replaced with a later deadline: wait out the remainder.
                     return Action::Task(delayed_toast_message(
                         deadline - now,
                         id,

--- a/src/modules/notifications.rs
+++ b/src/modules/notifications.rs
@@ -23,7 +23,7 @@ use itertools::Itertools;
 use log::error;
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use zbus::Connection;
 
@@ -163,6 +163,7 @@ pub struct Notifications {
     blocklist: Vec<crate::config::RegexCfg>,
     toasts: VecDeque<u32>,
     dismiss_phases: HashMap<u32, DismissPhase>,
+    toast_timers: HashMap<u32, Instant>,
     animations_enabled: bool,
 }
 
@@ -177,6 +178,7 @@ impl Notifications {
             blocklist,
             toasts: VecDeque::new(),
             dismiss_phases: HashMap::new(),
+            toast_timers: HashMap::new(),
             animations_enabled,
         }
     }
@@ -206,12 +208,14 @@ impl Notifications {
         let had_toasts = !self.toasts.is_empty();
         self.toasts.clear();
         self.dismiss_phases.clear();
+        self.toast_timers.clear();
         had_toasts
     }
 
     fn remove_toast(&mut self, id: u32) -> bool {
         let had_toasts = !self.toasts.is_empty();
         self.toasts.retain(|&toast_id| toast_id != id);
+        self.toast_timers.remove(&id);
         had_toasts
     }
 
@@ -219,6 +223,9 @@ impl Notifications {
         let had_toasts = !self.toasts.is_empty();
         let ids: HashSet<u32> = ids.iter().copied().collect();
         self.toasts.retain(|toast_id| !ids.contains(toast_id));
+        for id in &ids {
+            self.toast_timers.remove(id);
+        }
         had_toasts
     }
 
@@ -254,19 +261,28 @@ impl Notifications {
         match update_event {
             NotificationEvent::Received(notification) => {
                 if self.config.toast_limit == 0 {
-                    self.toasts.clear();
-                    self.dismiss_phases.clear();
+                    self.clear_toasts();
                     return Action::None;
                 }
 
-                while self.toasts.len() >= self.config.toast_limit {
-                    if let Some(evicted) = self.toasts.pop_front() {
-                        self.dismiss_phases.remove(&evicted);
+                if !self.toasts.contains(&notification.id) {
+                    while self.toasts.len() >= self.config.toast_limit {
+                        if let Some(evicted) = self.toasts.pop_front() {
+                            self.dismiss_phases.remove(&evicted);
+                            self.toast_timers.remove(&evicted);
+                        }
                     }
+                    self.toasts.push_back(notification.id);
                 }
-                self.toasts.push_back(notification.id);
 
-                let notification_id = notification.id;
+                // A replace cancels an in-flight dismissal: the replacement has
+                // to be shown even if the previous instance was sliding out.
+                // A user dismissal we already forwarded over D-Bus can still
+                // race its own trailing `Closed` event past this point, but a
+                // client replacing an id it was just told was closed is odd
+                // enough to leave alone.
+                self.dismiss_phases.remove(&notification.id);
+
                 // Critical notifications are persistent per the freedesktop
                 // spec: they must be acknowledged by the user.
                 let timeout = if notification.urgency == Urgency::Critical {
@@ -275,19 +291,26 @@ impl Notifications {
                     toast_timeout(notification.expire_timeout, self.config.toast_timeout)
                 };
 
-                let timer_task = if let Some(timeout) = timeout {
-                    Task::perform(
-                        async move {
-                            tokio::time::sleep(timeout).await;
-                            notification_id
-                        },
-                        Message::ExpireToast,
-                    )
+                let task = if let Some(timeout) = timeout {
+                    let deadline = Instant::now() + timeout;
+                    let previous = self.toast_timers.insert(notification.id, deadline);
+                    // A stored deadline always has a sleep in flight for it:
+                    // every wakeup either expires the toast, removing the
+                    // deadline, or reschedules itself. So a new sleep is only
+                    // needed when there was no deadline (a first notification,
+                    // or a critical one being replaced by a normal one) or when
+                    // the new deadline lands before the pending wakeup.
+                    if previous.is_none_or(|previous| deadline < previous) {
+                        delayed_toast_message(timeout, notification.id, Message::ExpireToast)
+                    } else {
+                        Task::none()
+                    }
                 } else {
+                    self.toast_timers.remove(&notification.id);
                     Task::none()
                 };
 
-                Action::Show(timer_task)
+                Action::Show(task)
             }
             NotificationEvent::Closed(id) => {
                 let id = *id;
@@ -303,6 +326,7 @@ impl Notifications {
     fn apply_update_event(&mut self, update_event: NotificationEvent) {
         match update_event {
             NotificationEvent::Received(notification) => {
+                self.notifications.retain(|n| n.id != notification.id);
                 self.notifications.push_front(*notification);
             }
             NotificationEvent::Closed(id) => {
@@ -320,7 +344,7 @@ impl Notifications {
                 self.blocklist = config.blocklist.clone();
                 self.config = config;
                 if hide {
-                    self.toasts.clear();
+                    self.clear_toasts();
                     Action::Hide(Task::none())
                 } else {
                     Action::None
@@ -390,6 +414,21 @@ impl Notifications {
                 Action::None
             }
             Message::ExpireToast(id) => {
+                let Some(&deadline) = self.toast_timers.get(&id) else {
+                    return Action::None;
+                };
+                let now = Instant::now();
+                if now < deadline {
+                    // Replaced with a later deadline after this sleep started:
+                    // wait out the remainder instead of expiring early.
+                    return Action::Task(delayed_toast_message(
+                        deadline - now,
+                        id,
+                        Message::ExpireToast,
+                    ));
+                }
+                self.toast_timers.remove(&id);
+
                 if self.toasts.contains(&id) && !self.dismiss_phases.contains_key(&id) {
                     if !self.animations_enabled {
                         let had_toasts = self.remove_toast(id);
@@ -446,7 +485,10 @@ impl Notifications {
                 }
             }
             Message::DismissAnimationComplete(id) => {
-                self.dismiss_phases.remove(&id);
+                if self.dismiss_phases.remove(&id).is_none() {
+                    // Cancelled by a replace: the toast is on screen again.
+                    return Action::None;
+                }
                 let had_toasts = self.remove_toast(id);
                 self.hide_toasts_if_empty(had_toasts)
             }

--- a/src/services/compositor/generic.rs
+++ b/src/services/compositor/generic.rs
@@ -594,7 +594,7 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for GenericState {
                         .as_chunks::<4>()
                         .0
                         .iter()
-                        .any(|c| u32::from_ne_bytes(*c) == activated);
+                        .any(|&c| u32::from_ne_bytes(c) == activated);
                 }
             }
             zwlr_foreign_toplevel_handle_v1::Event::Done => state.dirty = true,

--- a/src/services/compositor/generic.rs
+++ b/src/services/compositor/generic.rs
@@ -591,9 +591,10 @@ impl Dispatch<ZwlrForeignToplevelHandleV1, ()> for GenericState {
                     // (one per active state, not a bitmask), so we parse 4 bytes at a time.
                     let activated = zwlr_foreign_toplevel_handle_v1::State::Activated as u32;
                     t.activated = tl_state
-                        .chunks_exact(4)
-                        .filter_map(|c| c.try_into().ok())
-                        .any(|c| u32::from_ne_bytes(c) == activated);
+                        .as_chunks::<4>()
+                        .0
+                        .iter()
+                        .any(|c| u32::from_ne_bytes(*c) == activated);
                 }
             }
             zwlr_foreign_toplevel_handle_v1::Event::Done => state.dirty = true,

--- a/src/services/notifications/dbus.rs
+++ b/src/services/notifications/dbus.rs
@@ -17,6 +17,15 @@ pub enum NotificationEvent {
     Closed(u32),
 }
 
+/// Which instance of an id a close applies to.
+#[derive(Debug, Clone, Copy)]
+pub enum CloseGuard {
+    /// Whatever holds the id now.
+    Any,
+    /// Only while the id still carries this revision.
+    Revision(u64),
+}
+
 const NAME: WellKnownName =
     WellKnownName::from_static_str_unchecked("org.freedesktop.Notifications");
 pub const OBJECT_PATH: &str = "/org/freedesktop/Notifications";
@@ -201,18 +210,16 @@ impl NotificationDaemon {
         Ok((connection, event_tx))
     }
 
-    /// Invokes `action_key`, if any, and closes `id`.
-    ///
-    /// `revision` pins the instance the caller acted on. Both steps are skipped
+    /// `guard` pins the instance the caller acted on: both steps are skipped
     /// when `id` no longer carries it, because a `Notify` won the race against
-    /// this call and the notification the user acted on is gone: closing anyway
-    /// would take the replacement down with it. Taking the interface lock once
-    /// for the check and both steps is what keeps that ordering decidable.
-    pub async fn close_notification_by_id(
+    /// this call and the notification the user acted on is gone. Closing anyway
+    /// would take the replacement down with it. Holding the interface lock over
+    /// the check and both steps is what keeps that ordering decidable.
+    pub async fn invoke_and_close(
         connection: &Connection,
         id: u32,
         action_key: Option<String>,
-        revision: Option<u64>,
+        guard: CloseGuard,
     ) -> anyhow::Result<()> {
         let iface_ref = connection
             .object_server()
@@ -220,7 +227,9 @@ impl NotificationDaemon {
             .await?;
         let mut daemon = iface_ref.get_mut().await;
 
-        if revision.is_some_and(|revision| daemon.revisions.get(&id) != Some(&revision)) {
+        if let CloseGuard::Revision(revision) = guard
+            && daemon.revisions.get(&id) != Some(&revision)
+        {
             debug!("Skipping close of notification {}: replaced since", id);
             return Ok(());
         }

--- a/src/services/notifications/dbus.rs
+++ b/src/services/notifications/dbus.rs
@@ -48,6 +48,9 @@ impl Urgency {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Notification {
     pub id: u32,
+    /// Bumped on every `Notify`, so a consumer can tell one instance of an id
+    /// from the next one a `replaces_id` put in its place.
+    pub revision: u64,
     pub app_name: String,
     pub app_icon: String,
     pub summary: String,
@@ -63,6 +66,8 @@ pub struct Notification {
 
 pub struct NotificationDaemon {
     next_id: u32,
+    next_revision: u64,
+    revisions: HashMap<u32, u64>,
     event_tx: broadcast::Sender<NotificationEvent>,
     connection: Connection,
 }
@@ -71,6 +76,8 @@ impl NotificationDaemon {
     pub fn new(event_tx: broadcast::Sender<NotificationEvent>, connection: Connection) -> Self {
         Self {
             next_id: 0,
+            next_revision: 0,
+            revisions: HashMap::new(),
             event_tx,
             connection,
         }
@@ -107,10 +114,15 @@ impl NotificationDaemon {
             replaces_id
         };
 
+        self.next_revision += 1;
+        let revision = self.next_revision;
+        self.revisions.insert(id, revision);
+
         let icon = NotificationIcon::resolve(&app_name, &app_icon, &hints);
         let urgency = Urgency::from_hints(&hints);
         let notification = Notification {
             id,
+            revision,
             app_name,
             app_icon,
             summary,
@@ -134,6 +146,8 @@ impl NotificationDaemon {
     }
 
     async fn close_notification(&mut self, id: u32) {
+        self.revisions.remove(&id);
+
         // Send event through channel
         let _ = self.event_tx.send(NotificationEvent::Closed(id));
 
@@ -187,32 +201,43 @@ impl NotificationDaemon {
         Ok((connection, event_tx))
     }
 
-    pub async fn invoke_action(
+    /// Invokes `action_key`, if any, and closes `id`.
+    ///
+    /// `revision` pins the instance the caller acted on. Both steps are skipped
+    /// when `id` no longer carries it, because a `Notify` won the race against
+    /// this call and the notification the user acted on is gone: closing anyway
+    /// would take the replacement down with it. Taking the interface lock once
+    /// for the check and both steps is what keeps that ordering decidable.
+    pub async fn close_notification_by_id(
         connection: &Connection,
         id: u32,
-        action_key: String,
+        action_key: Option<String>,
+        revision: Option<u64>,
     ) -> anyhow::Result<()> {
-        connection
-            .emit_signal(
-                None::<&str>,
-                OBJECT_PATH,
-                NAME.as_str(),
-                "ActionInvoked",
-                &(id, action_key),
-            )
-            .await?;
-        Ok(())
-    }
-
-    pub async fn close_notification_by_id(connection: &Connection, id: u32) -> anyhow::Result<()> {
-        // Get the object server interface to call the method properly
         let iface_ref = connection
             .object_server()
             .interface::<_, NotificationDaemon>(OBJECT_PATH)
             .await?;
+        let mut daemon = iface_ref.get_mut().await;
 
-        // Call the close_notification method which properly cleans up and emits events
-        iface_ref.get_mut().await.close_notification(id).await;
+        if revision.is_some_and(|revision| daemon.revisions.get(&id) != Some(&revision)) {
+            debug!("Skipping close of notification {}: replaced since", id);
+            return Ok(());
+        }
+
+        if let Some(action_key) = action_key {
+            connection
+                .emit_signal(
+                    None::<&str>,
+                    OBJECT_PATH,
+                    NAME.as_str(),
+                    "ActionInvoked",
+                    &(id, action_key),
+                )
+                .await?;
+        }
+
+        daemon.close_notification(id).await;
         Ok(())
     }
 }

--- a/src/services/tray/mod.rs
+++ b/src/services/tray/mod.rs
@@ -60,7 +60,7 @@ fn pixmap_to_icon(icons: Vec<dbus::Icon>) -> Option<TrayIcon> {
         })
         .map(|mut i| {
             // Convert ARGB to RGBA
-            for pixel in i.bytes.chunks_exact_mut(4) {
+            for pixel in i.bytes.as_chunks_mut::<4>().0 {
                 pixel.rotate_left(1);
             }
             TrayIcon::Image(image::Handle::from_rgba(


### PR DESCRIPTION
Ran into two related bugs while poking at the toast notification flow. Both stem from the
freedesktop `replaces_id` mechanism: a client can send a new `Notify` call with
`replaces_id` pointing at a notification that is still on screen, and the daemon just echoes that id back.

### Bug 1: duplicate entries on replace

Nothing checked whether an incoming notification's id was already visible. A replace for
an id that is still showing got pushed onto both `self.toasts` (the toast queue) and
`self.notifications` (the full list) a second time, instead of updating the existing
entry, so the same notification was drawn twice.

Fixed by skipping the eviction/push step in `toast_action_for_update_event` when the id is
already in `toasts`, and by `retain`ing away any existing entry for that id in
`apply_update_event` before pushing the new one.

### Bug 2: the expiry timer survives the notification it belongs to

Toast expiry was a fire and forget `Task::perform(sleep(timeout))` resolving to
`ExpireToast(id)`. Nothing cancelled it, and the handler only checked "is this id still
visible and not already dismissing", so it had no idea the notification instance had
changed underneath it. Two user visible symptoms:

* A notification that arrives as normal priority (say a 5s timeout) and is then replaced
  by a `Critical` version gets auto dismissed about 5s later by the first instance's
  timer. Critical notifications are meant to be persistent: the spec says they need
  explicit user acknowledgement and no auto timeout.
* No critical urgency needed either: a normal notification replaced with a *longer*
  timeout still dies at the old, shorter deadline. A 1.5s notification replaced by a 4s
  one disappears after about 1s.

### How expiry works now

Each toast's absolute deadline lives in `toast_timers: HashMap<u32, Instant>`, and expiry
is still a `tokio::time::sleep`, but the wakeup is now checked against the stored
deadline instead of being trusted:

* No deadline for that id, so the toast is persistent or already gone: ignore the wakeup.
* Deadline not reached yet, so the toast was replaced with a later one: reschedule for
  the remaining time.
* Otherwise: drop the deadline and dismiss.

A replace therefore just overwrites or removes an entry in the map. Replacing with a
critical notification does `toast_timers.remove(&id)` and there is nothing left that can
dismiss it. A sleep is spawned when the id had no deadline (a first notification, or a
critical one being replaced by a normal one, which needs a fresh timer since no wakeup is
pending) or when the new deadline lands before the pending wakeup. Later or equal
deadlines ride the in flight wakeup's reschedule, so a client that replaces the same id
in a loop (progress notifications, the canonical `replaces_id` user) does not pile up
timers.

A replace also cancels an in flight dismissal now, so a replacement arriving while the
previous instance is sliding out is shown instead of being swallowed by the animation.
`DismissAnimationComplete` bails out when its phase entry is already gone.

Behaviour was checked against `main` and against the first version of this PR on a live
Hyprland session, driving the D-Bus interface directly and measuring the rendered toast
stack. Details in the comment below.
