### PR TITLE
feat(memory): amount option, showing XX.X GiB

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -318,6 +318,7 @@ pub enum DiskFormat {
 pub enum MemoryFormat {
     #[default]
     Percentage,
+    Amount,
     Fraction,
 }
 

--- a/src/modules/system_info.rs
+++ b/src/modules/system_info.rs
@@ -58,6 +58,7 @@ struct NetworkData {
 
 struct MemoryUsage {
     percentage: u32,
+    amount: f32,
     fraction: String,
 }
 
@@ -229,6 +230,7 @@ fn get_system_info(
         } else {
             0
         },
+        amount: utils::bytes_to_gib(used_mem),
         fraction: format!(
             "{:.2}/{:.2}",
             utils::bytes_to_gib(used_mem),
@@ -245,6 +247,7 @@ fn get_system_info(
         } else {
             0
         },
+        amount: utils::bytes_to_gib(used_swap),
         fraction: format!(
             "{:.2}/{:.2}",
             utils::bytes_to_gib(used_swap),
@@ -555,7 +558,7 @@ impl SystemInfo {
                                 format!("{}%", self.data.memory_usage.percentage),
                             MemoryFormat::Fraction =>
                                 format!("{} GiB", self.data.memory_usage.fraction),
-                        }
+                        MemoryFormat::Amount => format!("{:.2} GiB", self.data.memory_usage.amount)}
                     ))
                     .push(Self::info_element(
                         StaticIcon::Mem,
@@ -565,7 +568,7 @@ impl SystemInfo {
                                 format!("{}%", self.data.memory_swap_usage.percentage),
                             MemoryFormat::Fraction =>
                                 format!("{} GiB", self.data.memory_swap_usage.fraction),
-                        }
+                        MemoryFormat::Amount => format!("{:.2} GiB", self.data.memory_swap_usage.amount)}
                     ))
                     .push(self.data.temperature.celsius.map(|cel| {
                         Self::info_element(StaticIcon::Temp, t!("system-info-temperature"), {
@@ -660,6 +663,7 @@ impl SystemInfo {
                         (self.data.memory_usage.percentage.to_string(), "%")
                     }
                     MemoryFormat::Fraction => (self.data.memory_usage.fraction.clone(), " GiB"),
+                    MemoryFormat::Amount => (format!("{:.1}", self.data.memory_usage.amount), " GiB"),
                 },
                 Some((
                     self.data.memory_usage.percentage,
@@ -678,6 +682,7 @@ impl SystemInfo {
                     MemoryFormat::Fraction => {
                         (self.data.memory_swap_usage.fraction.clone(), " GiB")
                     }
+                    MemoryFormat::Amount => (format!("{:.1}", self.data.memory_swap_usage.amount), " GiB")
                 },
                 Some((
                     self.data.memory_swap_usage.percentage,

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -88,7 +88,7 @@ alert_threshold = 80
 [system_info.memory]
 warn_threshold = 70
 alert_threshold = 85
-# format = "Percentage"   # (default) or "Fraction"
+# format = "Percentage"   # (default), "Amount" or "Fraction"
 
 [system_info.temperature]
 # warn_threshold = 60     # (default: None, auto 60°C / 140°F based on unit system)

--- a/website/docs/configuration/modules/system_info.md
+++ b/website/docs/configuration/modules/system_info.md
@@ -45,6 +45,7 @@ To enable this indicator, add `Memory` to the `indicators` configuration.
 You can change the display format using the `format` option in `[system_info.memory]`:
 
 - `"Percentage"` (default) — shows memory usage as a percentage (e.g., `64%`)
+- `"Amount"` — shows memory usage gigabytes in a compact manner (e.g., `11.7G`)
 - `"Fraction"` — shows used and total memory in GiB (e.g., `5.12/15.89 GiB`)
 
 ### Memory Swap


### PR DESCRIPTION
This PR introduces a new option for how to display the memory. I called it "Amount", which will just show the amount of GiB used in XX.X GiB format.

I chose 1 decimal for aesthetics. I know 2 decimals are also often preferred, but it will then take up more space.

It looks like this:

<img width="699" height="554" alt="image" src="https://github.com/user-attachments/assets/442e852e-79e9-415d-aa55-1bec0c7f78fa" />

I was considering also setting the units based on how much is used (so if 0.5 GiB is used, it should show 500 MiB instead), but I think that's too much of a stretch.

Let me know what you think, let me know if you want anything changed.