### PR TITLE
fix: compositor dispatch edge cases, workspace scroll monitor match, tray hot-reload

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -214,6 +214,8 @@ impl App {
             .update(modules::notifications::Message::ConfigReloaded(
                 config.notifications,
             ));
+        self.tray
+            .update(modules::tray::Message::ConfigReloaded(config.tray));
         self.osd.update(osd::Message::ConfigReloaded(config.osd));
 
         workspaces_task

--- a/src/modules/tray.rs
+++ b/src/modules/tray.rs
@@ -59,6 +59,7 @@ pub enum Message {
     MenuToggled(String, i32),
     MenuOpened(String),
     Activate(String),
+    ConfigReloaded(TrayModuleConfig),
 }
 
 pub enum Action {
@@ -169,6 +170,11 @@ impl TrayModule {
                 }
                 _ => Action::None,
             },
+            Message::ConfigReloaded(config) => {
+                self.blocklist = config.blocklist;
+                self.right_click = config.right_click;
+                Action::None
+            }
         }
     }
 

--- a/src/modules/workspaces.rs
+++ b/src/modules/workspaces.rs
@@ -411,7 +411,7 @@ impl Workspaces {
                     .and_then(|name| {
                         self.ui_workspaces.iter().position(|w| {
                             !w.monitor.is_empty()
-                                && name.contains(w.monitor.as_str())
+                                && name == w.monitor.as_str()
                                 && matches!(w.displayed, Displayed::Active | Displayed::Visible)
                         })
                     })

--- a/src/services/compositor/hyprland.rs
+++ b/src/services/compositor/hyprland.rs
@@ -76,9 +76,11 @@ async fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
             format!("hl.dispatch(hl.dsp.focus({{ workspace = {id} }}))")
         }
         CompositorCommand::FocusSpecialWorkspace(name) => {
+            let name = escape_lua_string(&name);
             format!("hl.dispatch(hl.dsp.focus({{ workspace = \"special:{name}\" }}))")
         }
         CompositorCommand::ToggleSpecialWorkspace(name) => {
+            let name = escape_lua_string(&name);
             format!("hl.dispatch(hl.dsp.workspace.toggle_special(\"{name}\"))")
         }
         CompositorCommand::FocusMonitor(id) => {
@@ -96,6 +98,8 @@ async fn dispatch_lua(cmd: CompositorCommand) -> Result<()> {
             return Ok(());
         }
         CompositorCommand::CustomDispatch(dispatcher, args) => {
+            let dispatcher = escape_lua_string(&dispatcher);
+            let args = escape_lua_string(&args);
             format!("hl.dispatch(hl.dsp.{dispatcher}({args}))")
         }
     };
@@ -112,6 +116,13 @@ pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
     } else {
         dispatch_hyprlang(cmd)
     }
+}
+
+// Names reach the Lua layer by string interpolation, so quotes and
+// backslashes must be escaped or a workspace/dispatcher name containing
+// them breaks the generated program.
+fn escape_lua_string(value: &str) -> String {
+    value.replace('\\', "\\\\").replace('"', "\\\"")
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/services/compositor/niri.rs
+++ b/src/services/compositor/niri.rs
@@ -51,7 +51,7 @@ pub async fn execute_command(cmd: CompositorCommand) -> Result<()> {
         CompositorCommand::CustomDispatch(action, args) => {
             if action == "spawn" {
                 Action::Spawn {
-                    command: vec![args],
+                    command: args.split_whitespace().map(String::from).collect(),
                 }
             } else {
                 return Err(anyhow!("Unknown custom dispatch: {}", action));


### PR DESCRIPTION
Part of the cleanup discussed in #964 — this is the standalone bug-fix slice (each fix independent, no behavior questions beyond what's described).

## Workspaces: scroll monitor matching

`Message::Scroll` located the current workspace with `name.contains(w.monitor.as_str())`, while the `view()` filter a few lines below deliberately uses equality — its comment explains `.contains()` "falsely matches any pair where one name is a substring of the other — most commonly `eDP-1` vs `DP-1`". The scroll handler apparently predated that fix. Consequence: scrolling the laptop (`eDP-1`) bar matched a `DP-1` workspace as current and navigated the external monitor's workspaces. One-line change to `==`, mirroring the view filter.

## Niri: `spawn` custom dispatch

`CustomDispatch("spawn", args)` built `Action::Spawn { command: vec![args] }` — the whole args string as a single argv element, so `spawn kitty --hold sh` (or anything with flags) never worked. Split on whitespace like a shell would (no quoting support; happy to switch to shlex if you'd rather).

## Hyprland: unescaped interpolation into Lua dispatch

`toggle_special("…")` / `focus special:…` / `CustomDispatch` interpolated user-controlled names straight into the generated Lua string. A special-workspace name containing `"` or `\` (both legal in Hyprland config) produced a Lua syntax error and silently broke toggling on Lua-config systems. Adds a small `escape_lua_string` helper used at the three interpolation sites.

## Tray: config hot-reload silently skipped

Tray was the only module with a config but no `ConfigReloaded` handling in `App::refresh_config`, so changing `[tray] blocklist` / `right_click` in config.toml did nothing until restart while every sibling hot-reloads. Adds the variant + `update` arm + wiring, mirroring how `notifications`/`osd` do it.
