### PR TITLE
add click-to-focus player window with menu close

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -460,6 +460,11 @@ impl App {
             Message::MediaPlayer(msg) => match self.media_player.update(msg) {
                 modules::media_player::Action::None => Task::none(),
                 modules::media_player::Action::Command(task) => task.map(Message::MediaPlayer),
+                modules::media_player::Action::CommandAndCloseMenu(task) => Task::batch(vec![
+                    self.outputs
+                        .close_all_menus(self.general_config.enable_esc_key),
+                    task.map(Message::MediaPlayer),
+                ]),
             },
             Message::CloseAllMenus => {
                 if self.outputs.menu_is_open() {

--- a/src/modules/media_player.rs
+++ b/src/modules/media_player.rs
@@ -21,9 +21,10 @@ use iced::{
     alignment::Vertical,
     futures::SinkExt,
     gradient::ColorStop,
+    mouse::Interaction,
     stream::channel,
     widget::{
-        Stack,
+        MouseArea, Stack,
         canvas::{self, Canvas, Fill, Frame, Geometry, Path},
         column, container, image, row, scrollable, slider, space, text,
     },
@@ -149,6 +150,7 @@ pub enum Message {
     PlayPause(String),
     Next(String),
     SetVolume(String, f64),
+    Raise(String),
     Event(ServiceEvent<MprisPlayerService>),
     ConfigReloaded(MediaPlayerModuleConfig),
     Bars(Vec<f32>),
@@ -158,6 +160,7 @@ pub enum Message {
 pub enum Action {
     None,
     Command(Task<Message>),
+    CommandAndCloseMenu(Task<Message>),
 }
 
 pub struct MediaPlayer {
@@ -204,6 +207,9 @@ impl MediaPlayer {
             Message::Next(s) => Action::Command(self.handle_command(s, PlayerCommand::Next)),
             Message::SetVolume(s, v) => {
                 Action::Command(self.handle_command(s, PlayerCommand::Volume(v)))
+            }
+            Message::Raise(s) => {
+                Action::CommandAndCloseMenu(self.handle_command(s, PlayerCommand::Raise))
             }
             Message::Event(event) => match event {
                 ServiceEvent::Init(s) => {
@@ -392,7 +398,7 @@ impl MediaPlayer {
                         } else {
                             content
                         };
-                        container(body)
+                        let card = container(body)
                             .style(move |app_theme: &Theme| container::Style {
                                 background: Background::Color(
                                     app_theme.extended_palette().background.weak.color,
@@ -401,7 +407,10 @@ impl MediaPlayer {
                                 border: Border::default().rounded(radius.lg),
                                 ..container::Style::default()
                             })
-                            .width(Length::Fill)
+                            .width(Length::Fill);
+                        MouseArea::new(card)
+                            .on_press(Message::Raise(d.service.clone()))
+                            .interaction(Interaction::Pointer)
                             .into()
                     }))
                     .spacing(space.md)

--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -31,7 +31,7 @@ async fn is_lua_config() -> bool {
 
 /// Dispatch a command using the old hyprlang socket protocol.
 /// Works on all Hyprland versions but is broken on 0.55+ with Lua config.
-fn dispatch_hyprlang(cmd: CompositorCommand) -> Result<()> {
+async fn dispatch_hyprlang(cmd: CompositorCommand) -> Result<()> {
     match cmd {
         CompositorCommand::FocusWorkspace(id) => {
             Dispatch::call(DispatchType::Workspace(WorkspaceIdentifierWithSpecial::Id(
@@ -63,6 +63,10 @@ fn dispatch_hyprlang(cmd: CompositorCommand) -> Result<()> {
         }
         CompositorCommand::CustomDispatch(dispatcher, args) => {
             Dispatch::call(DispatchType::Custom(&dispatcher, &args))?;
+        }
+        CompositorCommand::FocusWindowByPid(pid) => {
+            let selector = window_selector_for_pid(pid).await;
+            Dispatch::call(DispatchType::Custom("focuswindow", &selector))?;
         }
     }
     Ok(())
@@ -98,6 +102,12 @@ async fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
         CompositorCommand::CustomDispatch(dispatcher, args) => {
             format!("hl.dispatch(hl.dsp.{dispatcher}({args}))")
         }
+        CompositorCommand::FocusWindowByPid(pid) => {
+            format!(
+                "hl.dispatch(hl.dsp.focus({{ window = \"{}\" }}))",
+                window_selector_for_pid(pid).await
+            )
+        }
     };
     tokio::process::Command::new("hyprctl")
         .args(["eval", &lua])
@@ -106,11 +116,25 @@ async fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
     Ok(())
 }
 
+async fn window_selector_for_pid(pid: u32) -> String {
+    Clients::get_async()
+        .await
+        .ok()
+        .and_then(|clients| {
+            clients
+                .iter()
+                .filter(|c| u32::try_from(c.pid).is_ok_and(|p| p == pid))
+                .min_by_key(|c| c.focus_history_id)
+                .map(|c| format!("address:{}", c.address))
+        })
+        .unwrap_or_else(|| format!("pid:{pid}"))
+}
+
 pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
     if is_lua_config().await {
         dispatch_lua(cmd).await
     } else {
-        dispatch_hyprlang(cmd)
+        dispatch_hyprlang(cmd).await
     }
 }
 

--- a/src/services/compositor/mod.rs
+++ b/src/services/compositor/mod.rs
@@ -167,6 +167,13 @@ impl Service for CompositorService {
     }
 }
 
+pub async fn focus_window_by_pid(pid: u32) -> Result<(), String> {
+    let backend =
+        detect_backend().ok_or_else(|| "No supported compositor backend found".to_string())?;
+
+    execute_command(backend, CompositorCommand::FocusWindowByPid(pid)).await
+}
+
 async fn execute_command(
     backend: CompositorChoice,
     command: CompositorCommand,

--- a/src/services/compositor/niri.rs
+++ b/src/services/compositor/niri.rs
@@ -6,7 +6,7 @@ use crate::services::ServiceEvent;
 use anyhow::{Context, Result, anyhow};
 use itertools::Itertools;
 use niri_ipc::{
-    Action, Event, Reply, Request, WorkspaceReferenceArg,
+    Action, Event, Reply, Request, Response, WorkspaceReferenceArg,
     state::{EventStreamState, EventStreamStatePart},
 };
 use std::{collections::HashMap, env, os::unix::net::UnixStream as StdUnixStream};
@@ -57,6 +57,10 @@ pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
                 return Err(anyhow!("Unknown custom dispatch: {}", action));
             }
         }
+
+        CompositorCommand::FocusWindowByPid(pid) => Action::FocusWindow {
+            id: window_id_for_pid(pid).await?,
+        },
     };
 
     send_command_request(&mut stream, Request::Action(action)).await?;
@@ -146,6 +150,10 @@ async fn connect() -> Result<UnixStream> {
 }
 
 async fn send_command_request(stream: &mut UnixStream, request: Request) -> Result<()> {
+    send_request(stream, request).await.map(|_| ())
+}
+
+async fn send_request(stream: &mut UnixStream, request: Request) -> Result<Response> {
     let mut json = serde_json::to_string(&request)?;
     json.push('\n');
     stream.write_all(json.as_bytes()).await?;
@@ -156,7 +164,27 @@ async fn send_command_request(stream: &mut UnixStream, request: Request) -> Resu
     reader.read_line(&mut response_line).await?;
 
     let reply: Reply = serde_json::from_str(&response_line)?;
-    reply.map_err(|e| anyhow!("Niri error: {}", e)).map(|_| ())
+    reply.map_err(|e| anyhow!("Niri error: {}", e))
+}
+
+async fn window_id_for_pid(pid: u32) -> Result<u64> {
+    let mut stream = connect().await?;
+
+    let Response::Windows(windows) = send_request(&mut stream, Request::Windows).await? else {
+        return Err(anyhow!("Unexpected reply to a Niri windows request"));
+    };
+
+    let owned: Vec<_> = windows
+        .iter()
+        .filter(|w| w.pid.is_some_and(|p| i64::from(p) == i64::from(pid)))
+        .collect();
+
+    owned
+        .iter()
+        .find(|w| w.is_focused)
+        .or(owned.first())
+        .map(|w| w.id)
+        .ok_or_else(|| anyhow!("No window found for pid {pid}"))
 }
 
 fn map_state(niri: &EventStreamState) -> CompositorState {

--- a/src/services/compositor/types.rs
+++ b/src/services/compositor/types.rs
@@ -136,4 +136,5 @@ pub enum CompositorCommand {
     ScrollWorkspace(i32),           // +1 or -1
     CustomDispatch(String, String), // For "vdesk"
     NextLayout,
+    FocusWindowByPid(u32),
 }

--- a/src/services/mpris/dbus.rs
+++ b/src/services/mpris/dbus.rs
@@ -2,6 +2,14 @@ use std::collections::HashMap;
 use zbus::{Result, proxy, zvariant::OwnedValue};
 
 #[proxy(
+    interface = "org.mpris.MediaPlayer2",
+    default_path = "/org/mpris/MediaPlayer2"
+)]
+pub trait MprisRoot {
+    fn raise(&self) -> Result<()>;
+}
+
+#[proxy(
     interface = "org.mpris.MediaPlayer2.Player",
     default_path = "/org/mpris/MediaPlayer2"
 )]

--- a/src/services/mpris/mod.rs
+++ b/src/services/mpris/mod.rs
@@ -1,5 +1,5 @@
-use super::{ReadOnlyService, Service, ServiceEvent};
-use dbus::MprisPlayerProxy;
+use super::{ReadOnlyService, Service, ServiceEvent, compositor};
+use dbus::{MprisPlayerProxy, MprisRootProxy};
 use iced::{
     Subscription,
     core::Bytes,
@@ -218,6 +218,38 @@ impl MprisPlayerService {
             })
             .collect();
         Ok(names)
+    }
+
+    async fn player_pid(conn: &zbus::Connection, service_name: &str) -> anyhow::Result<u32> {
+        let dbus = DBusProxy::new(conn).await?;
+        let pid = dbus
+            .get_connection_unix_process_id(service_name.try_into()?)
+            .await?;
+
+        Ok(pid)
+    }
+
+    async fn focus_player(conn: &zbus::Connection, service_name: &str) {
+        match Self::player_pid(conn, service_name).await {
+            Ok(pid) => match compositor::focus_window_by_pid(pid).await {
+                Ok(()) => {
+                    debug!("Focused {service_name} (pid {pid}) through the compositor");
+                    return;
+                }
+                Err(e) => debug!("Could not focus {service_name} via the compositor: {e}"),
+            },
+            Err(e) => debug!("Could not resolve the pid of {service_name}: {e}"),
+        }
+
+        match MprisRootProxy::new(conn, service_name.to_string()).await {
+            Ok(proxy) => {
+                let _ = proxy
+                    .raise()
+                    .await
+                    .inspect_err(|e| error!("Raise command error: {e}"));
+            }
+            Err(e) => error!("Failed to create the MPRIS root proxy for {service_name}: {e}"),
+        }
     }
 
     async fn create_proxies(
@@ -526,6 +558,7 @@ pub enum PlayerCommand {
     PlayPause,
     Next,
     Volume(f64),
+    Raise,
 }
 
 impl Service for MprisPlayerService {
@@ -538,6 +571,7 @@ impl Service for MprisPlayerService {
 
             if let Some(s) = s {
                 let mpris_player_proxy = s.proxy.clone();
+                let service_name = s.service.clone();
                 let conn = self.conn.clone();
                 iced::Task::perform(
                     async move {
@@ -565,6 +599,9 @@ impl Service for MprisPlayerService {
                                     .set_volume(v / 100.0)
                                     .await
                                     .inspect_err(|e| error!("Set volume command error: {e}"));
+                            }
+                            PlayerCommand::Raise => {
+                                Self::focus_player(&conn, &service_name).await;
                             }
                         }
                         Event::MetadataChanged(Self::get_mpris_player_data(&conn, &names).await)

--- a/website/docs/configuration/modules/media_player.md
+++ b/website/docs/configuration/modules/media_player.md
@@ -91,6 +91,17 @@ The menu shows all active media players with playback controls:
 - Previous, Play/Pause, and Next buttons
 - Volume slider (if supported by the player)
 
+Clicking a player card (anywhere outside the controls) focuses that player's
+window and closes the menu. When a player owns several windows the most
+recently focused one is picked, so clicking a browser card brings back the
+window you last watched the video in, not the tab, though: MPRIS carries no
+tab information, so a background tab stays in the background.
+
+Focusing goes through the compositor, which means it works on Hyprland and
+Niri. On other compositors ashell falls back to the MPRIS `Raise()` method,
+which most Wayland compositors ignore because a client cannot activate itself
+without an activation token.
+
 ## Example
 
 ```toml


### PR DESCRIPTION
Add a `Raise` command to the media player module that focuses the player's window through the compositor. 
Clicking a player card now triggers this behavior, selecting the most recently focused window when multiple windows exist for the same player.

`org.mpris.MediaPlayer2.Raise()` is the MPRIS method intended to bring the player's UI to the front, and the players tested here advertise `CanRaise = true`. 
On Wayland, successfully handling `Raise()` still requires the player to get its own surface activated: normal activation is mediated by `xdg-activation-v1` and an activation token, and the compositor decides whether to honor it. 
The MPRIS spec itself notes that `Raise()` may be prevented by the window manager even when `CanRaise` is true.

In the tested cases the D-Bus call therefore succeeds while the player's window stays unfocused:

```console
$ hyprctl activewindow -j | jq -r .class
firefox
$ busctl --user call org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2 \
        org.mpris.MediaPlayer2 Raise
$ hyprctl activewindow -j | jq -r .class
firefox     # Spotify never came up
```


Since the tested players do not reliably get their windows activated this way, asking
the compositor directly is the dependable alternative. `FocusWindowByPid` is therefore
implemented for the Hyprland and Niri backends, and MPRIS `Raise()` is kept as the
fallback, for backends that cannot focus by pid (MangoWC, generic Wayland) and for
clients where self-activation does work, such as X11/XWayland windows.

Clicking a card also closes the menu, so it does not sit on top of the window that
was just focused.

**Caveat**

This focuses the player's *window*, not a browser tab. MPRIS reports that a player is playing but carries no tab information, so with

```text
Firefox window A -> YouTube tab
Firefox window B -> Gmail tab
Firefox PiP window
```

resolving pid to window gets you to the application/window level, not to the tab that owns the media. 
A video playing in a background tab stays in the background.

**Testing**
- Verified on Hyprland (`configProvider: lua`) with Firefox and Spotify: clicking a
  card focuses the player, and with two Firefox windows open it lands on the one that
  was last used rather than on the picture-in-picture pop-up.

@MalpenZibo are you still using Niri ? 
- The Niri path is written against `niri-ipc` 26.4 but is untested on a live Niri
  session.
