### PR TITLE
add [logging] section with level, target and directory in config

### DIFF
--- a/docs/src/contributing/common-tasks.md
+++ b/docs/src/contributing/common-tasks.md
@@ -115,7 +115,8 @@ To see debug output for a specific module:
 
 ```toml
 # In config.toml
-log_level = "warn,ashell::modules::my_module=debug"
+[logging]
+level = "warn,ashell::modules::my_module=debug"
 ```
 
 ## Testing Config Hot-Reload
@@ -123,4 +124,4 @@ log_level = "warn,ashell::modules::my_module=debug"
 1. Start ashell: `make start`
 2. Edit `~/.config/ashell/config.toml` in another terminal
 3. Save — changes should appear immediately
-4. Check logs if changes don't apply: `tail -f $XDG_RUNTIME_DIR/ashell/*.log`
+4. Check logs if changes don't apply: `tail -f $XDG_RUNTIME_DIR/ashell_rCURRENT.log`

--- a/docs/src/contributing/testing-and-debugging.md
+++ b/docs/src/contributing/testing-and-debugging.md
@@ -6,10 +6,11 @@ ashell does not currently have an automated test suite. Testing is done manually
 
 ## Debugging with Logs
 
-ashell writes logs to `$XDG_RUNTIME_DIR/ashell/`. To watch logs in real time:
+ashell writes logs into `$XDG_RUNTIME_DIR` (falling back to `/tmp/ashell/`).
+To watch logs in real time:
 
 ```bash
-tail -f $XDG_RUNTIME_DIR/ashell/*.log
+tail -f $XDG_RUNTIME_DIR/ashell_rCURRENT.log
 ```
 
 ### Adjusting Log Level
@@ -17,7 +18,8 @@ tail -f $XDG_RUNTIME_DIR/ashell/*.log
 In the config file:
 
 ```toml
-log_level = "debug"
+[logging]
+level = "debug"
 ```
 
 Common levels: `error`, `warn`, `info`, `debug`, `trace`.
@@ -25,12 +27,27 @@ Common levels: `error`, `warn`, `info`, `debug`, `trace`.
 You can also set per-module levels:
 
 ```toml
-log_level = "warn,ashell::services::audio=debug"
+[logging]
+level = "warn,ashell::services::audio=debug"
 ```
+
+### Logging to the Terminal
+
+To skip the log file entirely and see the output in the terminal that started
+ashell:
+
+```toml
+[logging]
+target = "stdout"   # or "stderr"
+```
+
+`target` and `directory` are read once at startup, so changing them needs a
+restart.
 
 ### Debug Build Logging
 
-In debug builds (`cargo build` without `--release`), all logs are also printed to stdout.
+In debug builds (`cargo build` without `--release`), all logs are also printed
+to stdout when `target = "file"`.
 
 ## Common Debugging Scenarios
 

--- a/docs/src/core/app-struct.md
+++ b/docs/src/core/app-struct.md
@@ -80,7 +80,7 @@ fn refesh_config(&mut self, config: Box<Config>) {
     self.theme = AshellTheme::new(config.position, &config.appearance);
 
     // Update logger level
-    self.logger.set_new_spec(get_log_spec(&config.log_level));
+    self.logger.set_new_spec(get_log_spec(&config.logging.level));
 
     // Sync outputs (may create/destroy surfaces)
     let task = self.outputs.sync(/* ... */);
@@ -93,3 +93,6 @@ fn refesh_config(&mut self, config: Box<Config>) {
 ```
 
 This enables live editing of the config file without restarting ashell.
+Note that only `logging.level` is re-applied on reload: `logging.target` and
+`logging.directory` are read once at startup by `config::read_logging_config()`
+and need a restart.

--- a/docs/src/core/config-system.md
+++ b/docs/src/core/config-system.md
@@ -16,7 +16,7 @@ ashell --config-path /path/to/config.toml
 
 ```rust
 pub struct Config {
-    pub log_level: String,                          // Default: "warn"
+    pub logging: LoggingConfig,                     // Level, target and directory
     pub position: Position,                         // Top or Bottom
     pub layer: Layer,                               // Top, Bottom, or Overlay
     pub outputs: Outputs,                           // All, Active, or Targets
@@ -38,6 +38,26 @@ pub struct Config {
 ```
 
 Every field has a serde `#[serde(default)]` attribute, so **an empty config file is valid** — the bar works with zero configuration.
+
+## Logging Bootstrap
+
+The logger must exist before `get_config()` runs, but its destination lives in
+the config file. `config::read_logging_config()` solves this by parsing **only**
+the `[logging]` table into a throwaway wrapper struct, before the logger is
+initialized:
+
+```rust
+pub fn read_logging_config(path: Option<&PathBuf>) -> LoggingConfig
+```
+
+Because it runs before the logger exists it must not use `log::*`; problems are
+reported on `stderr` and it falls back to `LoggingConfig::default()`. Unknown
+top-level keys are skipped without being deserialized, so a broken `[modules]`
+section does not prevent the `[logging]` table from being read. Typos are still
+reported a moment later by the full `Config` parse.
+
+Only `logging.level` is re-applied on hot-reload; `logging.target` and
+`logging.directory` are fixed at startup.
 
 ## Module Layout
 

--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -62,17 +62,18 @@ The default config path is `~/.config/ashell/config.toml`.
 
 ## Logging
 
-ashell uses [flexi_logger](https://docs.rs/flexi_logger) and writes logs to `$XDG_RUNTIME_DIR/ashell/`.
+ashell uses [flexi_logger](https://docs.rs/flexi_logger) and writes logs into `$XDG_RUNTIME_DIR` (falling back to `/tmp/ashell/`).
 
 - Log files rotate daily and are kept for 7 days.
-- In debug builds, logs are also printed to stdout.
-- The log level is controlled by the `log_level` field in the config file (default: `"warn"`).
+- In debug builds, logs are also printed to stdout when `logging.target = "file"`.
+- The log level is controlled by the `logging.level` field in the config file (default: `"warn"`).
+- `logging.target` selects the destination: `"file"` (default), `"stdout"` or `"stderr"`; `logging.directory` overrides the log directory when the target is `"file"`.
 - The log level follows the [env_logger syntax](https://docs.rs/env_logger/latest/env_logger/#enabling-logging), e.g., `"debug"`, `"info"`, `"ashell=debug,iced=warn"`.
 
 To watch logs in real time:
 
 ```bash
-tail -f $XDG_RUNTIME_DIR/ashell/*.log
+tail -f $XDG_RUNTIME_DIR/ashell_rCURRENT.log
 ```
 
 ## IPC Socket

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -6,7 +6,6 @@ Complete reference for all configuration options in `~/.config/ashell/config.tom
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `log_level` | String | `"warn"` | Log level ([env_logger syntax](https://docs.rs/env_logger)) |
 | `language` | Option\<String\> | auto | UI language (BCP-47 or POSIX, e.g. `"en-US"`). Auto-detected from `$LC_MESSAGES` / `$LANG` when unset |
 | `region` | Option\<String\> | auto | Regional formatting — dates and unit defaults (e.g. `"it-IT"`). Auto-detected from `$LC_TIME` / `$LANG` when unset |
 | `position` | `"Top"` \| `"Bottom"` | `"Bottom"` | Bar position on screen |
@@ -16,6 +15,9 @@ Complete reference for all configuration options in `~/.config/ashell/config.tom
 | `osd.enabled` | bool | `false` | Show OSD overlay for IPC volume/brightness/airplane commands |
 | `osd.timeout` | u64 | `1500` | OSD auto-hide delay in milliseconds |
 | `animations.enabled` | bool | `false` | Master toggle for UI animations (bar widths, menu open/close, toast slides, etc.) |
+| `logging.level` | String | `"warn"` | Log level ([env_logger syntax](https://docs.rs/env_logger)) |
+| `logging.target` | `"file"` \| `"stdout"` \| `"stderr"` | `"file"` | Where logs are written |
+| `logging.directory` | Option\<PathBuf\> | `$XDG_RUNTIME_DIR` | Log directory, only used when `logging.target = "file"`. Supports `~` and `$VAR` |
 
 ## Module Layout
 

--- a/docs/src/reference/environment-variables.md
+++ b/docs/src/reference/environment-variables.md
@@ -25,14 +25,17 @@ The config path can also be overridden with the `--config-path` CLI flag, which 
 
 ## Logging
 
-ashell uses [flexi_logger](https://docs.rs/flexi_logger) which reads the log level from the config file's `log_level` field. The format follows [env_logger syntax](https://docs.rs/env_logger/latest/env_logger/#enabling-logging):
+ashell uses [flexi_logger](https://docs.rs/flexi_logger) which reads the log level from the config file's `logging.level` field. The format follows [env_logger syntax](https://docs.rs/env_logger/latest/env_logger/#enabling-logging):
 
 ```toml
 # In config.toml
-log_level = "debug"
-log_level = "warn,ashell::services=debug"
-log_level = "info,ashell::modules::settings=trace"
+[logging]
+level = "debug"
+# level = "warn,ashell::services=debug"
+# level = "info,ashell::modules::settings=trace"
 ```
+
+`logging.target` selects the destination (`"file"`, the default, or `"stdout"` / `"stderr"`) and `logging.directory` overrides the log directory used by the `"file"` target.
 
 ## Wayland
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -255,7 +255,8 @@ impl App {
                     ));
                 }
 
-                self.logger.set_new_spec(get_log_spec(&config.log_level));
+                self.logger
+                    .set_new_spec(get_log_spec(&config.logging.level));
                 tasks.push(self.refresh_config(config));
 
                 Task::batch(tasks)

--- a/src/config.rs
+++ b/src/config.rs
@@ -1391,11 +1391,11 @@ impl Default for OsdConfig {
 
 /// Bootstrap-parse only the `[logging]` section from the config file.
 ///
-/// This runs **before** the logger is initialized, so it must not use `log::*`.
-/// On any error (missing file, parse failure, expansion failure) it silently
-/// returns `LoggingConfig::default()` (file target, default directory).
-/// Extra top-level keys are ignored — typos are caught later by the full
-/// `Config` parse.
+/// This runs **before** the logger is initialized, so it must not use `log::*`
+/// and reports problems on `stderr` instead. A missing config file is not a
+/// problem; on any other failure it falls back to `LoggingConfig::default()`
+/// (file target, default directory). Extra top-level keys are ignored, typos
+/// are caught later by the full `Config` parse.
 pub fn read_logging_config(path: Option<&PathBuf>) -> LoggingConfig {
     #[derive(Deserialize)]
     struct LoggingConfigWrapper {
@@ -1410,17 +1410,37 @@ pub fn read_logging_config(path: Option<&PathBuf>) -> LoggingConfig {
 
     let config_path = match config_path {
         Ok(p) => p,
-        Err(_) => return LoggingConfig::default(),
+        Err(e) => {
+            eprintln!(
+                "ashell: warning: cannot expand the config path: {e}, using the default logging setup"
+            );
+            return LoggingConfig::default();
+        }
     };
 
     let content = match std::fs::read_to_string(&config_path) {
         Ok(c) => c,
-        Err(_) => return LoggingConfig::default(),
+        Err(e) => {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                eprintln!(
+                    "ashell: warning: cannot read {}: {e}, using the default logging setup",
+                    config_path.display()
+                );
+            }
+            return LoggingConfig::default();
+        }
     };
 
-    toml::from_str::<LoggingConfigWrapper>(&content)
-        .map(|w| w.logging)
-        .unwrap_or_default()
+    match toml::from_str::<LoggingConfigWrapper>(&content) {
+        Ok(wrapper) => wrapper.logging,
+        Err(e) => {
+            eprintln!(
+                "ashell: warning: cannot read the [logging] section of {}, using the default logging setup:\n{e}",
+                config_path.display()
+            );
+            LoggingConfig::default()
+        }
+    }
 }
 
 pub fn get_config(path: Option<PathBuf>) -> Result<(Config, PathBuf), Box<dyn Error + Send>> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,10 +20,37 @@ use tokio::time::sleep;
 
 pub const DEFAULT_CONFIG_FILE_PATH: &str = "~/.config/ashell/config.toml";
 
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum LogTarget {
+    #[default]
+    File,
+    Stdout,
+    Stderr,
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
+pub struct LoggingConfig {
+    pub level: String,
+    pub target: LogTarget,
+    pub directory: Option<PathBuf>,
+}
+
+impl Default for LoggingConfig {
+    fn default() -> Self {
+        Self {
+            level: "warn".to_owned(),
+            target: LogTarget::default(),
+            directory: None,
+        }
+    }
+}
+
+#[derive(Deserialize, Clone, Debug, Default)]
+#[serde(default)]
 pub struct Config {
-    pub log_level: String,
+    pub logging: LoggingConfig,
     pub language: Option<String>,
     pub region: Option<String>,
     pub position: Position,
@@ -46,35 +73,6 @@ pub struct Config {
     pub animations: AnimationsConfig,
     pub enable_esc_key: bool,
     pub osd: OsdConfig,
-}
-
-impl Default for Config {
-    fn default() -> Self {
-        Self {
-            log_level: "warn".to_owned(),
-            language: None,
-            region: None,
-            position: Position::default(),
-            layer: Layer::default(),
-            outputs: Outputs::default(),
-            modules: Modules::default(),
-            updates: None,
-            workspaces: WorkspacesModuleConfig::default(),
-            window_title: WindowTitleConfig::default(),
-            system_info: SystemInfoModuleConfig::default(),
-            notifications: NotificationsModuleConfig::default(),
-            tray: TrayModuleConfig::default(),
-            tempo: TempoModuleConfig::default(),
-            settings: SettingsModuleConfig::default(),
-            appearance: Appearance::default(),
-            media_player: MediaPlayerModuleConfig::default(),
-            keyboard_layout: KeyboardLayoutModuleConfig::default(),
-            animations: AnimationsConfig::default(),
-            custom_modules: vec![],
-            enable_esc_key: false,
-            osd: OsdConfig::default(),
-        }
-    }
 }
 
 #[derive(Deserialize, Clone, Debug, Default)]
@@ -1391,6 +1389,40 @@ impl Default for OsdConfig {
     }
 }
 
+/// Bootstrap-parse only the `[logging]` section from the config file.
+///
+/// This runs **before** the logger is initialized, so it must not use `log::*`.
+/// On any error (missing file, parse failure, expansion failure) it silently
+/// returns `LoggingConfig::default()` (file target, default directory).
+/// Extra top-level keys are ignored — typos are caught later by the full
+/// `Config` parse.
+pub fn read_logging_config(path: Option<&PathBuf>) -> LoggingConfig {
+    #[derive(Deserialize)]
+    struct LoggingConfigWrapper {
+        #[serde(default)]
+        logging: LoggingConfig,
+    }
+
+    let config_path = match path {
+        Some(p) => expand_path(p.clone()),
+        None => expand_path(PathBuf::from(DEFAULT_CONFIG_FILE_PATH)),
+    };
+
+    let config_path = match config_path {
+        Ok(p) => p,
+        Err(_) => return LoggingConfig::default(),
+    };
+
+    let content = match std::fs::read_to_string(&config_path) {
+        Ok(c) => c,
+        Err(_) => return LoggingConfig::default(),
+    };
+
+    toml::from_str::<LoggingConfigWrapper>(&content)
+        .map(|w| w.logging)
+        .unwrap_or_default()
+}
+
 pub fn get_config(path: Option<PathBuf>) -> Result<(Config, PathBuf), Box<dyn Error + Send>> {
     match path {
         Some(p) => {
@@ -1424,7 +1456,7 @@ pub fn get_config(path: Option<PathBuf>) -> Result<(Config, PathBuf), Box<dyn Er
     }
 }
 
-fn expand_path(path: PathBuf) -> Result<PathBuf, Box<dyn Error + Send>> {
+pub(crate) fn expand_path(path: PathBuf) -> Result<PathBuf, Box<dyn Error + Send>> {
     let str_path = path.to_string_lossy();
     let expanded =
         shellexpand::full(&str_path).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use crate::config::{Position, get_config};
+use crate::config::{LogTarget, Position, get_config};
 use crate::outputs::Outputs;
 use crate::theme::BarLayout;
 use app::App;
@@ -193,26 +193,44 @@ fn main() -> iced::Result {
 
     debug!("args: {args:?}");
 
-    let logdir = xdg::get_runtime_dir()
-        .unwrap_or_else(|| [env::temp_dir(), PathBuf::from("ashell")].iter().collect());
-    let logger = Logger::with(
-        LogSpecBuilder::new()
-            .default(log::LevelFilter::Info)
-            .build(),
-    )
-    .log_to_file(FileSpec::default().directory(logdir))
-    .rotate(
-        Criterion::AgeOrSize(Age::Day, TMP_FILE_SIZE),
-        Naming::Timestamps,
-        Cleanup::KeepLogFiles(7),
-    );
-    let logger = if cfg!(debug_assertions) {
+    let log_prefs = config::read_logging_config(args.config_path.as_ref());
+
+    let default_logdir = || {
+        xdg::get_runtime_dir()
+            .unwrap_or_else(|| [env::temp_dir(), PathBuf::from("ashell")].iter().collect())
+    };
+
+    let logdir = match &log_prefs.directory {
+        Some(dir) => config::expand_path(dir.clone()).unwrap_or_else(|e| {
+            eprintln!(
+                "ashell: warning: cannot expand logging.directory {dir:?}: {e}, using default"
+            );
+            default_logdir()
+        }),
+        None => default_logdir(),
+    };
+
+    let log_spec = LogSpecBuilder::new()
+        .default(log::LevelFilter::Info)
+        .build();
+    let logger = match log_prefs.target {
+        LogTarget::File => Logger::with(log_spec)
+            .log_to_file(FileSpec::default().directory(logdir))
+            .rotate(
+                Criterion::AgeOrSize(Age::Day, TMP_FILE_SIZE),
+                Naming::Timestamps,
+                Cleanup::KeepLogFiles(7),
+            ),
+        LogTarget::Stdout => Logger::with(log_spec).log_to_stdout(),
+        LogTarget::Stderr => Logger::with(log_spec).log_to_stderr(),
+    };
+    let logger = if cfg!(debug_assertions) && matches!(log_prefs.target, LogTarget::File) {
         logger.duplicate_to_stdout(flexi_logger::Duplicate::All)
     } else {
         logger
     };
     let logger = logger.start().unwrap_or_else(|e| {
-        eprintln!("Failed to initialize file logger: {e}, falling back to stderr-only");
+        eprintln!("Failed to initialize logger: {e}, falling back to stderr-only");
         Logger::with(
             LogSpecBuilder::new()
                 .default(log::LevelFilter::Info)
@@ -234,7 +252,7 @@ fn main() -> iced::Result {
         std::process::exit(1);
     });
 
-    logger.set_new_spec(get_log_spec(&config.log_level));
+    logger.set_new_spec(get_log_spec(&config.logging.level));
 
     let font = if let Some(font_name) = &config.appearance.font_name {
         resolve_font(font_name)

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -10,13 +10,19 @@ Commented-out lines show the default; uncomment and change to customize.
 ```toml
 # ── General ───────────────────────────────────────────────────────────────────
 
-log_level = "warn"
 # language = "en-US"        # UI language; defaults to $LC_MESSAGES / $LANG
 # region   = "it-IT"        # date format + unit system; defaults to $LC_TIME / $LANG
 # outputs = "All"            # "All" (default), "Active", or { Targets = ["eDP-1"] }
 position = "Top"             # "Top" (default) or "Bottom"
 # layer = "Bottom"           # "Bottom" (default), "Top", or "Overlay"
 # enable_esc_key = false     # Pressing Escape closes open menus
+
+# ── Logging ───────────────────────────────────────────────────────────────────
+
+[logging]
+# level = "warn"             # (default) "error", "warn", "info", or "debug"; supports per-module filters
+# target = "file"            # (default) "file", "stdout", or "stderr"
+# directory = "~/.local/log" # (default: $XDG_RUNTIME_DIR/ashell) supports ~ and $VAR
 
 # ── Modules ───────────────────────────────────────────────────────────────────
 

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -22,7 +22,7 @@ position = "Top"             # "Top" (default) or "Bottom"
 [logging]
 # level = "warn"             # (default) "error", "warn", "info", or "debug"; supports per-module filters
 # target = "file"            # (default) "file", "stdout", or "stderr"
-# directory = "~/.local/log" # (default: $XDG_RUNTIME_DIR/ashell) supports ~ and $VAR
+# directory = "~/.local/log" # (default: $XDG_RUNTIME_DIR) supports ~ and $VAR
 
 # ── Modules ───────────────────────────────────────────────────────────────────
 

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -7,59 +7,79 @@ sidebar_position: 1
 This page contains the base configuration options for Ashell.
 
 It allows you to configure things like the log level, the monitor(s) used to
-render the status bar, and the bar’s position.
+render the status bar, and the bar's position.
 
 All these configurations are defined in the root of the `toml` file.
 
-## Log Level
+## Logging
 
-The log level controls the verbosity of logs.
+The `[logging]` section controls log level, destination, and file location.
 
-You can set it to a general level like `debug`, `info`, `warn`, or `error`,
-or specify fine-grained control to enable logs from specific modules
-in the codebase, e.g., `ashell::services::network=debug`.
+By default, ashell logs at `warn` level to a file in `$XDG_RUNTIME_DIR/ashell/`
+(or `/tmp/ashell/` as a fallback). Log files are rotated daily or when they
+reach 10 MB, and the last 7 files are kept.
 
-See more about [log levels](https://docs.rs/env_logger/latest/env_logger/#enabling-logging).
+See [log levels](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)
+for the full filter syntax.
+
+### Options
+
+- `level` — Log verbosity: `"error"`, `"warn"`, `"info"`, or `"debug"` (default: `"warn"`).
+- `target` — Where to write logs: `"file"` (default), `"stdout"`, or `"stderr"`.
+- `directory` — Custom log directory (only used when `target = "file"`).
+  Supports `~` and environment variable expansion. Defaults to `$XDG_RUNTIME_DIR/ashell/`.
 
 :::warning
 
-This configuration **requires** restarting Ashell to take effect.
+Changing the `[logging]` section requires restarting ashell to take effect.
+The log destination is set once at startup and cannot be changed via hot-reload.
 
 :::
 
-### Log Examples
+:::caution
 
-Set the global log level to `debug` for all modules:
+On multi-user systems, avoid setting `directory` to a shared path like `/tmp/ashell`.
+The default `$XDG_RUNTIME_DIR` is per-user and avoids permission conflicts when
+multiple users run ashell on the same machine. See
+[#760](https://github.com/MalpenZibo/ashell/pull/760) for details.
 
-```toml
-log_level = "debug"
-```
+:::
 
-Set the log level for the `ashell` module only:
-
-```toml
-log_level = "ashell=debug"
-```
-
-Set the log level to `warn` for all modules, `info` for Ashell modules,
-and `debug` only for the network service:
+### Examples
 
 ```toml
-log_level = "warn,ashell=info,ashell::services::network=debug"
+[logging]
+level = "debug"
 ```
 
-To understand all possible module names you can use, check
-the [source code](https://github.com/MalpenZibo/ashell).  
-The `src` folder is the root of the `ashell` module, and every directory
-or file under it declares a module or submodule.
+```toml
+[logging]
+level = "warn,ashell=info,ashell::services::network=debug"
+```
 
-For example, the file `src/modules/media_player.rs` maps to the module `ashell::modules::media_player`.
+```toml
+[logging]
+target = "stdout"
+```
+
+```toml
+[logging]
+target = "file"
+directory = "~/.local/log/ashell"
+```
+
+The `level` option supports fine-grained control per Rust module, e.g.
+`"warn,ashell::services::network=debug"`. To understand all possible module
+names, check the [source code](https://github.com/MalpenZibo/ashell). The `src`
+folder is the root of the `ashell` module, and every directory or file under it
+declares a module or submodule. For example, `src/modules/media_player.rs` maps
+to `ashell::modules::media_player`.
 
 :::warning
 
-Don’t confuse Ashell features (called “modules”) with Rust modules
-(defined with `mod.rs` or in files).  
-In this configuration, we're referring to Rust modules.
+Don't confuse Ashell features (called "modules") with Rust modules
+(defined with `mod.rs` or in files). In this configuration, we're
+referring to Rust modules.
 
 :::
 

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -44,8 +44,7 @@ The log destination is set once at startup and cannot be changed via hot-reload.
 On multi-user systems, avoid setting `directory` to a shared path like `/tmp/ashell`.
 The default `$XDG_RUNTIME_DIR` is per-user and avoids permission conflicts when
 multiple users run ashell on the same machine; ashell only falls back to
-`/tmp/ashell` when `$XDG_RUNTIME_DIR` is unusable. See
-[#760](https://github.com/MalpenZibo/ashell/pull/760) for details.
+`/tmp/ashell` when `$XDG_RUNTIME_DIR` is unusable.
 
 :::
 

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -15,9 +15,11 @@ All these configurations are defined in the root of the `toml` file.
 
 The `[logging]` section controls log level, destination, and file location.
 
-By default, ashell logs at `warn` level to a file in `$XDG_RUNTIME_DIR/ashell/`
-(or `/tmp/ashell/` as a fallback). Log files are rotated daily or when they
-reach 10 MB, and the last 7 files are kept.
+By default, ashell logs at `warn` level to a file directly inside
+`$XDG_RUNTIME_DIR`, for example `/run/user/1000/ashell_rCURRENT.log`. When
+`$XDG_RUNTIME_DIR` is unset or is not a private per-user directory, the
+fallback is `/tmp/ashell/`. Log files are rotated daily or when they reach
+10 MB, and the last 7 files are kept.
 
 See [log levels](https://docs.rs/env_logger/latest/env_logger/#enabling-logging)
 for the full filter syntax.
@@ -27,7 +29,8 @@ for the full filter syntax.
 - `level` — Log verbosity: `"error"`, `"warn"`, `"info"`, or `"debug"` (default: `"warn"`).
 - `target` — Where to write logs: `"file"` (default), `"stdout"`, or `"stderr"`.
 - `directory` — Custom log directory (only used when `target = "file"`).
-  Supports `~` and environment variable expansion. Defaults to `$XDG_RUNTIME_DIR/ashell/`.
+  Supports `~` and environment variable expansion, and is created if missing.
+  Defaults to `$XDG_RUNTIME_DIR`.
 
 :::warning
 
@@ -40,7 +43,8 @@ The log destination is set once at startup and cannot be changed via hot-reload.
 
 On multi-user systems, avoid setting `directory` to a shared path like `/tmp/ashell`.
 The default `$XDG_RUNTIME_DIR` is per-user and avoids permission conflicts when
-multiple users run ashell on the same machine. See
+multiple users run ashell on the same machine; ashell only falls back to
+`/tmp/ashell` when `$XDG_RUNTIME_DIR` is unusable. See
 [#760](https://github.com/MalpenZibo/ashell/pull/760) for details.
 
 :::


### PR DESCRIPTION
Right now the only logging knob is a top-level `log_level`, and logs always go to a
file in `$XDG_RUNTIME_DIR/ashell/`. Annoying if you're debugging and just want the
output in the terminal you launched ashell from, or if you want the logs somewhere
that survives a reboot.

This moves logging into its own `[logging]` section and adds two options:

```toml
[logging]
level = "warn"                 # same as the old log_level
target = "file"                # or "stdout" / "stderr"
directory = "~/.local/log"     # only for target = "file", supports ~ and $VAR
```

**Breaking**
`log_level` at the top level is gone, it's `[logging] level` now. Nothing crashes
if you leave the old key in place, it's just ignored. Once #922 lands you'll also
get a warning on `stderr` telling you the key was skipped.


The logger has to be up before the config is parsed, so there's a small
`read_logging_config` that bootstrap-parses just the `[logging]` table before
anything else. It's deliberately silent on errors (it can't log, the logger
doesn't exist yet) and falls back to the old defaults; typos still get caught by
the real `Config` parse a moment later.

Also swapped the hand-written `Config::default()` for a derive while I was in
there, I checked every field, the values are identical.

**Notes**
Changing `[logging]` needs a restart. Hot-reload only re-applies `level`; the destination is fixed at startup.
In debug builds, the duplicate-to-stdout behaviour now only kicks in for `target = "file"`, otherwise you'd see every line twice.
Docs updated in `website/docs/configuration/` (main + full_config).

closes https://github.com/MalpenZibo/ashell/issues/891
