### PR TITLE
feat(config): separate color palette configuration into colors.tomlFeat/separate colors config

### DIFF
--- a/docs/src/core/config-system.md
+++ b/docs/src/core/config-system.md
@@ -2,14 +2,15 @@
 
 The configuration system is defined in `src/config.rs`. ashell uses a TOML file for all user-facing settings.
 
-## Config File Location
+## Config File Locations
 
-Default path: `~/.config/ashell/config.toml`
+- General settings: `~/.config/ashell/config.toml`
+- Color palette: `~/.config/ashell/colors.toml`
 
-Override with the `--config-path` CLI flag:
+Override with the `--config-path` and `--colors-path` CLI flags:
 
 ```bash
-ashell --config-path /path/to/config.toml
+ashell --config-path /path/to/config.toml --colors-path /path/to/colors.toml
 ```
 
 ## The Config Struct
@@ -135,11 +136,10 @@ margin = "sm"              # none|xxs..xxl, CSS margin shorthand
 default = 0.9
 bar = 1.0
 
-[appearance.background]
-base = "#1e1e2e"
-
 [appearance.menu]
 backdrop = 0.3
 ```
+
+Color palette options (`background_color`, `primary_color`, etc.) are configured separately in `colors.toml`.
 
 See the [Configuration Reference](../reference/config-reference.md) for a complete list of all configuration options.

--- a/docs/src/reference/config-reference.md
+++ b/docs/src/reference/config-reference.md
@@ -55,23 +55,6 @@ radius = "none"                 # none|sm|md|lg|xl, CSS border-radius shorthand 
 margin = "none"                 # none|xxs..xxl, CSS margin shorthand
 ```
 
-### Colors
-
-```toml
-# Simple hex color
-[appearance]
-background = "#1e1e2e"
-
-# Complete color with variants
-[appearance.primary]
-base = "#cba6f7"
-strong = "#dbbcff"
-weak = "#a385d8"
-text = "#1e1e2e"
-```
-
-Available color fields: `background`, `text`, `primary`, `secondary`, `success`, `danger`.
-
 ### Menu Appearance
 
 ```toml
@@ -79,13 +62,34 @@ Available color fields: `background`, `text`, `primary`, `secondary`, `success`,
 backdrop = 0.3                  # darkening drawn behind an open menu
 ```
 
-### Workspace Colors
+## Colors Configuration (`colors.toml`)
+
+Colors are configured separately in `~/.config/ashell/colors.toml` (or via `--colors-path`).
 
 ```toml
-[appearance]
+# Simple hex color
+primary_color = "#cba6f7"
+success_color = "#a6e3a1"
+warning_color = "#f9e2af"
+danger_color = "#f38ba8"
+text_color = "#cdd6f4"
 workspace_colors = ["#cba6f7", "#f38ba8", "#a6e3a1", "#89b4fa"]
 special_workspace_colors = ["#fab387"]
+
+# Complete color with variants
+[primary_color]
+base = "#cba6f7"
+strong = "#dbbcff"
+weak = "#a385d8"
+text = "#1e1e2e"
+
+[background_color]
+base = "#1e1e2e"
+weak = "#313244"
+strong = "#45475a"
 ```
+
+Available color fields: `background_color`, `text_color`, `primary_color`, `success_color`, `warning_color`, `danger_color`, `workspace_colors`, `special_workspace_colors`.
 
 ## Updates Module
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,6 +53,7 @@ pub struct GeneralConfig {
 
 pub struct App {
     config_path: PathBuf,
+    colors_path: PathBuf,
     logger: LoggerHandle,
     pub general_config: GeneralConfig,
     pub outputs: Outputs,
@@ -80,7 +81,7 @@ pub use message::Message;
 
 impl App {
     pub fn new(
-        (logger, config, config_path): (LoggerHandle, Config, PathBuf),
+        (logger, config, config_path, colors_path): (LoggerHandle, Config, PathBuf, PathBuf),
     ) -> impl FnOnce() -> (Self, Task<Message>) {
         move || {
             let mut outputs = Outputs::new(
@@ -118,6 +119,7 @@ impl App {
             (
                 App {
                     config_path,
+                    colors_path,
                     logger,
                     general_config: GeneralConfig {
                         outputs: config.outputs,
@@ -732,7 +734,7 @@ impl App {
             Subscription::batch(self.modules_subscriptions(&self.general_config.modules.left)),
             Subscription::batch(self.modules_subscriptions(&self.general_config.modules.center)),
             Subscription::batch(self.modules_subscriptions(&self.general_config.modules.right)),
-            config::subscription(&self.config_path),
+            config::subscription(&self.config_path, &self.colors_path),
             crate::services::logind::LogindService::subscribe().map(|event| match event {
                 crate::services::ServiceEvent::Update(_) => Message::ResumeFromSleep,
                 _ => Message::None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -1220,6 +1220,51 @@ impl Default for PaletteConfig {
     }
 }
 
+/// Legacy color fields that were previously part of `[appearance]` in `config.toml`.
+/// Kept for backward compatibility: when no `colors.toml` is present these values
+/// are used as a fallback before falling back to built-in defaults.
+#[derive(Deserialize, Clone, Debug, Default)]
+pub struct LegacyColors {
+    pub background_color: Option<BackgroundAppearanceColor>,
+    pub primary_color: Option<AppearanceColor>,
+    pub success_color: Option<AppearanceColor>,
+    pub warning_color: Option<AppearanceColor>,
+    pub danger_color: Option<AppearanceColor>,
+    pub text_color: Option<AppearanceColor>,
+    pub workspace_colors: Option<Vec<AppearanceColor>>,
+    pub special_workspace_colors: Option<Vec<AppearanceColor>>,
+}
+
+impl LegacyColors {
+    /// Returns `true` if at least one color field was explicitly set.
+    pub fn has_any(&self) -> bool {
+        self.background_color.is_some()
+            || self.primary_color.is_some()
+            || self.success_color.is_some()
+            || self.warning_color.is_some()
+            || self.danger_color.is_some()
+            || self.text_color.is_some()
+            || self.workspace_colors.is_some()
+            || self.special_workspace_colors.is_some()
+    }
+
+    /// Merge into a `PaletteConfig`, using `defaults` for any unset fields.
+    pub fn into_palette(self, defaults: PaletteConfig) -> PaletteConfig {
+        PaletteConfig {
+            background_color: self.background_color.unwrap_or(defaults.background_color),
+            primary_color: self.primary_color.unwrap_or(defaults.primary_color),
+            success_color: self.success_color.unwrap_or(defaults.success_color),
+            warning_color: self.warning_color.unwrap_or(defaults.warning_color),
+            danger_color: self.danger_color.unwrap_or(defaults.danger_color),
+            text_color: self.text_color.unwrap_or(defaults.text_color),
+            workspace_colors: self.workspace_colors.unwrap_or(defaults.workspace_colors),
+            special_workspace_colors: self
+                .special_workspace_colors
+                .or(defaults.special_workspace_colors),
+        }
+    }
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct Appearance {
@@ -1234,6 +1279,10 @@ pub struct Appearance {
     pub blur: BlurMode,
     #[serde(skip)]
     pub palette: PaletteConfig,
+    /// Legacy color fields from `config.toml` — used as fallback when
+    /// `colors.toml` is absent. Flattened so serde reads them transparently.
+    #[serde(flatten)]
+    pub legacy_colors: LegacyColors,
 }
 
 /// When to ask the compositor for background blur.
@@ -1304,6 +1353,7 @@ impl Default for Appearance {
             menu: MenuAppearance::default(),
             blur: BlurMode::default(),
             palette: PaletteConfig::default(),
+            legacy_colors: LegacyColors::default(),
         }
     }
 }
@@ -1671,6 +1721,10 @@ pub fn load_config_and_colors(config_path: &Path, colors_path: &Path) -> Config 
     let mut config = read_config(config_path).unwrap_or_default();
     if colors_path.exists() {
         config.appearance.palette = read_colors(colors_path).unwrap_or_default();
+    } else if config.appearance.legacy_colors.has_any() {
+        // Backward compatibility: fall back to color fields set in config.toml
+        let legacy = std::mem::take(&mut config.appearance.legacy_colors);
+        config.appearance.palette = legacy.into_palette(PaletteConfig::default());
     }
     config
 }
@@ -2016,6 +2070,76 @@ mod tests {
         assert_eq!(
             config.appearance.palette.primary_color.get_base(),
             hex_to_color(HexColor::rgb(0, 255, 170))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_load_config_legacy_colors_fallback() {
+        let dir = std::env::temp_dir().join(format!("ashell_test_legacy_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let config_file = dir.join("config.toml");
+        let non_existent_colors_file = dir.join("non_existent_colors.toml");
+
+        std::fs::write(
+            &config_file,
+            r##"
+            [appearance]
+            scale_factor = 1.2
+            primary_color = "#112233"
+            success_color = "#445566"
+        "##,
+        )
+        .unwrap();
+
+        let config = load_config_and_colors(&config_file, &non_existent_colors_file);
+        assert_eq!(config.appearance.scale_factor, 1.2);
+        assert_eq!(
+            config.appearance.palette.primary_color.get_base(),
+            hex_to_color(HexColor::rgb(0x11, 0x22, 0x33))
+        );
+        assert_eq!(
+            config.appearance.palette.success_color.get_base(),
+            hex_to_color(HexColor::rgb(0x44, 0x55, 0x66))
+        );
+        // Default color for unset fields
+        assert_eq!(
+            config.appearance.palette.danger_color.get_base(),
+            hex_to_color(HexColor::rgb(247, 118, 142))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_colors_toml_takes_precedence_over_legacy_config() {
+        let dir = std::env::temp_dir().join(format!("ashell_test_prec_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let config_file = dir.join("config.toml");
+        let colors_file = dir.join("colors.toml");
+
+        std::fs::write(
+            &config_file,
+            r##"
+            [appearance]
+            primary_color = "#111111"
+        "##,
+        )
+        .unwrap();
+
+        std::fs::write(
+            &colors_file,
+            r##"
+            primary_color = "#999999"
+        "##,
+        )
+        .unwrap();
+
+        let config = load_config_and_colors(&config_file, &colors_file);
+        assert_eq!(
+            config.appearance.palette.primary_color.get_base(),
+            hex_to_color(HexColor::rgb(0x99, 0x99, 0x99))
         );
 
         let _ = std::fs::remove_dir_all(&dir);

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ use std::{collections::HashMap, error::Error, ops::Deref, path::Path};
 use tokio::time::sleep;
 
 pub const DEFAULT_CONFIG_FILE_PATH: &str = "~/.config/ashell/config.toml";
+pub const DEFAULT_COLORS_FILE_PATH: &str = "~/.config/ashell/colors.toml";
 
 #[derive(Deserialize, Clone, Debug, Default)]
 #[serde(rename_all = "lowercase")]
@@ -837,7 +838,7 @@ fn hex_to_pair(hex: HexColor, text: Option<HexColor>, text_fallback: Color) -> p
     )
 }
 
-#[derive(Deserialize, Clone, Copy, Debug)]
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum AppearanceColor {
     Simple(HexColor),
@@ -883,7 +884,7 @@ impl AppearanceColor {
     }
 }
 
-#[derive(Deserialize, Clone, Copy, Debug)]
+#[derive(Deserialize, Clone, Copy, Debug, PartialEq, Eq)]
 #[serde(untagged)]
 pub enum BackgroundAppearanceColor {
     Simple(HexColor),
@@ -1178,6 +1179,47 @@ impl<'de> Deserialize<'de> for Opacity {
     }
 }
 
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+#[serde(default)]
+pub struct PaletteConfig {
+    pub background_color: BackgroundAppearanceColor,
+    pub primary_color: AppearanceColor,
+    pub success_color: AppearanceColor,
+    pub warning_color: AppearanceColor,
+    pub danger_color: AppearanceColor,
+    pub text_color: AppearanceColor,
+    pub workspace_colors: Vec<AppearanceColor>,
+    pub special_workspace_colors: Option<Vec<AppearanceColor>>,
+}
+
+impl Default for PaletteConfig {
+    fn default() -> Self {
+        Self {
+            background_color: BackgroundAppearanceColor::Complete {
+                base: HexColor::rgb(26, 27, 38),
+                weakest: None,
+                weaker: None,
+                weak: Some(HexColor::rgb(36, 39, 58)),
+                neutral: None,
+                strong: Some(HexColor::rgb(65, 72, 104)),
+                stronger: None,
+                strongest: None,
+                text: None,
+            },
+            primary_color: AppearanceColor::Simple(PRIMARY),
+            success_color: AppearanceColor::Simple(HexColor::rgb(158, 206, 106)),
+            warning_color: AppearanceColor::Simple(HexColor::rgb(224, 175, 104)),
+            danger_color: AppearanceColor::Simple(HexColor::rgb(247, 118, 142)),
+            text_color: AppearanceColor::Simple(HexColor::rgb(169, 177, 214)),
+            workspace_colors: vec![
+                AppearanceColor::Simple(PRIMARY),
+                AppearanceColor::Simple(HexColor::rgb(158, 206, 106)),
+            ],
+            special_workspace_colors: None,
+        }
+    }
+}
+
 #[derive(Deserialize, Clone, Debug)]
 #[serde(default)]
 pub struct Appearance {
@@ -1187,17 +1229,11 @@ pub struct Appearance {
     pub opacity: Opacity,
     pub bar: BarAppearance,
     pub menu: MenuAppearance,
-    pub background_color: BackgroundAppearanceColor,
-    pub primary_color: AppearanceColor,
-    pub success_color: AppearanceColor,
-    pub warning_color: AppearanceColor,
-    pub danger_color: AppearanceColor,
-    pub text_color: AppearanceColor,
-    pub workspace_colors: Vec<AppearanceColor>,
-    pub special_workspace_colors: Option<Vec<AppearanceColor>>,
     /// Blur the wallpaper behind ashell's translucent surfaces via
     /// `ext-background-effect-v1`. No-op where the protocol is unsupported.
     pub blur: BlurMode,
+    #[serde(skip)]
+    pub palette: PaletteConfig,
 }
 
 /// When to ask the compositor for background blur.
@@ -1266,28 +1302,8 @@ impl Default for Appearance {
             opacity: Opacity::default(),
             bar: BarAppearance::default(),
             menu: MenuAppearance::default(),
-            background_color: BackgroundAppearanceColor::Complete {
-                base: HexColor::rgb(26, 27, 38),
-                weakest: None,
-                weaker: None,
-                weak: Some(HexColor::rgb(36, 39, 58)),
-                neutral: None,
-                strong: Some(HexColor::rgb(65, 72, 104)),
-                stronger: None,
-                strongest: None,
-                text: None,
-            },
-            primary_color: AppearanceColor::Simple(PRIMARY),
-            success_color: AppearanceColor::Simple(HexColor::rgb(158, 206, 106)),
-            warning_color: AppearanceColor::Simple(HexColor::rgb(224, 175, 104)),
-            danger_color: AppearanceColor::Simple(HexColor::rgb(247, 118, 142)),
-            text_color: AppearanceColor::Simple(HexColor::rgb(169, 177, 214)),
-            workspace_colors: vec![
-                AppearanceColor::Simple(PRIMARY),
-                AppearanceColor::Simple(HexColor::rgb(158, 206, 106)),
-            ],
-            special_workspace_colors: None,
             blur: BlurMode::default(),
+            palette: PaletteConfig::default(),
         }
     }
 }
@@ -1576,9 +1592,95 @@ fn resolve_config_path(path: Option<&Path>) -> Result<PathBuf, Box<dyn Error + S
     })
 }
 
-pub fn get_config(path: Option<PathBuf>) -> Result<(Config, PathBuf), Box<dyn Error + Send>> {
-    let explicit = path.is_some();
-    let expanded = resolve_config_path(path.as_deref())?;
+fn resolve_colors_path(
+    path: Option<&Path>,
+    config_path: &Path,
+) -> Result<PathBuf, Box<dyn Error + Send>> {
+    if let Some(p) = path {
+        return expand_path(p.to_path_buf());
+    }
+
+    if let Some(parent) = config_path.parent() {
+        let sibling_colors = parent.join("colors.toml");
+        if sibling_colors.exists() {
+            return Ok(sibling_colors);
+        }
+    }
+
+    expand_path(PathBuf::from(DEFAULT_COLORS_FILE_PATH))
+}
+
+pub fn read_colors(path: &Path) -> Result<PaletteConfig, Box<dyn Error + Send>> {
+    let content =
+        std::fs::read_to_string(path).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;
+
+    info!("Decoding colors file {path:?}");
+
+    let value: toml::Value =
+        toml::from_str(&content).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;
+
+    let (content_to_parse, target_name) = if let Some(table) = value.as_table() {
+        if let Some(palette) = table.get("palette") {
+            (
+                toml::to_string(palette).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?,
+                "nested [palette]",
+            )
+        } else if let Some(colors) = table.get("colors") {
+            (
+                toml::to_string(colors).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?,
+                "nested [colors]",
+            )
+        } else if let Some(appearance) = table.get("appearance") {
+            (
+                toml::to_string(appearance).map_err(|e| Box::new(e) as Box<dyn Error + Send>)?,
+                "nested [appearance]",
+            )
+        } else {
+            (content, "root table")
+        }
+    } else {
+        (content, "root table")
+    };
+
+    debug!("Parsing colors from {target_name}");
+    let de = toml::Deserializer::parse(&content_to_parse)
+        .map_err(|e| Box::new(e) as Box<dyn Error + Send>)?;
+    let mut unknown_fields = Vec::new();
+    let res = serde_ignored::deserialize(de, |field| {
+        unknown_fields.push(field.to_string());
+    });
+
+    match res {
+        Ok(palette) => {
+            for field in &unknown_fields {
+                let msg = format!("Unknown color configuration field ignored: {field}");
+                warn!("{msg}");
+                eprintln!("ashell: warning: {msg}");
+            }
+            info!("Colors file loaded successfully");
+            Ok(palette)
+        }
+        Err(e) => {
+            warn!("Failed to parse colors file: {e}");
+            Err(Box::new(e))
+        }
+    }
+}
+
+pub fn load_config_and_colors(config_path: &Path, colors_path: &Path) -> Config {
+    let mut config = read_config(config_path).unwrap_or_default();
+    if colors_path.exists() {
+        config.appearance.palette = read_colors(colors_path).unwrap_or_default();
+    }
+    config
+}
+
+pub fn get_config(
+    config_path: Option<PathBuf>,
+    colors_path: Option<PathBuf>,
+) -> Result<(Config, PathBuf, PathBuf), Box<dyn Error + Send>> {
+    let explicit = config_path.is_some();
+    let expanded = resolve_config_path(config_path.as_deref())?;
 
     if explicit {
         info!("Config path provided {expanded:?}");
@@ -1601,7 +1703,23 @@ pub fn get_config(path: Option<PathBuf>) -> Result<(Config, PathBuf), Box<dyn Er
         }
     }
 
-    Ok((read_config(&expanded).unwrap_or_default(), expanded))
+    let explicit_colors = colors_path.is_some();
+    let expanded_colors = resolve_colors_path(colors_path.as_deref(), &expanded)?;
+
+    if explicit_colors {
+        info!("Colors path provided {expanded_colors:?}");
+
+        if !expanded_colors.exists() {
+            return Err(Box::new(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                format!("Colors file does not exist: {}", expanded_colors.display()),
+            )));
+        }
+    }
+
+    let config = load_config_and_colors(&expanded, &expanded_colors);
+
+    Ok((config, expanded, expanded_colors))
 }
 
 fn expand_path(path: PathBuf) -> Result<PathBuf, Box<dyn Error + Send>> {
@@ -1649,115 +1767,257 @@ enum Event {
     Removed,
 }
 
-pub fn subscription(path: &Path) -> Subscription<Message> {
-    let path = path.to_path_buf();
+pub fn subscription(config_path: &Path, colors_path: &Path) -> Subscription<Message> {
+    let config_path = config_path.to_path_buf();
+    let colors_path = colors_path.to_path_buf();
 
-    Subscription::run_with(path, |path| {
-        let path = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+    Subscription::run_with((config_path, colors_path), |(config_path, colors_path)| {
+        let config_path =
+            std::fs::canonicalize(config_path).unwrap_or_else(|_| config_path.clone());
+        let colors_path =
+            std::fs::canonicalize(colors_path).unwrap_or_else(|_| colors_path.clone());
         channel(100, async move |mut output| {
-            match (path.parent(), path.file_name(), Inotify::init()) {
-                (Some(folder), Some(file_name), Ok(inotify)) => {
-                    debug!("Watching config file at {path:?}");
+            let config_parent = config_path.parent();
+            let config_name = config_path.file_name().map(|n| n.to_os_string());
+            let colors_parent = colors_path.parent();
+            let colors_name = colors_path.file_name().map(|n| n.to_os_string());
 
-                    let res = inotify.watches().add(
-                        folder,
-                        WatchMask::CREATE | WatchMask::DELETE | WatchMask::MOVE | WatchMask::MODIFY,
-                    );
+            let inotify = match Inotify::init() {
+                Ok(inotify) => inotify,
+                Err(e) => {
+                    error!("Failed to initialize inotify: {e}");
+                    return;
+                }
+            };
 
-                    if let Err(e) = res {
-                        error!("Failed to add watch for {folder:?}: {e}");
-                        return;
-                    }
+            let mut watch_folders = std::collections::HashSet::new();
+            if let Some(folder) = config_parent {
+                watch_folders.insert(folder.to_path_buf());
+            }
+            if let Some(folder) = colors_parent {
+                watch_folders.insert(folder.to_path_buf());
+            }
 
-                    let buffer = [0; 1024];
-                    let stream = inotify.into_event_stream(buffer);
+            if watch_folders.is_empty() {
+                error!("Neither config nor colors path has a parent directory to watch");
+                return;
+            }
 
-                    if let Ok(stream) = stream {
-                        let mut stream = stream.ready_chunks(10);
+            for folder in &watch_folders {
+                debug!("Watching folder for changes: {folder:?}");
+                let res = inotify.watches().add(
+                    folder,
+                    WatchMask::CREATE | WatchMask::DELETE | WatchMask::MOVE | WatchMask::MODIFY,
+                );
+                if let Err(e) = res {
+                    error!("Failed to add watch for {folder:?}: {e}");
+                    return;
+                }
+            }
 
-                        debug!("Starting config file watch loop");
+            let buffer = [0; 1024];
+            let stream = inotify.into_event_stream(buffer);
 
-                        loop {
-                            let events = stream.next().await.unwrap_or(vec![]);
+            if let Ok(stream) = stream {
+                let mut stream = stream.ready_chunks(10);
 
-                            debug!("Received inotify events: {events:?}");
+                debug!("Starting config/colors file watch loop");
 
-                            let mut file_event = None;
+                loop {
+                    let events = stream.next().await.unwrap_or(vec![]);
 
-                            for event in events {
-                                debug!("Event: {event:?}");
-                                match event {
-                                    Ok(inotify::Event {
-                                        name: Some(name),
-                                        mask: EventMask::DELETE | EventMask::MOVED_FROM,
-                                        ..
-                                    }) if file_name == name => {
-                                        debug!("File deleted or moved");
-                                        file_event = Some(Event::Removed);
-                                    }
-                                    Ok(inotify::Event {
-                                        name: Some(name),
-                                        mask:
-                                            EventMask::CREATE | EventMask::MODIFY | EventMask::MOVED_TO,
-                                        ..
-                                    }) if file_name == name => {
-                                        debug!("File created or moved");
+                    debug!("Received inotify events: {events:?}");
 
-                                        file_event = Some(Event::Changed);
-                                    }
-                                    _ => {
-                                        debug!("Ignoring event");
-                                    }
-                                }
+                    let mut file_event = None;
+
+                    for event in events {
+                        debug!("Event: {event:?}");
+                        match event {
+                            Ok(inotify::Event {
+                                name: Some(name),
+                                mask: EventMask::DELETE | EventMask::MOVED_FROM,
+                                ..
+                            }) if config_name.as_deref() == Some(&name)
+                                || colors_name.as_deref() == Some(&name) =>
+                            {
+                                debug!("Config or colors file deleted or moved");
+                                file_event = Some(Event::Removed);
                             }
-
-                            match file_event {
-                                Some(Event::Changed) => {
-                                    info!("Reload config file");
-
-                                    let path_clone = path.clone();
-                                    let new_config = tokio::task::spawn_blocking(move || {
-                                        read_config(&path_clone).unwrap_or_default()
-                                    })
-                                    .await
-                                    .unwrap_or_default();
-
-                                    let _ = output
-                                        .send(Message::ConfigChanged(Box::new(new_config)))
-                                        .await;
-                                }
-                                Some(Event::Removed) => {
-                                    // wait and double check if the file is really gone
-                                    sleep(Duration::from_millis(500)).await;
-
-                                    if !path.exists() {
-                                        info!("Config file removed");
-                                        let _ = output
-                                            .send(Message::ConfigChanged(Box::default()))
-                                            .await;
-                                    }
-                                }
-                                None => {
-                                    debug!("No relevant file event detected.");
-                                }
+                            Ok(inotify::Event {
+                                name: Some(name),
+                                mask: EventMask::CREATE | EventMask::MODIFY | EventMask::MOVED_TO,
+                                ..
+                            }) if config_name.as_deref() == Some(&name)
+                                || colors_name.as_deref() == Some(&name) =>
+                            {
+                                debug!("Config or colors file created or modified");
+                                file_event = Some(Event::Changed);
+                            }
+                            _ => {
+                                debug!("Ignoring event");
                             }
                         }
-                    } else {
-                        error!("Failed to create inotify event stream");
+                    }
+
+                    match file_event {
+                        Some(Event::Changed) => {
+                            info!("Reload config and colors files");
+
+                            let config_path_clone = config_path.clone();
+                            let colors_path_clone = colors_path.clone();
+                            let new_config = tokio::task::spawn_blocking(move || {
+                                load_config_and_colors(&config_path_clone, &colors_path_clone)
+                            })
+                            .await
+                            .unwrap_or_default();
+
+                            let _ = output
+                                .send(Message::ConfigChanged(Box::new(new_config)))
+                                .await;
+                        }
+                        Some(Event::Removed) => {
+                            // wait and double check if the files are really gone
+                            sleep(Duration::from_millis(500)).await;
+
+                            info!("Config or colors file removed, reloading configuration");
+                            let config_path_clone = config_path.clone();
+                            let colors_path_clone = colors_path.clone();
+                            let new_config = tokio::task::spawn_blocking(move || {
+                                load_config_and_colors(&config_path_clone, &colors_path_clone)
+                            })
+                            .await
+                            .unwrap_or_default();
+
+                            let _ = output
+                                .send(Message::ConfigChanged(Box::new(new_config)))
+                                .await;
+                        }
+                        None => {
+                            debug!("No relevant file event detected.");
+                        }
                     }
                 }
-                (None, _, _) => {
-                    error!(
-                        "Config file path does not have a parent directory, cannot watch for changes"
-                    );
-                }
-                (_, None, _) => {
-                    error!("Config file path does not have a file name, cannot watch for changes");
-                }
-                (_, _, Err(e)) => {
-                    error!("Failed to initialize inotify: {e}");
-                }
+            } else {
+                error!("Failed to create inotify event stream");
             }
         })
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_colors_direct() {
+        let toml_str = r##"
+            primary_color = "#ff0000"
+            success_color = "#00ff00"
+            warning_color = "#ffff00"
+            danger_color = "#ff00ff"
+            text_color = "#ffffff"
+            workspace_colors = ["#ff0000", "#00ff00"]
+
+            [background_color]
+            base = "#111111"
+            weak = "#222222"
+            strong = "#333333"
+        "##;
+        let dir = std::env::temp_dir().join(format!("ashell_test_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file_path = dir.join("colors.toml");
+        std::fs::write(&file_path, toml_str).unwrap();
+
+        let palette = read_colors(&file_path).unwrap();
+        assert_eq!(
+            palette.primary_color.get_base(),
+            hex_to_color(HexColor::rgb(255, 0, 0))
+        );
+        assert_eq!(
+            palette.background_color.get_base(),
+            hex_to_color(HexColor::rgb(17, 17, 17))
+        );
+        assert_eq!(palette.workspace_colors.len(), 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_parse_colors_nested_palette() {
+        let toml_str = r##"
+            [palette]
+            primary_color = "#123456"
+            success_color = "#654321"
+        "##;
+        let dir = std::env::temp_dir().join(format!("ashell_test_palette_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file_path = dir.join("colors.toml");
+        std::fs::write(&file_path, toml_str).unwrap();
+
+        let palette = read_colors(&file_path).unwrap();
+        assert_eq!(
+            palette.primary_color.get_base(),
+            hex_to_color(HexColor::rgb(0x12, 0x34, 0x56))
+        );
+        assert_eq!(
+            palette.success_color.get_base(),
+            hex_to_color(HexColor::rgb(0x65, 0x43, 0x21))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_parse_colors_nested_appearance() {
+        let toml_str = r##"
+            [appearance]
+            primary_color = "#abcdef"
+        "##;
+        let dir = std::env::temp_dir().join(format!("ashell_test_app_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let file_path = dir.join("colors.toml");
+        std::fs::write(&file_path, toml_str).unwrap();
+
+        let palette = read_colors(&file_path).unwrap();
+        assert_eq!(
+            palette.primary_color.get_base(),
+            hex_to_color(HexColor::rgb(0xab, 0xcd, 0xef))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn test_load_config_and_colors() {
+        let dir = std::env::temp_dir().join(format!("ashell_test_load_{}", std::process::id()));
+        let _ = std::fs::create_dir_all(&dir);
+        let config_file = dir.join("config.toml");
+        let colors_file = dir.join("colors.toml");
+
+        std::fs::write(
+            &config_file,
+            r#"
+            [appearance]
+            scale_factor = 1.5
+        "#,
+        )
+        .unwrap();
+
+        std::fs::write(
+            &colors_file,
+            r##"
+            primary_color = "#00ffaa"
+        "##,
+        )
+        .unwrap();
+
+        let config = load_config_and_colors(&config_file, &colors_file);
+        assert_eq!(config.appearance.scale_factor, 1.5);
+        assert_eq!(
+            config.appearance.palette.primary_color.get_base(),
+            hex_to_color(HexColor::rgb(0, 255, 170))
+        );
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,9 @@ struct Args {
     #[arg(short, long, value_parser = clap::value_parser!(PathBuf))]
     config_path: Option<PathBuf>,
 
+    #[arg(long, value_parser = clap::value_parser!(PathBuf))]
+    colors_path: Option<PathBuf>,
+
     #[command(subcommand)]
     command: Option<Command>,
 }
@@ -230,11 +233,12 @@ fn main() -> iced::Result {
 
     info!("ashell {VERSION}");
 
-    let (config, config_path) = get_config(args.config_path).unwrap_or_else(|err| {
-        error!("Failed to read config: {err}");
+    let (config, config_path, colors_path) = get_config(args.config_path, args.colors_path)
+        .unwrap_or_else(|err| {
+            error!("Failed to read config: {err}");
 
-        std::process::exit(1);
-    });
+            std::process::exit(1);
+        });
 
     logger.set_new_spec(get_log_spec(&config.logging.level));
 
@@ -254,7 +258,7 @@ fn main() -> iced::Result {
     };
 
     iced::application(
-        App::new((logger, config.clone(), config_path)),
+        App::new((logger, config.clone(), config_path, colors_path)),
         App::update,
         App::view,
     )

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -363,12 +363,12 @@ pub fn card_style(radius: impl Into<border::Radius>) -> impl Fn(&Theme) -> conta
 
 fn base_palette(appearance: &Appearance) -> Palette {
     Palette {
-        background: appearance.background_color.get_base(),
-        text: appearance.text_color.get_base(),
-        primary: appearance.primary_color.get_base(),
-        success: appearance.success_color.get_base(),
-        warning: appearance.warning_color.get_base(),
-        danger: appearance.danger_color.get_base(),
+        background: appearance.palette.background_color.get_base(),
+        text: appearance.palette.text_color.get_base(),
+        primary: appearance.palette.primary_color.get_base(),
+        success: appearance.palette.success_color.get_base(),
+        warning: appearance.palette.warning_color.get_base(),
+        danger: appearance.palette.danger_color.get_base(),
     }
 }
 
@@ -377,7 +377,11 @@ fn base_palette(appearance: &Appearance) -> Palette {
 /// generated once and shared by all four surface themes.
 fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extended {
     let text = palette.text;
-    let bg_text = appearance.background_color.get_text().unwrap_or(text);
+    let bg_text = appearance
+        .palette
+        .background_color
+        .get_text()
+        .unwrap_or(text);
     // `mix` interpolates alpha too, so deriving from the translucent
     // colour would spread assorted alphas across the variants.
     let background = Color {
@@ -388,6 +392,7 @@ fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extende
     let default_bg = palette::Background::new(background, bg_text);
     let bg = |level, fallback| {
         appearance
+            .palette
             .background_color
             .get_pair(level, text)
             .unwrap_or(fallback)
@@ -396,22 +401,22 @@ fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extende
     let default_primary = palette::Primary::generate(
         palette.primary,
         background,
-        appearance.primary_color.get_text().unwrap_or(text),
+        appearance.palette.primary_color.get_text().unwrap_or(text),
     );
     let default_success = palette::Success::generate(
         palette.success,
         background,
-        appearance.success_color.get_text().unwrap_or(text),
+        appearance.palette.success_color.get_text().unwrap_or(text),
     );
     let default_warning = palette::Warning::generate(
         palette.warning,
         background,
-        appearance.warning_color.get_text().unwrap_or(text),
+        appearance.palette.warning_color.get_text().unwrap_or(text),
     );
     let default_danger = palette::Danger::generate(
         palette.danger,
         background,
-        appearance.danger_color.get_text().unwrap_or(text),
+        appearance.palette.danger_color.get_text().unwrap_or(text),
     );
 
     palette::Extended {
@@ -428,10 +433,12 @@ fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extende
         primary: palette::Primary {
             base: default_primary.base,
             weak: appearance
+                .palette
                 .primary_color
                 .get_weak_pair(text)
                 .unwrap_or(default_primary.weak),
             strong: appearance
+                .palette
                 .primary_color
                 .get_strong_pair(text)
                 .unwrap_or(default_primary.strong),
@@ -440,10 +447,12 @@ fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extende
         success: palette::Success {
             base: default_success.base,
             weak: appearance
+                .palette
                 .success_color
                 .get_weak_pair(text)
                 .unwrap_or(default_success.weak),
             strong: appearance
+                .palette
                 .success_color
                 .get_strong_pair(text)
                 .unwrap_or(default_success.strong),
@@ -451,10 +460,12 @@ fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extende
         warning: palette::Warning {
             base: default_warning.base,
             weak: appearance
+                .palette
                 .warning_color
                 .get_weak_pair(text)
                 .unwrap_or(default_warning.weak),
             strong: appearance
+                .palette
                 .warning_color
                 .get_strong_pair(text)
                 .unwrap_or(default_warning.strong),
@@ -462,10 +473,12 @@ fn build_extended(appearance: &Appearance, palette: Palette) -> palette::Extende
         danger: palette::Danger {
             base: default_danger.base,
             weak: appearance
+                .palette
                 .danger_color
                 .get_weak_pair(text)
                 .unwrap_or(default_danger.weak),
             strong: appearance
+                .palette
                 .danger_color
                 .get_strong_pair(text)
                 .unwrap_or(default_danger.strong),
@@ -503,8 +516,8 @@ fn base_theme_from_appearance(
         bar_radius: appearance.bar.radius,
         bar_margin: appearance.bar.margin,
         menu: appearance.menu,
-        workspace_colors: appearance.workspace_colors.clone(),
-        special_workspace_colors: appearance.special_workspace_colors.clone(),
+        workspace_colors: appearance.palette.workspace_colors.clone(),
+        special_workspace_colors: appearance.palette.special_workspace_colors.clone(),
         scale_factor: appearance.scale_factor,
         animations_enabled,
         palette,

--- a/website/docs/configuration/appearance/palette.md
+++ b/website/docs/configuration/appearance/palette.md
@@ -7,6 +7,8 @@ sidebar_position: 2
 With these configuration options, you can customize
 the color palette of your status bar.
 
+All color palette options are stored in `~/.config/ashell/colors.toml` (in the same configuration directory as `config.toml`). You can also override the path with the `--colors-path` CLI option.
+
 ## Color Syntax
 
 Each color can be specified as a simple hex color or as an object with variants.
@@ -20,7 +22,7 @@ primary_color = "#7aa2f7"
 ### Advanced Syntax
 
 ```toml
-[appearance.primary_color]
+[primary_color]
 base = "#7aa2f7"
 strong = "#8aacff"
 weak = "#6988e6"
@@ -54,7 +56,7 @@ The background color supports additional granularity. Beyond `base`, `weak`,
 `strong`, and `text`, you can also specify intermediate levels:
 
 ```toml
-[appearance.background_color]
+[background_color]
 base = "#1e1e2e"
 weakest = "#1a1a28"
 weaker = "#1c1c2c"

--- a/website/docs/configuration/appearance/theme.md
+++ b/website/docs/configuration/appearance/theme.md
@@ -4,11 +4,11 @@ sidebar_position: 3
 
 # Theme
 
+Themes are configured in `~/.config/ashell/colors.toml`.
+
 ## Catppuccin Mocha
 
 ```toml
-[appearance]
-
 success_color = "#a6e3a1"
 warning_color = "#f9e2af"
 danger_color = "#f38ba8"
@@ -16,11 +16,11 @@ text_color = "#cdd6f4"
 
 workspace_colors = [ "#fab387", "#b4befe", "#cba6f7" ]
 
-[appearance.primary_color]
+[primary_color]
 base = "#fab387"
 text = "#1e1e2e"
 
-[appearance.background_color]
+[background_color]
 base = "#1e1e2e"
 weak = "#313244"
 strong = "#45475a"
@@ -29,8 +29,6 @@ strong = "#45475a"
 ## Tokyo Night - night
 
 ```toml
-[appearance]
-
 primary_color = "#7aa2f7"
 success_color = "#9ece6a"
 warning_color = "#e0af68"
@@ -39,7 +37,7 @@ text_color = "#a9b1d6"
 
 workspace_colors = [ "#7aa2f7", "#9ece6a" ]
 
-[appearance.background_color]
+[background_color]
 base = "#1a1b26"
 weak = "#24273a"
 strong = "#414868"
@@ -48,18 +46,17 @@ strong = "#414868"
 ## Nord
 
 ```toml
-[appearance]
 success_color = "#a3be8c"
 warning_color = "#ebcb8b"
 danger_color = "#bf616a"
 text_color = "#eceff4"
 workspace_colors = [ "#88c0d0", "#81a1c1", "#5e81ac" ]
 
-[appearance.primary_color]
+[primary_color]
 base = "#88c0d0"
 text = "#242933"
 
-[appearance.background_color]
+[background_color]
 base = "#3b4252"
 weak = "#434c5e"
 strong = "#4c566a"

--- a/website/docs/configuration/full_config.md
+++ b/website/docs/configuration/full_config.md
@@ -211,13 +211,6 @@ enabled = false   # (default)
 # opacity = 1.0                # (default) range: 0.0 to 1.0, every surface ashell draws
                                # or a table: [appearance.opacity] with default/bar/menu/osd/notifications
 # blur = "auto"                # (default) auto|always|never, compositor blur
-primary_color = "#7aa2f7"
-success_color = "#9ece6a"
-warning_color = "#e0af68"
-danger_color = "#f7768e"
-text_color = "#a9b1d6"
-workspace_colors = [ "#7aa2f7", "#9ece6a" ]
-# special_workspace_colors = [ "#7aa2f7", "#9ece6a" ]  # (default: None, falls back to workspace_colors)
 
 [appearance.bar]
 surface = "transparent"  # (default) or "solid"
@@ -226,8 +219,22 @@ surface = "transparent"  # (default) or "solid"
 
 [appearance.menu]
 # backdrop = 0.0   # (default) darkening drawn behind an open menu
+```
 
-[appearance.background_color]
+## Colors Configuration (`colors.toml`)
+
+Color palette configuration is stored in `~/.config/ashell/colors.toml`:
+
+```toml
+primary_color = "#7aa2f7"
+success_color = "#9ece6a"
+warning_color = "#e0af68"
+danger_color = "#f7768e"
+text_color = "#a9b1d6"
+workspace_colors = [ "#7aa2f7", "#9ece6a" ]
+# special_workspace_colors = [ "#7aa2f7", "#9ece6a" ]  # (default: None, falls back to workspace_colors)
+
+[background_color]
 base = "#1a1b26"
 weak = "#24273a"
 strong = "#414868"


### PR DESCRIPTION
## Description

This PR separates the color palette configuration from `config.toml` into a dedicated `colors.toml` file (`~/.config/ashell/colors.toml`), while maintaining full backward compatibility with existing configurations.

## Summary of Changes

- **Separate `colors.toml`**: Added support for reading palette colors from `~/.config/ashell/colors.toml` (or `--colors-path <path>`).
- **File watcher**: Updated inotify subscription to watch and hot-reload changes from both `config.toml` and `colors.toml`.
- **Backward Compatibility**: If `colors.toml` does not exist, color fields configured in `config.toml` under `[appearance]` are automatically used as a fallback before defaulting to built-in colors.
- **CLI Options**: Added `--colors-path` argument to override the colors file location.
- **Documentation**: Updated mdBook reference docs and website documentation.

## Testing & Quality

- [x] `make check` passes (`cargo fmt` + `cargo check` + `cargo clippy --all-features -- -D warnings`).
- [x] Unit tests added and passing for `colors.toml` parsing, backward compatibility fallback, and precedence.