### PR TITLE
note special workspaces are Hyprland-only

### DIFF
--- a/website/docs/configuration/modules/workspaces.md
+++ b/website/docs/configuration/modules/workspaces.md
@@ -50,6 +50,9 @@ group_by_monitor = true
 If you would like to make the special workspaces invisible, set the `disable_special_workspaces` to `true`.
 By default, special workspaces will be visible.
 
+Special workspaces are currently a Hyprland-only concept. On other compositors
+there are none to show, so this option has no effect.
+
 ## Workspace Filling And Maximum Workspaces
 
 You can also enable or disable filling the workspace  


### PR DESCRIPTION

Add clarification that special workspaces are a Hyprland-only concept,
and that the `disable_special_workspaces` option has no effect on other
compositors since they do not implement this feature.