### PR TITLE
fix(network): handle iwd station lifecycle after rfkill unblock

### DIFF
--- a/src/services/network/iwd_dbus/mod.rs
+++ b/src/services/network/iwd_dbus/mod.rs
@@ -30,8 +30,9 @@ use iced::futures::stream::select_all;
 use iced::futures::{Stream, StreamExt};
 
 use log::{debug, info, warn};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::ops::Deref;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::process::Command;
 use zbus::fdo::ObjectManagerProxy;
 use zbus::zvariant::OwnedObjectPath;
@@ -348,6 +349,8 @@ impl From<String> for IwdStationState {
     }
 }
 
+static NEXT_SIGNAL_AGENT_ID: AtomicU64 = AtomicU64::new(0);
+
 struct SignalAgent {
     tx: tokio::sync::mpsc::UnboundedSender<(OwnedObjectPath, u8)>,
 }
@@ -356,27 +359,60 @@ struct SignalAgentCleanup {
     conn: zbus::Connection,
     station_path: OwnedObjectPath,
     agent_path: OwnedObjectPath,
+    cleaned: bool,
+}
+
+impl SignalAgentCleanup {
+    async fn cleanup(&mut self) {
+        if self.cleaned {
+            return;
+        }
+
+        cleanup_signal_agent(
+            self.conn.clone(),
+            self.station_path.clone(),
+            self.agent_path.clone(),
+        )
+        .await;
+        self.cleaned = true;
+    }
+}
+
+async fn cleanup_signal_agent(
+    conn: zbus::Connection,
+    station_path: OwnedObjectPath,
+    agent_path: OwnedObjectPath,
+) {
+    let station = match StationProxy::builder(&conn)
+        .destination("net.connman.iwd")
+        .and_then(|b| b.path(station_path))
+    {
+        Ok(builder) => builder.build().await.ok(),
+        Err(_) => None,
+    };
+
+    if let Some(station) = station {
+        let _ = station.unregister_signal_level_agent(&agent_path).await;
+    }
+
+    let _ = conn
+        .object_server()
+        .remove::<SignalAgent, _>(&agent_path)
+        .await;
 }
 
 impl Drop for SignalAgentCleanup {
     fn drop(&mut self) {
+        if self.cleaned {
+            return;
+        }
+
         let conn = self.conn.clone();
         let station_path = self.station_path.clone();
         let agent_path = self.agent_path.clone();
 
         tokio::spawn(async move {
-            let station = match StationProxy::builder(&conn)
-                .destination("net.connman.iwd")
-                .and_then(|b| b.path(station_path.clone()))
-            {
-                Ok(builder) => match builder.build().await {
-                    Ok(station) => station,
-                    Err(_) => return,
-                },
-                Err(_) => return,
-            };
-
-            let _ = station.unregister_signal_level_agent(&agent_path).await;
+            cleanup_signal_agent(conn, station_path, agent_path).await;
         });
     }
 }
@@ -506,6 +542,29 @@ impl IwdDbus<'_> {
 
         //self.register_psk_agent().await?;
 
+        // Subscribe before enumerating stations so station additions/removals cannot be missed.
+        let mut station_interface_changes = select_all(vec![
+            self.receive_interfaces_added()
+                .await?
+                .filter_map(|signal| async move {
+                    let args = signal.args().ok()?;
+                    args.interfaces_and_properties()
+                        .contains_key("net.connman.iwd.Station")
+                        .then_some(())
+                })
+                .boxed(),
+            self.receive_interfaces_removed()
+                .await?
+                .filter_map(|signal| async move {
+                    let args = signal.args().ok()?;
+                    args.interfaces()
+                        .iter()
+                        .any(|interface| interface == "net.connman.iwd.Station")
+                        .then_some(())
+                })
+                .boxed(),
+        ]);
+
         // --- WiFi Enabled ---
         let mut wireless_enabled_changes = vec![];
         for adapter_proxy in self.adapters().await? {
@@ -528,6 +587,10 @@ impl IwdDbus<'_> {
 
         // connectivity, access points, strengths and known - all in one
         let stations = self.stations().await?;
+        let initial_station_paths: HashSet<_> = stations
+            .iter()
+            .map(|station| station.inner().path().clone())
+            .collect();
         let mut connectivity_changes = vec![];
         let mut ap_s_kap_changes = vec![];
         let mut signal_level_updates = vec![];
@@ -585,8 +648,7 @@ impl IwdDbus<'_> {
                             debug!("Stopped scanning wifi");
                             events.push(NetworkEvent::ScanningNearbyWifi(false));
                             events.push(NetworkEvent::WirelessDevice {
-                                // TODO: can we reasonably assume this is true here?
-                                wifi_present: iwd.wireless_enabled().await.unwrap_or(false),
+                                wifi_present: iwd.wifi_device_present().await.unwrap_or(false),
                                 wireless_access_points: aps,
                             });
                         }
@@ -608,8 +670,10 @@ impl IwdDbus<'_> {
                 .as_str()
                 .trim_matches('/')
                 .replace('/', "_");
-            let agent_path =
-                OwnedObjectPath::try_from(format!("/com/ashell/signalagent/{station_id}"))?;
+            let agent_id = NEXT_SIGNAL_AGENT_ID.fetch_add(1, Ordering::Relaxed);
+            let agent_path = OwnedObjectPath::try_from(format!(
+                "/com/ashell/signalagent/{station_id}_{agent_id}"
+            ))?;
             let station_for_signal_stream = station.clone();
 
             let server = self
@@ -655,6 +719,13 @@ impl IwdDbus<'_> {
                     .boxed(),
             );
 
+            signal_agent_cleanups.push(SignalAgentCleanup {
+                conn: self.inner().connection().clone(),
+                station_path,
+                agent_path: agent_path.clone(),
+                cleaned: false,
+            });
+
             // Register signal level agent with thresholds aligned to NM's bar ranges
             // NM's bar ranges: >80% (5 bars), >55% (4 bars), >30% (3 bars), >5% (2 bars), ≤5% (1 bar)
             // Using NM linear mapping, this translates to RSSI thresholds:
@@ -663,50 +734,15 @@ impl IwdDbus<'_> {
             station
                 .register_signal_level_agent(&agent_path, &signal_thresholds)
                 .await?;
-
-            signal_agent_cleanups.push(SignalAgentCleanup {
-                conn: self.inner().connection().clone(),
-                station_path,
-                agent_path,
-            });
         }
 
-        // TODO: probably would need to listen to interfaces registered and unregistered
-        //let devices = nm.wireless_devices().await.unwrap_or_default();
-
-        //let wireless_devices_changed = nm
-        //    .receive_devices_changed()
-        //    .await
-        //    .filter_map({
-        //        let conn = conn.clone();
-        //        let devices = devices.clone();
-        //        move |_| {
-        //            let conn = conn.clone();
-        //            let devices = devices.clone();
-        //            async move {
-        //                let nm = NetworkDbus::new(&conn).await.unwrap();
-
-        //                let current_devices = nm.wireless_devices().await.unwrap_or_default();
-        //                if current_devices != devices {
-        //                    let wifi_present = nm.wifi_device_present().await.unwrap_or_default();
-        //                    let wireless_access_points =
-        //                        nm.wireless_access_points().await.unwrap_or_default();
-
-        //                    debug!(
-        //                        "Wireless device changed: wifi present {:?}, wireless_access_points {:?}",
-        //                        wifi_present, wireless_access_points,
-        //                    );
-        //                    Some(NetworkEvent::WirelessDevice {
-        //                        wifi_present,
-        //                        wireless_access_points,
-        //                    })
-        //                } else {
-        //                    None
-        //                }
-        //            }
-        //        }
-        //    })
-        //    .boxed();
+        let current_station_paths: HashSet<_> = self
+            .stations()
+            .await?
+            .into_iter()
+            .map(|station| station.inner().path().clone())
+            .collect();
+        let station_topology_changed = initial_station_paths != current_station_paths;
 
         //TODO: likely need to register an auth agent and wait for it here, same goes for network
         //configuration etc - these all are agents registered with IWD - and represent device
@@ -746,18 +782,30 @@ impl IwdDbus<'_> {
 
         //let access_points = select_all(ac_changes).boxed();
 
+        let station_lifecycle = async move {
+            let topology_changed =
+                station_topology_changed || station_interface_changes.next().await.is_some();
+
+            if topology_changed {
+                debug!("IWD station topology changed; restarting listeners");
+            }
+
+            for cleanup in &mut signal_agent_cleanups {
+                cleanup.cleanup().await;
+            }
+        };
+
         let events = select_all(vec![
             select_all(wireless_enabled_changes).boxed(),
             select_all(connectivity_changes).boxed(),
             select_all(ap_s_kap_changes).boxed(),
             select_all(signal_level_updates).boxed(),
+            iced::futures::stream::pending().boxed(),
             // TODO: add a future that waits for 10s to poll certain information like the signal
             // strength change
         ])
-        .map(move |event| {
-            let _keep_alive = &signal_agent_cleanups;
-            event
-        });
+        .take_until(station_lifecycle)
+        .boxed();
 
         Ok(events)
     }
@@ -774,14 +822,7 @@ impl IwdDbus<'_> {
 
     /// Return true if any device in station mode is present.
     pub async fn wifi_device_present(&self) -> anyhow::Result<bool> {
-        let devices = self.wireless_devices().await?;
-
-        for d in devices {
-            if d.powered().await? {
-                return Ok(true);
-            }
-        }
-        Ok(false)
+        Ok(!self.wireless_devices().await?.is_empty())
     }
 
     /// List all networks currently connected (Connected = true).

--- a/src/services/network/mod.rs
+++ b/src/services/network/mod.rs
@@ -182,7 +182,7 @@ impl Deref for NetworkService {
 
 enum State {
     Init,
-    Active(zbus::Connection, BackendChoice),
+    Active(zbus::Connection, BackendChoice, bool),
     Error,
 }
 
@@ -460,7 +460,7 @@ impl NetworkService {
                                     pending_scan_devices: Vec::new(),
                                 }))
                                 .await;
-                            State::Active(conn, choice)
+                            State::Active(conn, choice, false)
                         }
                         Err(err) => {
                             if err.is::<zbus::Error>() {
@@ -478,7 +478,7 @@ impl NetworkService {
                     State::Error
                 }
             },
-            State::Active(conn, choice) => {
+            State::Active(conn, choice, refresh_data) => {
                 info!("Listening for network events");
 
                 // TODO: i dont know how to combine the opaque types.. rust streams
@@ -508,7 +508,7 @@ impl NetworkService {
 
                                 debug!("Network service exit events stream");
 
-                                State::Active(conn, choice)
+                                State::Active(conn, choice, false)
                             }
                             Err(err) => {
                                 error!("Failed to listen for network events: {err}");
@@ -527,6 +527,26 @@ impl NetworkService {
                         };
                         match iwd.subscribe_events().await {
                             Ok(mut event_s) => {
+                                if refresh_data {
+                                    match iwd.initialize_data().await {
+                                        Ok(data) => {
+                                            let _ = output
+                                                .send(ServiceEvent::Init(NetworkService {
+                                                    data,
+                                                    conn: conn.clone(),
+                                                    backend_choice: choice,
+                                                    pending_scan_devices: Vec::new(),
+                                                }))
+                                                .await;
+                                        }
+                                        Err(err) => {
+                                            error!(
+                                                "Failed to refresh network service after IWD station topology change: {err}"
+                                            );
+                                        }
+                                    }
+                                }
+
                                 while let Some(events) = event_s.next().await {
                                     for event in events {
                                         // TODO: network manager leaves with device - we can also
@@ -537,8 +557,9 @@ impl NetworkService {
                                 }
 
                                 debug!("Network service exit events stream");
+                                drop(event_s);
 
-                                State::Active(conn, choice)
+                                State::Active(conn, choice, true)
                             }
                             Err(err) => {
                                 error!("Failed to listen for network events: {err}");


### PR DESCRIPTION
## Summary

Fix IWD Wi-Fi state recovery when AShell is restarted while Wi-Fi is disabled through RFKill.

AShell itself disables IWD Wi-Fi by setting the adapter power state, which correctly results in a kernel RFKill soft block. The RFKill behavior is expected and should remain unchanged.

The bug was in how AShell recovered from that valid soft-blocked state after restarting.

Previously, the IWD backend treated a powered-off Wi-Fi device as if no Wi-Fi device was present. After restarting AShell with Wi-Fi soft-blocked, this caused the Wi-Fi toggle to disappear.

Keeping the device visible exposed a second issue: IWD creates and removes its `Station` interface as the radio state changes. If AShell starts while Wi-Fi is blocked, there is no `Station` interface to subscribe to, so enabling Wi-Fi later leaves station-specific listeners missing and the network UI stale.

## Changes

* Separate Wi-Fi device presence from whether the radio is powered on.
* Keep existing IWD/RFKill behavior when AShell disables Wi-Fi.
* Watch IWD `Station` interface additions and removals through the D-Bus object manager.
* Rebuild station-dependent listeners when IWD station topology changes.
* Refresh network state after rebuilding listeners.
* Clean up registered signal level agents before rebuilding.
* Use unique signal agent object paths across listener generations.
* Use actual device presence instead of powered state when updating Wi-Fi presence after scans.

## Before

```text
AShell disables Wi-Fi
→ IWD adapter Powered=false
→ kernel RFKill soft block (expected)
→ restart AShell
→ Wi-Fi device considered absent
→ Wi-Fi toggle unavailable
```

After correcting device presence alone:

```text
restart while blocked
→ toggle remains available
→ enable Wi-Fi
→ RFKill unblocks
→ IWD creates Station
→ old AShell subscription has no Station listeners
→ scan / connection / signal state remains stale
```

## After

```text
AShell disables Wi-Fi
→ RFKill soft block remains expected behavior
→ restart while Wi-Fi is blocked
→ Wi-Fi remains present but disabled
→ enable Wi-Fi
→ RFKill unblocks
→ IWD creates Station
→ AShell detects Station topology change
→ station listeners are rebuilt
→ network state is refreshed
→ scanning, connection state and signal updates resume
```

## Testing

Manually tested the reported flow:

* Disable Wi-Fi through AShell/IWD.
* Confirm this results in the expected RFKill soft block.
* Restart AShell while Wi-Fi remains soft-blocked.
* Confirm Wi-Fi toggle remains visible and disabled.
* Enable Wi-Fi from AShell.
* Confirm RFKill is unblocked.
* Confirm nearby Wi-Fi networks populate again.
* Confirm connection state and Wi-Fi indicator recover without restarting AShell.
