### PR TITLE
feat(workspaces): add configurable font size

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -142,6 +142,17 @@ pub struct WorkspacesModuleConfig {
     pub workspace_names: Vec<String>,
     pub enable_virtual_desktops: bool,
     pub invert_scroll_direction: Option<InvertScrollDirection>,
+    pub font_size: WorkspaceFontSize,
+}
+
+/// Bar height is fixed, so only sizes that are known to fit the workspace
+/// button are offered; anything larger needs configurable bar height first.
+#[derive(Deserialize, Default, Copy, Clone, Eq, PartialEq, Debug)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkspaceFontSize {
+    #[default]
+    Small,
+    Large,
 }
 
 #[derive(Deserialize, Copy, Clone, Default, PartialEq, Eq, Debug)]

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -1,8 +1,8 @@
 use crate::{
     components::icons::icon,
     config::{
-        AppearanceColor, InvertScrollDirection, WorkspaceIndicatorFormat, WorkspaceVisibilityMode,
-        WorkspacesModuleConfig,
+        AppearanceColor, InvertScrollDirection, WorkspaceFontSize, WorkspaceIndicatorFormat,
+        WorkspaceVisibilityMode, WorkspacesModuleConfig,
     },
     outputs::Outputs,
     services::{
@@ -567,7 +567,10 @@ impl Workspaces {
                                 } else {
                                     Message::ToggleSpecialWorkspace(w.id)
                                 };
-                                let font_size = theme.font_size.xs;
+                                let font_size = match self.config.font_size {
+                                    WorkspaceFontSize::Small => theme.font_size.xs,
+                                    WorkspaceFontSize::Large => theme.font_size.sm,
+                                };
                                 let height = theme.space.md;
 
                                 // Numbered workspaces animate to a fixed width; icon

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -49,6 +49,7 @@ enable_workspace_filling = false  # (default)
 # workspace_names = ["1", "2", "3"] # (default: []) custom names for workspaces
 # enable_virtual_desktops = false   # (default) group workspaces into virtual desktops
 # invert_scroll_direction = "All"   # (default: None) "All", "Mouse", or "Trackpad"
+# font_size = "small"               # "small" (default) or "large"
 
 # ── Custom Modules ────────────────────────────────────────────────────────────
 

--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -159,6 +159,24 @@ changed icon theme are picked up the next time `ashell` is restarted.
 
 :::
 
+## Font Size
+
+Workspace numbers/names render smaller than most other bar text by default. Set
+`font_size = "large"` to bump them up one step:
+
+```toml
+[workspaces]
+font_size = "large"
+```
+
+:::note
+
+Only `"small"` (default) and `"large"` are offered today: the bar's height is
+fixed, and larger steps don't fit inside the workspace button without also
+making the bar taller, which isn't currently configurable.
+
+:::
+
 ## Default Configuration
 
 The default configuration is:
@@ -171,6 +189,7 @@ group_by_monitor = false
 enable_workspace_filling = false
 disable_special_workspaces = false
 invert_scroll_direction = None
+font_size = "small"
 ```
 
 ## Examples


### PR DESCRIPTION
Workspace numbers/names currently render at the smallest step on ashell's
font-size scale (`theme.font_size.xs`, 10px), which is smaller than the
rest of the bar (`window_title` uses 12px, the clock's main time text falls
back to iced's 16px default), and there is no way to change it from config.

Adds a basic `font_size` option on `[workspaces]`: `"small"` (default, unchanged
behavior) or `"large"` (bumps to `theme.font_size.sm`, matching
`window_title`).

Only two values for now (limited-scope change). The bar height is a fixed
constant, and the workspace button height is pegged to `theme.space.md`
(16px). A larger `theme.font_size.md` (16px) font would leave no vertical margin
and looks cramped/clipped without additional changes so anything past `large`
(internal `sm` font size) isn't usable until bar height itself becomes configurable,
which is separate, larger work (see #120).

```toml
[workspaces]
font_size = "large"
```

Hot-reloads for free since `WorkspacesModuleConfig` already flows through
the existing `ConfigReloaded` path — no new plumbing needed.

## Screenshots

### `Small` (default, current)
<img width="3840" height="70" alt="small_numbers" src="https://github.com/user-attachments/assets/4915835c-5f48-4d93-a4d9-5bd1a57aae3d" />
<img width="3840" height="70" alt="small_letters" src="https://github.com/user-attachments/assets/6cd7c50a-ca48-44fe-8e84-0607225447d1" />


### `Large` (new)
<img width="3840" height="70" alt="large_numbers" src="https://github.com/user-attachments/assets/2be5bc18-9407-464c-8012-c40f26fbd416" />
<img width="3840" height="70" alt="large_letters" src="https://github.com/user-attachments/assets/51572b87-3498-48f0-8f97-0efe00b39dff" />
