### PR TITLE
 perf: reduce unnecessary service and icon cache overhead

### DIFF
--- a/src/services/brightness.rs
+++ b/src/services/brightness.rs
@@ -106,10 +106,7 @@ impl BrightnessService {
             .match_subsystem("backlight")?
             .listen()?;
 
-        Ok(AsyncFd::with_interest(
-            socket,
-            Interest::READABLE | Interest::WRITABLE,
-        )?)
+        Ok(AsyncFd::with_interest(socket, Interest::READABLE)?)
     }
 
     fn backlight_enumerate() -> anyhow::Result<Vec<udev::Device>> {
@@ -175,7 +172,7 @@ impl BrightnessService {
                         loop {
                             debug!("Waiting for brightness events");
 
-                            match socket.writable_mut().await {
+                            match socket.readable_mut().await {
                                 Ok(mut socket) => {
                                     for evt in socket.get_inner().iter() {
                                         debug!("{:?}: {:?}", evt.event_type(), evt.device());
@@ -215,7 +212,7 @@ impl BrightnessService {
                                     socket.clear_ready();
                                 }
                                 _ => {
-                                    warn!("Failed to get writable socket");
+                                    warn!("Failed to get readable socket");
                                     break;
                                 }
                             }

--- a/src/services/privacy.rs
+++ b/src/services/privacy.rs
@@ -9,7 +9,9 @@ use iced::{
 use inotify::{EventMask, Inotify, WatchMask};
 use log::{debug, error, info, warn};
 use pipewire::{context::ContextBox, main_loop::MainLoopBox};
-use std::{any::TypeId, fs, ops::Deref, path::Path, thread};
+use std::{
+    any::TypeId, cell::RefCell, collections::HashSet, fs, ops::Deref, path::Path, rc::Rc, thread,
+};
 use tokio::sync::mpsc::{UnboundedReceiver, unbounded_channel};
 
 const WEBCAM_DEVICE_PATH: &str = "/dev/video0";
@@ -92,10 +94,13 @@ impl PrivacyService {
             let core = unwrap_or_send_err!(context.connect(None), boot_tx);
             let registry = unwrap_or_send_err!(core.get_registry(), boot_tx);
 
+            let tracked_ids: Rc<RefCell<HashSet<u32>>> = Rc::new(RefCell::new(HashSet::new()));
+
             let _listener = registry
                 .add_listener_local()
                 .global({
                     let tx = tx.clone();
+                    let tracked_ids = Rc::clone(&tracked_ids);
                     move |global| {
                         if let Some(props) = global.props
                             && let Some(media) = props.get("media.class").filter(|v| {
@@ -103,6 +108,7 @@ impl PrivacyService {
                             })
                         {
                             debug!("New global: {global:?}");
+                            tracked_ids.borrow_mut().insert(global.id);
                             let _ = tx.send(PrivacyEvent::AddNode(ApplicationNode {
                                 id: global.id,
                                 media: if media == "Stream/Input/Video" {
@@ -117,8 +123,10 @@ impl PrivacyService {
                 .global_remove({
                     let tx = tx.clone();
                     move |id| {
-                        debug!("Remove global: {id}");
-                        let _ = tx.send(PrivacyEvent::RemoveNode(id));
+                        if tracked_ids.borrow_mut().remove(&id) {
+                            debug!("Remove tracked global: {id}");
+                            let _ = tx.send(PrivacyEvent::RemoveNode(id));
+                        }
                     }
                 })
                 .register();

--- a/src/services/xdg_icons.rs
+++ b/src/services/xdg_icons.rs
@@ -17,21 +17,34 @@ use std::sync::RwLock;
 
 const MAX_SIMILAR_ICON_CANDIDATES: usize = 5;
 
+struct IconEntry {
+    name: Box<str>,
+    normalized: Option<Box<str>>,
+}
+
+impl IconEntry {
+    fn normalized(&self) -> &str {
+        self.normalized.as_deref().unwrap_or(&self.name)
+    }
+}
+
 static ICON_CACHE: LazyLock<RwLock<HashMap<String, Option<XdgIcon>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
-static SYSTEM_ICON_ENTRIES: LazyLock<Vec<(Cow<'static, str>, Cow<'static, str>)>> =
-    LazyLock::new(|| {
-        let names = load_system_icon_names();
-        names
-            .iter()
-            .filter_map(|name| {
-                let name_str = name.to_str()?;
-                let normalized = normalize_icon_name(name_str);
-                let normalized_cow = Cow::Owned(normalized.into_owned());
-                Some((Cow::Owned(name_str.to_string()), normalized_cow))
+static SYSTEM_ICON_ENTRIES: LazyLock<Vec<IconEntry>> = LazyLock::new(|| {
+    load_system_icon_names()
+        .iter()
+        .filter_map(|name| {
+            let name_str = name.to_str()?;
+            Some(IconEntry {
+                name: name_str.into(),
+                normalized: match normalize_icon_name(name_str) {
+                    Cow::Borrowed(_) => None,
+                    Cow::Owned(normalized) => Some(normalized.into_boxed_str()),
+                },
             })
-            .collect()
-    });
+        })
+        .collect()
+});
 static DESKTOP_ICON_INDEX: LazyLock<HashMap<String, String>> =
     LazyLock::new(build_desktop_icon_index);
 
@@ -158,18 +171,17 @@ fn find_similar_icon(icon_name: &str) -> Option<Vec<Cow<'static, str>>> {
     let normalized_no_separators = strip_icon_separators(normalized.as_ref());
     let mut matches: Vec<Cow<'static, str>> = Vec::with_capacity(MAX_SIMILAR_ICON_CANDIDATES);
 
-    for (candidate_name, candidate_normalized) in SYSTEM_ICON_ENTRIES.iter() {
-        if candidate_normalized.as_ref() == normalized.as_ref() {
+    for candidate in SYSTEM_ICON_ENTRIES.iter() {
+        let candidate_normalized = candidate.normalized();
+        if candidate_normalized == normalized.as_ref() {
             continue;
         }
 
-        if candidate_normalized.as_ref().contains(normalized.as_ref())
-            || normalized.as_ref().contains(candidate_normalized.as_ref())
-            || candidate_normalized
-                .as_ref()
-                .contains(normalized_no_separators.as_ref())
+        if candidate_normalized.contains(normalized.as_ref())
+            || normalized.as_ref().contains(candidate_normalized)
+            || candidate_normalized.contains(normalized_no_separators.as_ref())
         {
-            matches.push(Cow::Borrowed(candidate_name.as_ref()));
+            matches.push(Cow::Borrowed(&candidate.name));
             if matches.len() >= MAX_SIMILAR_ICON_CANDIDATES {
                 break;
             }
@@ -216,17 +228,17 @@ fn prefix_match_icon(icon_name: &str) -> Option<Cow<'static, str>> {
 
     if let Some(exact) = SYSTEM_ICON_ENTRIES
         .iter()
-        .find(|(_, norm)| norm.as_ref() == normalized.as_ref())
+        .find(|entry| entry.normalized() == normalized.as_ref())
     {
-        return Some(Cow::Borrowed(exact.0.as_ref()));
+        return Some(Cow::Borrowed(&exact.name));
     }
 
     let mut candidates: Vec<_> = SYSTEM_ICON_ENTRIES.iter().collect();
     for (idx, ch) in normalized.chars().enumerate() {
-        candidates.retain(|(_, name)| name.chars().nth(idx) == Some(ch));
+        candidates.retain(|entry| entry.normalized().chars().nth(idx) == Some(ch));
 
         if candidates.len() == 1 {
-            return Some(Cow::Borrowed(candidates[0].0.as_ref()));
+            return Some(Cow::Borrowed(&candidates[0].name));
         }
 
         if candidates.is_empty() {
@@ -234,9 +246,7 @@ fn prefix_match_icon(icon_name: &str) -> Option<Cow<'static, str>> {
         }
     }
 
-    candidates
-        .first()
-        .map(|(name, _)| Cow::Borrowed(name.as_ref()))
+    candidates.first().map(|entry| Cow::Borrowed(&*entry.name))
 }
 
 fn find_desktop_icon(icon_name: &str) -> Option<PathBuf> {

--- a/src/services/xdg_icons.rs
+++ b/src/services/xdg_icons.rs
@@ -19,19 +19,15 @@ const MAX_SIMILAR_ICON_CANDIDATES: usize = 5;
 
 static ICON_CACHE: LazyLock<RwLock<HashMap<String, Option<XdgIcon>>>> =
     LazyLock::new(|| RwLock::new(HashMap::new()));
-static SYSTEM_ICON_NAMES: LazyLock<BTreeSet<OsString>> = LazyLock::new(load_system_icon_names);
 static SYSTEM_ICON_ENTRIES: LazyLock<Vec<(Cow<'static, str>, Cow<'static, str>)>> =
     LazyLock::new(|| {
-        SYSTEM_ICON_NAMES
+        let names = load_system_icon_names();
+        names
             .iter()
             .filter_map(|name| {
                 let name_str = name.to_str()?;
                 let normalized = normalize_icon_name(name_str);
-                let normalized_cow = if normalized.as_ref() == name_str {
-                    Cow::Borrowed(name_str)
-                } else {
-                    Cow::Owned(normalized.into_owned())
-                };
+                let normalized_cow = Cow::Owned(normalized.into_owned());
                 Some((Cow::Owned(name_str.to_string()), normalized_cow))
             })
             .collect()
@@ -51,7 +47,6 @@ pub fn fallback_icon() -> XdgIcon {
 }
 
 fn warm_cache() {
-    LazyLock::force(&SYSTEM_ICON_NAMES);
     LazyLock::force(&SYSTEM_ICON_ENTRIES);
     LazyLock::force(&DESKTOP_ICON_INDEX);
 }


### PR DESCRIPTION
This PR contains three small, independent resource-usage cleanups:

**Brightness**
- Listen for `READABLE` readiness on the udev monitor socket instead of `WRITABLE`.
- The socket is consumed as a read-side event source, so this matches the actual I/O direction.

**Privacy**
- Track PipeWire globals that were added as privacy streams.
- Only emit `PrivacyEvent::RemoveNode` for IDs that were previously tracked as `Stream/Input/Audio` or `Stream/Input/Video`.

**XDG icons**
- Stop retaining `SYSTEM_ICON_NAMES` for the lifetime of the process.
- Build `SYSTEM_ICON_ENTRIES` from a temporary `BTreeSet` and release it after the index is constructed.
- Store a separate normalized icon name only when normalization changes the original value, avoiding duplicate string storage for already-normalized names.

## Why

These changes remove unnecessary work and retained data without changing intended user-visible behavior.

For PipeWire, `global_remove` is emitted for all kinds of graph objects. Previously every removal was forwarded through the privacy service and iced update loop, even when the object had never been tracked as a privacy stream.

For XDG icons, the system icon-name set was only needed while building the search entries but remained resident afterward. The entry representation also no longer stores a duplicate normalized string when the original name is already normalized.

The brightness change is mainly a correctness/clarity fix. The existing `clear_ready()` already prevented a busy loop, but the service was waiting for write readiness while consuming read events.

## Measurements

Tested on a Ryzen 7 7735HS / Hyprland / Wayland system using a release build.

### Privacy

```text
global_remove callbacks:        6
RemoveNode events before:       6
RemoveNode events after:        0
````

This removes 100% of unrelated privacy updates for that workload.

### XDG icons

System icon scan found:

```text
unique icon names:              9,689
retained SYSTEM_ICON_NAMES:     ~766 KiB
estimated net retained saving:  ~378–766 KiB
```

Exact RSS change depends on allocator page retention. The additional allocation reduction from the compact icon-entry representation was not separately measured.

### Brightness

A udev readiness probe showed:

```text
current path:  1 initial WRITABLE wakeup
patched path:  0 READABLE wakeups
```

No measurable idle CPU difference was observed. This change makes readiness semantics match actual socket usage.

### Validation

* `cargo fmt`
* `cargo check`
* `cargo clippy --all-features -- -D warnings`

No intended user-visible behavior changes.