### PR TITLE
feat(ipc command): LoadConfig command for config switching

### DIFF
--- a/docs/src/getting-started/development-environment.md
+++ b/docs/src/getting-started/development-environment.md
@@ -93,6 +93,7 @@ ashell msg brightness-up
 ashell msg brightness-down
 ashell msg toggle-airplane-mode
 ashell msg toggle-idle-inhibitor
+ashell msg load-config -f `file_path`
 ```
 
 Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD overlay. Add `--no-osd` to suppress it.

--- a/src/app.rs
+++ b/src/app.rs
@@ -594,17 +594,13 @@ impl App {
             Message::LoadConfig(config) => {
                 self.config_path = config;
 
-                let mut tasks = vec![];
                 match get_config(Some(self.config_path.clone())) {
-                    Ok((config, _)) => {
-                        tasks.push(self.refresh_config(Box::new(config)));
-                    }
+                    Ok((config, _)) => self.update(Message::ConfigChanged(Box::new(config))),
                     Err(e) => {
-                        info!("Invalid config {e:?}")
+                        info!("Invalid config {e:?}");
+                        Task::none()
                     }
                 }
-
-                Task::Batch(tasks)
             }
         }
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,7 +1,10 @@
 use crate::{
     HEIGHT,
     components::{Centerbox, menu::MenuType},
-    config::{self, BarSurface, Config, ModuleName, Modules, Surface, WorkspaceIndicatorFormat},
+    config::{
+        self, BarSurface, Config, ModuleName, Modules, Surface, WorkspaceIndicatorFormat,
+        get_config,
+    },
     get_log_spec,
     i18n::{Localizer, init_localizer},
     ipc::IpcCommand,
@@ -532,6 +535,12 @@ impl App {
                         );
                         modules::settings::Action::None
                     }
+                    IpcCommand::LoadConfig { .. } => {
+                        warn!(
+                            "IpcCommand::LoadConfig reached IpcOsdCommand handler; use Message::LoadConfig instead"
+                        );
+                        modules::settings::Action::None
+                    }
                 };
                 if let settings::Action::Command(task) = action {
                     tasks.push(task.map(Message::Settings));
@@ -581,6 +590,21 @@ impl App {
                         })
                         .collect::<Vec<_>>(),
                 )
+            }
+            Message::LoadConfig(config) => {
+                self.config_path = config;
+
+                let mut tasks = vec![];
+                match get_config(Some(self.config_path.clone())) {
+                    Ok((config, _)) => {
+                        tasks.push(self.refresh_config(Box::new(config)));
+                    }
+                    Err(e) => {
+                        info!("Invalid config {e:?}")
+                    }
+                }
+
+                Task::Batch(tasks)
             }
         }
     }
@@ -777,6 +801,7 @@ impl App {
             self.settings.subscription().map(Message::Settings),
             crate::ipc::subscription().map(|cmd| match cmd {
                 IpcCommand::ToggleVisibility => Message::ToggleVisibility,
+                IpcCommand::LoadConfig { file } => Message::LoadConfig(file),
                 other => Message::IpcOsdCommand(other),
             }),
         ])

--- a/src/app/message.rs
+++ b/src/app/message.rs
@@ -6,6 +6,7 @@ use crate::{
     osd,
 };
 use iced::{OutputEvent, SurfaceId};
+use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub enum Message {
@@ -33,4 +34,5 @@ pub enum Message {
     ResumeFromSleep,
     None,
     ToggleVisibility,
+    LoadConfig(PathBuf),
 }

--- a/src/app/osd_info.rs
+++ b/src/app/osd_info.rs
@@ -82,5 +82,6 @@ pub fn osd_info_for(app: &App, cmd: &IpcCommand) -> Option<(OsdKind, f32, f32, b
             }
         }
         IpcCommand::ToggleVisibility => None,
+        IpcCommand::LoadConfig { .. } => None,
     }
 }

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -131,7 +131,6 @@ impl FromStr for IpcCommand {
         let name = parts.next().unwrap_or("").trim();
         let rest = parts.next().map(str::trim).filter(|s| !s.is_empty());
 
-        println!("ok {}", s);
         match name {
             "toggle-visibility" => Ok(IpcCommand::ToggleVisibility),
             "volume-up" => Ok(IpcCommand::VolumeUp { no_osd }),

--- a/src/ipc.rs
+++ b/src/ipc.rs
@@ -64,6 +64,10 @@ pub enum IpcCommand {
         #[arg(long)]
         no_osd: bool,
     },
+    LoadConfig {
+        #[arg(short, long)]
+        file: PathBuf,
+    },
 }
 
 impl IpcCommand {
@@ -80,6 +84,7 @@ impl IpcCommand {
             | IpcCommand::BrightnessDown { no_osd }
             | IpcCommand::ToggleAirplaneMode { no_osd }
             | IpcCommand::ToggleIdleInhibitor { no_osd } => *no_osd,
+            IpcCommand::LoadConfig { .. } => false,
         }
     }
 }
@@ -100,8 +105,12 @@ impl fmt::Display for IpcCommand {
             IpcCommand::BrightnessDown { .. } => "brightness-down",
             IpcCommand::ToggleAirplaneMode { .. } => "toggle-airplane-mode",
             IpcCommand::ToggleIdleInhibitor { .. } => "toggle-idle-inhibitor",
+            IpcCommand::LoadConfig { .. } => "load-config",
         };
         write!(f, "{base}")?;
+        if let IpcCommand::LoadConfig { file } = self {
+            write!(f, " {}", file.display())?;
+        }
         if self.no_osd() {
             write!(f, "{NO_OSD_SUFFIX}")?;
         }
@@ -117,7 +126,13 @@ impl FromStr for IpcCommand {
             Some(base) => (base, true),
             None => (s, false),
         };
-        match cmd {
+
+        let mut parts = cmd.splitn(2, char::is_whitespace);
+        let name = parts.next().unwrap_or("").trim();
+        let rest = parts.next().map(str::trim).filter(|s| !s.is_empty());
+
+        println!("ok {}", s);
+        match name {
             "toggle-visibility" => Ok(IpcCommand::ToggleVisibility),
             "volume-up" => Ok(IpcCommand::VolumeUp { no_osd }),
             "volume-down" => Ok(IpcCommand::VolumeDown { no_osd }),
@@ -129,6 +144,12 @@ impl FromStr for IpcCommand {
             "brightness-down" => Ok(IpcCommand::BrightnessDown { no_osd }),
             "toggle-airplane-mode" => Ok(IpcCommand::ToggleAirplaneMode { no_osd }),
             "toggle-idle-inhibitor" => Ok(IpcCommand::ToggleIdleInhibitor { no_osd }),
+            "load-config" => match rest {
+                Some(file) => Ok(IpcCommand::LoadConfig {
+                    file: PathBuf::from(file),
+                }),
+                None => Err(anyhow!("config requires a file path")),
+            },
             _ => Err(anyhow!("unknown IPC command: {s:?}")),
         }
     }

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -86,6 +86,7 @@ Available commands:
 | `brightness-down`        | Decrease screen brightness by 5%     |
 | `toggle-airplane-mode`   | Toggle airplane mode                 |
 | `toggle-idle-inhibitor`  | Toggle idle inhibitor                |
+| `load-config`            | Loads a config passed through        |
 
 
 Volume, microphone, brightness, airplane and idle inhibitor commands show an OSD (On-Screen Display)

--- a/website/docs/configuration/main.md
+++ b/website/docs/configuration/main.md
@@ -199,6 +199,14 @@ Alternatively, you can still use a `SIGUSR1` signal:
 kill -SIGUSR1 $(pidof ashell)
 ```
 
+## Config Load
+
+You can load another config file, this can be useful for managing different themes
+
+```bash
+ashell msg load-config -f ~/.config/ashell/mac_bar.toml
+```
+
 ## OSD (On-Screen Display)
 
 Ashell can show a transient overlay when volume, microphone, brightness, airplane mode


### PR DESCRIPTION
I've added an IPC command that allows ashell to load a different config file at runtime without the need to restart the instance. This will be useful for when you want to multiple themes you want to load quickly.

Usage
ashell msg load-config -f ~/.config/ashell/mac_bar.toml