### PR TITLE
extract numeric prefix parsing for workspace index

### DIFF
--- a/src/services/compositor/generic.rs
+++ b/src/services/compositor/generic.rs
@@ -199,14 +199,22 @@ impl GenericState {
             .enumerate()
             .map(|(pos, ws)| {
                 let (monitor, monitor_id) = self.workspace_monitor(ws);
-                // ext-workspace has no inherent index. Prefer the workspace name
-                // when it is a positive integer (the common 1..N labelling),
+                // ext-workspace has no inherent index. Prefer a leading numeric
+                // prefix from the workspace name (e.g. "1: " → 1, the common
+                // 1..N labelling used by Sway/i3 and tools like workstyle),
                 // else fall back to display order so the value stays small and
                 // dense instead of the ever-growing numeric_id.
                 let index = ws
                     .name
-                    .parse::<i32>()
-                    .ok()
+                    .split(|c: char| !c.is_ascii_digit())
+                    .next()
+                    .and_then(|s| {
+                        if s.is_empty() {
+                            None
+                        } else {
+                            s.parse::<i32>().ok()
+                        }
+                    })
                     .filter(|n| *n > 0)
                     .unwrap_or(pos as i32 + 1);
                 CompositorWorkspace {


### PR DESCRIPTION
The workspace index calculation in `GenericState` previously attempted to
parse the entire workspace name as an integer, which failed for names
containing non-numeric characters (e.g. "1: web"). This caused a fallback
to display order, producing incorrect indices for Sway/i3 setups using
prefixed workspace labels.

The parsing logic now splits the workspace name on non-digit characters
and parses only the leading numeric segment, preserving the fallback to
display order for names without a valid numeric prefix.

closes #926 