### PR TITLE
Use notification hint image data for icon

### DIFF
--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -29,9 +29,11 @@ impl NotificationIcon {
         app_icon: &str,
         hints: &HashMap<String, OwnedValue>,
     ) -> Option<Self> {
-        try_icon_from_hints(hints)..or_else(|| icon_candidates(app_name, app_icon, hints)
-            .find_map(resolve_candidate)
-            .map(Self::from_path))
+        try_icon_from_hints(hints)..or_else(|| {
+            icon_candidates(app_name, app_icon, hints)
+                .find_map(resolve_candidate)
+                .map(Self::from_path)
+        })
     }
 
     fn from_path(path: PathBuf) -> Self {

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -47,8 +47,9 @@ impl NotificationIcon {
     }
 }
 
+// freedesktop notification hint image data type
 #[derive(zvariant::OwnedValue, Debug)]
-struct FreedesktopNotificationHintImageData {
+struct HintImageData {
     width: i32,
     height: i32,
     rowstride: i32,
@@ -63,36 +64,31 @@ fn try_icon_from_hints(hints: &HashMap<String, OwnedValue>) -> Option<Notificati
         .get("image-data")
         .or(hints.get("image_data"))
         .or(hints.get("icon_data"))
-        && let Ok(freedesktop_image_data) =
-            FreedesktopNotificationHintImageData::try_from(image_data.clone())
-    {
-        let bytes = if freedesktop_image_data.has_alpha && freedesktop_image_data.channels == 4 {
-            freedesktop_image_data.image_bytes
-        } else if !freedesktop_image_data.has_alpha && freedesktop_image_data.channels == 3 {
-            freedesktop_image_data
-                .image_bytes
-                .as_chunks::<3>()
-                .0
-                .iter()
-                .flat_map(|[r, g, b]| [*r, *g, *b, 255_u8])
-                .collect()
-        } else {
-            return None;
-        };
-
-        if bytes.len()
-            == (freedesktop_image_data.width * freedesktop_image_data.height * 4) as usize
-        {
-            Some(NotificationIcon::Image(
-                iced::advanced::image::Handle::from_rgba(
-                    freedesktop_image_data.width as u32,
-                    freedesktop_image_data.height as u32,
-                    bytes,
-                ),
-            ))
+        && let Ok(hint_image_data) = HintImageData::try_from(image_data.clone())
+        && let Some(bytes) = if hint_image_data.has_alpha && hint_image_data.channels == 4 {
+            Some(hint_image_data.image_bytes)
+        } else if !hint_image_data.has_alpha && hint_image_data.channels == 3 {
+            Some(
+                hint_image_data
+                    .image_bytes
+                    .as_chunks::<3>()
+                    .0
+                    .iter()
+                    .flat_map(|[r, g, b]| [*r, *g, *b, 255_u8])
+                    .collect(),
+            )
         } else {
             None
         }
+        && bytes.len() == (hint_image_data.width * hint_image_data.height * 4) as usize
+    {
+        Some(NotificationIcon::Image(
+            iced::advanced::image::Handle::from_rgba(
+                hint_image_data.width as u32,
+                hint_image_data.height as u32,
+                bytes,
+            ),
+        ))
     } else {
         None
     }

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -29,7 +29,7 @@ impl NotificationIcon {
         app_icon: &str,
         hints: &HashMap<String, OwnedValue>,
     ) -> Option<Self> {
-        try_icon_from_hints(hints).or(icon_candidates(app_name, app_icon, hints)
+        try_icon_from_hints(hints)..or_else(|| icon_candidates(app_name, app_icon, hints)
             .find_map(resolve_candidate)
             .map(Self::from_path))
     }

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -29,7 +29,7 @@ impl NotificationIcon {
         app_icon: &str,
         hints: &HashMap<String, OwnedValue>,
     ) -> Option<Self> {
-        try_icon_from_hints(hints)..or_else(|| {
+        try_icon_from_hints(hints).or_else(|| {
             icon_candidates(app_name, app_icon, hints)
                 .find_map(resolve_candidate)
                 .map(Self::from_path)

--- a/src/services/notifications/mod.rs
+++ b/src/services/notifications/mod.rs
@@ -9,8 +9,8 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use tokio::sync::broadcast;
 use tokio_stream::wrappers::BroadcastStream;
-use zbus::Connection;
 use zbus::zvariant::OwnedValue;
+use zbus::{Connection, zvariant};
 
 pub mod dbus;
 
@@ -29,9 +29,9 @@ impl NotificationIcon {
         app_icon: &str,
         hints: &HashMap<String, OwnedValue>,
     ) -> Option<Self> {
-        icon_candidates(app_name, app_icon, hints)
+        try_icon_from_hints(hints).or(icon_candidates(app_name, app_icon, hints)
             .find_map(resolve_candidate)
-            .map(Self::from_path)
+            .map(Self::from_path))
     }
 
     fn from_path(path: PathBuf) -> Self {
@@ -44,6 +44,57 @@ impl NotificationIcon {
         } else {
             Self::Image(image::Handle::from_path(path))
         }
+    }
+}
+
+#[derive(zvariant::OwnedValue, Debug)]
+struct FreedesktopNotificationHintImageData {
+    width: i32,
+    height: i32,
+    rowstride: i32,
+    has_alpha: bool,
+    bits_per_sample: i32,
+    channels: i32,
+    image_bytes: Vec<u8>,
+}
+
+fn try_icon_from_hints(hints: &HashMap<String, OwnedValue>) -> Option<NotificationIcon> {
+    if let Some(image_data) = hints
+        .get("image-data")
+        .or(hints.get("image_data"))
+        .or(hints.get("icon_data"))
+        && let Ok(freedesktop_image_data) =
+            FreedesktopNotificationHintImageData::try_from(image_data.clone())
+    {
+        let bytes = if freedesktop_image_data.has_alpha && freedesktop_image_data.channels == 4 {
+            freedesktop_image_data.image_bytes
+        } else if !freedesktop_image_data.has_alpha && freedesktop_image_data.channels == 3 {
+            freedesktop_image_data
+                .image_bytes
+                .as_chunks::<3>()
+                .0
+                .iter()
+                .flat_map(|[r, g, b]| [*r, *g, *b, 255_u8])
+                .collect()
+        } else {
+            return None;
+        };
+
+        if bytes.len()
+            == (freedesktop_image_data.width * freedesktop_image_data.height * 4) as usize
+        {
+            Some(NotificationIcon::Image(
+                iced::advanced::image::Handle::from_rgba(
+                    freedesktop_image_data.width as u32,
+                    freedesktop_image_data.height as u32,
+                    bytes,
+                ),
+            ))
+        } else {
+            None
+        }
+    } else {
+        None
     }
 }
 


### PR DESCRIPTION
This PR adds support for the image-data hint of Freedesktop notifications while still falling back to the existing lookup system. It looks a bit funny since the application name is still Firefox, so this PR may still need a couple changes.

## Before
<img width="562" height="209" alt="ashell_before" src="https://github.com/user-attachments/assets/55288ce4-7452-4525-8328-9ba1abf605fa" />

## After
<img width="562" height="209" alt="ashell_after" src="https://github.com/user-attachments/assets/7263f21d-f8c5-4046-a5ba-639a8c861583" />
