### PR TITLE
warn on unknown configuration fields during deserialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -165,6 +165,7 @@ dependencies = [
  "reqwest",
  "rust-embed",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_with",
  "shellexpand",
@@ -3997,6 +3998,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ hex_color = { version = "3", features = ["serde"] }
 anyhow = "1"
 udev = { version = "0.9", features = ["send", "sync"] }
 toml = "1"
+serde_ignored = "0.1"
 freedesktop-icons = "0.4"
 linicon-theme = "1.2.0"
 serde_json = "1"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1438,10 +1438,20 @@ fn read_config(path: &Path) -> Result<Config, Box<dyn Error + Send>> {
 
     info!("Decoding config file {path:?}");
 
-    let res = toml::from_str::<Config>(&content);
+    let de =
+        toml::Deserializer::parse(&content).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;
+    let mut unknown_fields = Vec::new();
+    let res = serde_ignored::deserialize(de, |path| {
+        unknown_fields.push(path.to_string());
+    });
 
     match res {
         Ok(config) => {
+            for field in &unknown_fields {
+                let msg = format!("Unknown configuration field ignored: {field}");
+                warn!("{msg}");
+                eprintln!("ashell: warning: {msg}");
+            }
             info!("Config file loaded successfully");
             let mut config: Config = config;
             config.validate();


### PR DESCRIPTION

Adds `serde_ignored` to `read_config` so unknown TOML keys produce a warning on both the log target and stderr. No hard failure,  the config still loads, you just get told about fields that don't match anything.

Catches typos (`max_title_lenght`), keys in wrong sections, and stale fields from older configs. Hot-reload warns too since inotify already calls `read_config`.

```
WARN [ashell::config] Unknown configuration field ignored: media_player.max_title_length
ashell: warning: Unknown configuration field ignored: media_player.max_title_length
```

<img width="761" height="467" alt="Image" src="https://github.com/user-attachments/assets/7c274aca-8321-42f6-8cbc-86ae70628289" />

<img width="644" height="510" alt="Image" src="https://github.com/user-attachments/assets/11f13522-6c43-4a07-9cc2-59095aebf8bd" />

<img width="773" height="249" alt="image" src="https://github.com/user-attachments/assets/0da680cf-ad6a-4847-a242-ec807c31cb90" />
<img width="820" height="336" alt="image" src="https://github.com/user-attachments/assets/ab022f46-bebb-4288-b784-b2325e031405" />


Closes #887